### PR TITLE
chore: separate app config for local and dev

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,8 +4,6 @@ services:
     build:
       context: .
       dockerfile: ./packages/app/Dockerfile
-    environment:
-      - VITE_APP_ENVIRONMENT=local
     command: npm run --prefix packages/app dev -- --host
     ports:
       - '3010:3010'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,9 +4,14 @@ services:
     build:
       context: .
       dockerfile: ./packages/app/Dockerfile
+    environment:
+      - VITE_APP_ENVIRONMENT=local
     command: npm run --prefix packages/app dev -- --host
     ports:
       - '3010:3010'
+    volumes:
+      - ./packages/app:/usr/src/app/packages/app
+      - /usr/src/app/packages/app/node_modules
     depends_on:
       - api
     restart: unless-stopped
@@ -26,6 +31,7 @@ services:
       - DATABASE_PASSWORD=postgres
       - DATABASE_NAME=block-explorer
       - BLOCKCHAIN_RPC_URL=http://zksync:3050
+      - BATCHES_PROCESSING_POLLING_INTERVAL=1000
     ports:
       - '3001:3001'
       - '9229:9229'
@@ -33,7 +39,6 @@ services:
     volumes:
       - ./packages/worker:/usr/src/app/packages/worker
       - /usr/src/app/packages/worker/node_modules
-      - ./node_modules:/usr/src/worker/node_modules:ro
     depends_on:
       zksync:
         condition: service_healthy
@@ -59,7 +64,6 @@ services:
     volumes:
       - ./packages/api:/usr/src/app/packages/api
       - /usr/src/app/packages/api/node_modules
-      - ./node_modules:/usr/src/api/node_modules:ro
     depends_on:
       - worker
     restart: unless-stopped

--- a/packages/app/src/composables/useEnvironmentConfig.ts
+++ b/packages/app/src/composables/useEnvironmentConfig.ts
@@ -5,7 +5,7 @@ import type { EnvironmentConfig, NetworkConfig } from "@/configs";
 const config = ref<EnvironmentConfig | null>(null);
 
 const HYPERCHAIN_CONFIG_NAME = "hyperchain";
