### PR TITLE
fix: change docker file workdir to fix worker migrations

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -38,5 +38,6 @@ ENV METRICS_PORT $METRICS_PORT
 EXPOSE $PORT $METRICS_PORT 9229 9230
 
 USER node
+WORKDIR /usr/src/app/packages/api
 
-CMD [ "node", "packages/api/dist/main.js" ]
+CMD [ "node", "dist/main.js" ]

--- a/packages/worker/Dockerfile
+++ b/packages/worker/Dockerfile
@@ -38,5 +38,6 @@ ENV PORT $PORT
 EXPOSE $PORT 9229 9230
 
 USER node
+WORKDIR /usr/src/app/packages/worker
 
-CMD [ "node", "packages/worker/dist/main.js" ]
+CMD [ "node", "dist/main.js" ]


### PR DESCRIPTION
# What ❔

Fix for Block Explorer Worker migrations.

## Why ❔

Since Worker was moved to `packages/worker` folder, to make TypeOrm migrations work, the directory from where Worker is started must be changed.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
