### PR TITLE
fix: do not request verification info when running local node

### DIFF
--- a/packages/app/src/composables/useAddress.ts
+++ b/packages/app/src/composables/useAddress.ts
@@ -93,6 +93,9 @@ export default (context = useContext()) => {
   const item = ref(<null | AddressItem>null);
 
   const getContractVerificationInfo = async (address: string): Promise<ContractVerificationInfo | null> => {
+    if (!context.currentNetwork.value.verificationApiUrl) {
+      return null;
+    }
     try {
       return await $fetch(`${context.currentNetwork.value.verificationApiUrl}/contract_verification/info/${address}`);
     } catch (e) {

--- a/packages/app/src/composables/useContractABI.ts
+++ b/packages/app/src/composables/useContractABI.ts
@@ -12,6 +12,9 @@ import { checksumAddress } from "@/utils/formatters";
 
 const retrieveAddressInfo = useMemoize(
   async (address: Address, context: Context = useContext()) => {
+    if (!context.currentNetwork.value.verificationApiUrl) {
+      return null;
+    }
     return await $fetch(`${context.currentNetwork.value.verificationApiUrl}/contract_verification/info/${address}`);
   },
   {

--- a/packages/app/src/configs/dev.config.json
+++ b/packages/app/src/configs/dev.config.json
@@ -2,7 +2,6 @@
   "networks": [
     {
       "apiUrl": "http://localhost:3020",
-      "verificationApiUrl": "http://127.0.0.1:3070",
       "bridgeUrl": "http://localhost:3000/bridge",
       "hostnames": [
         "localhost"

--- a/packages/app/src/configs/index.ts
+++ b/packages/app/src/configs/index.ts
@@ -1,7 +1,7 @@
 export type NetworkConfig = {
   name: string;
   icon: string;
-  verificationApiUrl: string;
+  verificationApiUrl?: string;
   apiUrl: string;
   newProverUrl: string;
   rpcUrl: string;

--- a/packages/app/src/configs/local.config.json
+++ b/packages/app/src/configs/local.config.json
@@ -2,7 +2,6 @@
   "networks": [
     {
       "apiUrl": "http://localhost:3020",
-      "verificationApiUrl": "http://127.0.0.1:3070",
       "bridgeUrl": "http://localhost:3000/bridge",
       "hostnames": [
         "localhost"

--- a/packages/app/tests/composables/useAddress.spec.ts
+++ b/packages/app/tests/composables/useAddress.spec.ts
@@ -118,6 +118,22 @@ describe("useAddresses", () => {
       });
     });
 
+    it("doesn't make contract verification request when network has no verificationApiUrl", async () => {
+      const currentNetwork = computed(() => ({ apiUrl: "http://api.url" }));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { item, getByAddress } = useAddress({ currentNetwork } as any);
+      await getByAddress("0xc31f9d4cbf557b6cf0ad2af66d44c358f7fa7a1c");
+      expect($fetch).toHaveBeenCalledOnce();
+      expect($fetch).toHaveBeenCalledWith("http://api.url/address/0xc31f9d4cbf557b6cf0ad2af66d44c358f7fa7a1c");
+      expect(item.value).toEqual({
+        address: "0xc31f9d4cbf557b6cf0ad2af66d44c358f7fa7a1c",
+        balances: {},
+        type: "contract",
+        verificationInfo: null,
+        proxyInfo: null,
+      });
+    });
+
     it("takes proxy implementation contract from implementation function when it exists", async () => {
       const { item, getByAddress } = useAddress();
       await getByAddress("0xc31f9d4cbf557b6cf0ad2af66d44c358f7fa7a1c");

--- a/packages/app/tests/composables/useContractABI.spec.ts
+++ b/packages/app/tests/composables/useContractABI.spec.ts
@@ -68,6 +68,7 @@ describe("useContractABI:", () => {
   });
   it("doesn't make request when there is no verification api url", async () => {
     const mock = ($fetch as unknown as SpyInstance).mockClear();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { getCollection } = useContractABI({ currentNetwork: computed(() => ({})) } as any);
     await getCollection(["0x5550000000000000000000000000000000000000"]);
     expect(mock).toHaveBeenCalledTimes(0);

--- a/packages/app/tests/composables/useContractABI.spec.ts
+++ b/packages/app/tests/composables/useContractABI.spec.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from "vue";
+import { ref } from "vue";
 
 import { describe, expect, it, type SpyInstance, vi } from "vitest";
 

--- a/packages/app/tests/composables/useContractABI.spec.ts
+++ b/packages/app/tests/composables/useContractABI.spec.ts
@@ -1,4 +1,4 @@
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 import { describe, expect, it, type SpyInstance, vi } from "vitest";
 
@@ -64,6 +64,13 @@ describe("useContractABI:", () => {
     await getCollection(["0x0000000000000000000000000000000000000123"]);
 
     expect(isRequestFailed.value).toEqual(true);
+    mock.mockRestore();
+  });
+  it("doesn't make request when there is no verification api url", async () => {
+    const mock = ($fetch as unknown as SpyInstance).mockClear();
+    const { getCollection } = useContractABI({ currentNetwork: computed(() => ({})) } as any);
+    await getCollection(["0x5550000000000000000000000000000000000000"]);
+    expect(mock).toHaveBeenCalledTimes(0);
     mock.mockRestore();
   });
   it("caches the results", async () => {

--- a/packages/app/tests/composables/useContractABI.spec.ts
+++ b/packages/app/tests/composables/useContractABI.spec.ts
@@ -1,4 +1,4 @@
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 import { describe, expect, it, type SpyInstance, vi } from "vitest";
 
@@ -64,6 +64,14 @@ describe("useContractABI:", () => {
     await getCollection(["0x0000000000000000000000000000000000000123"]);
 
     expect(isRequestFailed.value).toEqual(true);
+    mock.mockRestore();
+  });
+  it("doesn't make request when there is no verification api url", async () => {
+    const mock = ($fetch as unknown as SpyInstance).mockClear();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { getCollection } = useContractABI({ currentNetwork: computed(() => ({})) } as any);
+    await getCollection(["0x5550000000000000000000000000000000000000"]);
+    expect(mock).toHaveBeenCalledTimes(0);
     mock.mockRestore();
   });
   it("caches the results", async () => {

--- a/packages/app/tests/composables/useContractABI.spec.ts
+++ b/packages/app/tests/composables/useContractABI.spec.ts
@@ -66,14 +66,6 @@ describe("useContractABI:", () => {
     expect(isRequestFailed.value).toEqual(true);
     mock.mockRestore();
   });
-  it("doesn't make request when there is no verification api url", async () => {
-    const mock = ($fetch as unknown as SpyInstance).mockClear();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { getCollection } = useContractABI({ currentNetwork: computed(() => ({})) } as any);
-    await getCollection(["0x5550000000000000000000000000000000000000"]);
-    expect(mock).toHaveBeenCalledTimes(0);
-    mock.mockRestore();
-  });
   it("caches the results", async () => {
     const mock = ($fetch as unknown as SpyInstance).mockClear();
     const { getCollection } = useContractABI();

--- a/packages/app/tests/mocks.ts
+++ b/packages/app/tests/mocks.ts
@@ -22,7 +22,7 @@ import type { Provider } from "zksync-web3";
 
 export const GOERLI_NETWORK: NetworkConfig = {
   name: "goerli",
-  verificationApiUrl: "",
+  verificationApiUrl: "https://zksync2-testnet-explorer.zksync.dev",
   apiUrl: "https://block-explorer-api.testnets.zksync.dev",
   icon: "",
   l2ChainId: 280,
@@ -37,7 +37,7 @@ export const GOERLI_NETWORK: NetworkConfig = {
 };
 export const GOERLI_BETA_NETWORK: NetworkConfig = {
   name: "goerli-beta",
-  verificationApiUrl: "",
+  verificationApiUrl: "https://zksync2-testnet-explorer.zksync.dev",
   apiUrl: "https://block-explorer-api.mock.zksync.dev",
   icon: "",
   l2ChainId: 270,


### PR DESCRIPTION
# What ❔
- Do not request contract verification info when running against local node

## Why ❔
- Since contract verification is not yet implemented in the Block Explorer API the request simply fails and any contract page becomes unavailable