-const LOCAL_CONFIG_NAME = "local";
+const DEVELOPMENT_CONFIG_NAME = "dev";
 
 export async function loadEnvironmentConfig(appEnvironment: string): Promise<void> {
   let envConfig: EnvironmentConfig;
@@ -13,7 +13,7 @@ export async function loadEnvironmentConfig(appEnvironment: string): Promise<voi
     try {
       envConfig = (await import(`../configs/${HYPERCHAIN_CONFIG_NAME}.config.json`)).default;
     } catch {
-      envConfig = (await import(`../configs/${LOCAL_CONFIG_NAME}.config.json`)).default;
+      envConfig = (await import(`../configs/${DEVELOPMENT_CONFIG_NAME}.config.json`)).default;
     }
   } else {
     envConfig = (await import(`../configs/${appEnvironment}.config.json`)).default;

--- a/packages/app/src/configs/dev.config.json
+++ b/packages/app/src/configs/dev.config.json
@@ -1,0 +1,74 @@
+{
+  "networks": [
+    {
+      "apiUrl": "http://localhost:3020",
+      "verificationApiUrl": "http://127.0.0.1:3070",
+      "bridgeUrl": "http://localhost:3000/bridge",
+      "hostnames": [
+        "localhost"
+      ],
+      "icon": "/images/icons/zksync-arrows.svg",
+      "l2ChainId": 270,
+      "l2NetworkName": "Local",
+      "l2WalletUrl": "http://localhost:3000",
+      "maintenance": false,
+      "name": "local",
+      "newProverUrl": "https://storage.googleapis.com/zksync-era-testnet-proofs/proofs_fri",
+      "published": true,
+      "rpcUrl": "http://localhost:3050"
+    },
+    {
+      "apiUrl": "https://block-explorer-api.testnets.zksync.dev",
+      "verificationApiUrl": "https://zksync2-testnet-explorer.zksync.dev",
+      "bridgeUrl": "https://staging.goerli.bridge.zksync.dev",
+      "hostnames": [
+        "https://goerli.staging-scan-v2.zksync.dev"
+      ],
+      "icon": "/images/icons/zksync-arrows.svg",
+      "l1ExplorerUrl": "https://goerli.etherscan.io",
+      "l2ChainId": 280,
+      "l2NetworkName": "zkSync Era Testnet",
+      "l2WalletUrl": "https://goerli.staging-portal.zksync.dev/",
+      "maintenance": false,
+      "name": "goerli",
+      "newProverUrl": "https://storage.googleapis.com/zksync-era-testnet-proofs/proofs_fri",
+      "published": true,
+      "rpcUrl": "https://testnet.era.zksync.dev"
+    },
+    {
+      "apiUrl": "https://block-explorer-api.stage.zksync.dev",
+      "verificationApiUrl": "https://z2-dev-api-explorer.zksync.dev",
+      "hostnames": [
+        "https://goerli-beta.staging-scan-v2.zksync.dev"
+      ],
+      "icon": "/images/icons/zksync-arrows.svg",
+      "l1ExplorerUrl": "https://goerli.etherscan.io",
+      "l2ChainId": 270,
+      "l2NetworkName": "Goerli (Stage2)",
+      "l2WalletUrl": "https://goerli-beta.staging-portal.zksync.dev/",
+      "maintenance": false,
+      "name": "goerli-beta",
+      "newProverUrl": "https://storage.googleapis.com/zksync-era-stage-proofs/proofs_fri",
+      "published": true,
+      "rpcUrl": "https://z2-dev-api.zksync.dev"
+    },
+    {
+      "apiUrl": "https://block-explorer-api.mainnet.zksync.io",
+      "verificationApiUrl": "https://zksync2-mainnet-explorer.zksync.io",
+      "bridgeUrl": "https://staging.bridge.zksync.dev",
+      "hostnames": [
+        "https://staging-scan-v2.zksync.dev"
+      ],
+      "icon": "/images/icons/zksync-arrows.svg",
+      "l1ExplorerUrl": "https://etherscan.io",
+      "l2ChainId": 324,
+      "l2NetworkName": "zkSync Era Mainnet",
+      "l2WalletUrl": "https://staging-portal.zksync.dev/",
+      "maintenance": false,
+      "name": "mainnet",
+      "newProverUrl": "https://storage.googleapis.com/zksync-era-mainnet-proofs/proofs_fri",
+      "published": true,
+      "rpcUrl": "https://mainnet.era.zksync.io"
+    }
+  ]
+}

--- a/packages/app/src/configs/local.config.json
+++ b/packages/app/src/configs/local.config.json
@@ -16,59 +16,6 @@
       "newProverUrl": "https://storage.googleapis.com/zksync-era-testnet-proofs/proofs_fri",
       "published": true,
       "rpcUrl": "http://localhost:3050"
-    },
-    {
-      "apiUrl": "https://block-explorer-api.testnets.zksync.dev",
-      "verificationApiUrl": "https://zksync2-testnet-explorer.zksync.dev",
-      "bridgeUrl": "https://staging.goerli.bridge.zksync.dev",
-      "hostnames": [
-        "https://goerli.staging-scan-v2.zksync.dev"
-      ],
-      "icon": "/images/icons/zksync-arrows.svg",
-      "l1ExplorerUrl": "https://goerli.etherscan.io",
-      "l2ChainId": 280,
-      "l2NetworkName": "zkSync Era Testnet",
-      "l2WalletUrl": "https://goerli.staging-portal.zksync.dev/",
-      "maintenance": false,
-      "name": "goerli",
-      "newProverUrl": "https://storage.googleapis.com/zksync-era-testnet-proofs/proofs_fri",
-      "published": true,
-      "rpcUrl": "https://testnet.era.zksync.dev"
-    },
-    {
-      "apiUrl": "https://block-explorer-api.stage.zksync.dev",
-      "verificationApiUrl": "https://z2-dev-api-explorer.zksync.dev",
-      "hostnames": [
-        "https://goerli-beta.staging-scan-v2.zksync.dev"
-      ],
-      "icon": "/images/icons/zksync-arrows.svg",
-      "l1ExplorerUrl": "https://goerli.etherscan.io",
-      "l2ChainId": 270,
-      "l2NetworkName": "Goerli (Stage2)",
-      "l2WalletUrl": "https://goerli-beta.staging-portal.zksync.dev/",
-      "maintenance": false,
-      "name": "goerli-beta",
-      "newProverUrl": "https://storage.googleapis.com/zksync-era-stage-proofs/proofs_fri",
-      "published": true,
-      "rpcUrl": "https://z2-dev-api.zksync.dev"
-    },
-    {
-      "apiUrl": "https://block-explorer-api.mainnet.zksync.io",
-      "verificationApiUrl": "https://zksync2-mainnet-explorer.zksync.io",
-      "bridgeUrl": "https://staging.bridge.zksync.dev",
-      "hostnames": [
-        "https://staging-scan-v2.zksync.dev"
-      ],
-      "icon": "/images/icons/zksync-arrows.svg",
-      "l1ExplorerUrl": "https://etherscan.io",
-      "l2ChainId": 324,
-      "l2NetworkName": "zkSync Era Mainnet",
-      "l2WalletUrl": "https://staging-portal.zksync.dev/",
-      "maintenance": false,
-      "name": "mainnet",
-      "newProverUrl": "https://storage.googleapis.com/zksync-era-mainnet-proofs/proofs_fri",
-      "published": true,
-      "rpcUrl": "https://mainnet.era.zksync.io"
     }
   ]
 }


### PR DESCRIPTION
# What ❔

Separate App configurations for local and dev setups.

## Why ❔

For development setup we're gonna show all networks, but for local (which will be used when running from CLI) only Local network will be shown.

**Dev (default if you just run the application):**
<img width="203" alt="Screenshot 2023-10-12 at 12 23 53" src="https://github.com/matter-labs/block-explorer/assets/6553665/89cb6fe4-ad99-451a-9659-c1b1fe8d40d0">

**Local (will be used by CLI):**
<img width="212" alt="Screenshot 2023-10-12 at 12 24 29" src="https://github.com/matter-labs/block-explorer/assets/6553665/3d882cf0-d3bb-451f-bca4-08a09343ac23">

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
