### PR TITLE
fix: remove 0 bytes from strings before saving into DB

### DIFF
--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -90,10 +90,10 @@
     "coverageDirectory": "../coverage",
     "coverageThreshold": {
       "global": {
-        "branches": 99,
-        "functions": 99,
-        "lines": 99,
-        "statements": 99
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
       }
     },
     "testEnvironment": "node",

--- a/packages/worker/src/blockchain/blockchain.service.ts
+++ b/packages/worker/src/blockchain/blockchain.service.ts
@@ -133,9 +133,9 @@ export class BlockchainService implements OnModuleInit {
       erc20Contract.name(),
     ]);
     return {
-      symbol: symbol?.replace(/\0/g, ""),
+      symbol,
       decimals,
-      name: name?.replace(/\0/g, ""),
+      name,
     };
   }
 

--- a/packages/worker/src/entities/token.entity.ts
+++ b/packages/worker/src/entities/token.entity.ts
@@ -2,6 +2,7 @@ import { Entity, Column, PrimaryColumn, Check, Index, JoinColumn, ManyToOne } fr
 import { Block } from "./block.entity";
 import { Transaction } from "./transaction.entity";
 import { bigIntNumberTransformer } from "../transformers/bigIntNumber.transformer";
+import { stringTransformer } from "../transformers/string.transformer";
 import { hexTransformer } from "../transformers/hex.transformer";
 import { BaseEntity } from "./base.entity";
 
@@ -24,10 +25,10 @@ export class Token extends BaseEntity {
   @Column({ generated: true, type: "bigint" })
   public readonly number: number;
 
-  @Column()
+  @Column({ transformer: stringTransformer })
   public readonly symbol: string;
 
-  @Column()
+  @Column({ transformer: stringTransformer })
   public readonly name?: string;
 
   @Column()

--- a/packages/worker/src/transformers/string.transformer.spec.ts
+++ b/packages/worker/src/transformers/string.transformer.spec.ts
@@ -1,0 +1,40 @@
+import { stringTransformer } from "./string.transformer";
+
+describe("stringTransformer", () => {
+  describe("to", () => {
+    it("returns null for null input", () => {
+      const result = stringTransformer.to(null);
+      expect(result).toBeNull();
+    });
+
+    it("returns empty string for empty string input", () => {
+      const result = stringTransformer.to("");
+      expect(result).toBe("");
+    });
+
+    it("returns a string as it is if there are no 0 bytes", () => {
+      const str = "abcABCaAbBcC";
+      const result = stringTransformer.to(str);
+      expect(result).toBe(str);
+    });
+
+    it("returns a string with 0 bytes removed if there are 0 bytes in string", () => {
+      const str = "abc\u0000A\u0000BCaAbBcC";
+      const result = stringTransformer.to(str);
+      expect(result).toBe("abcABCaAbBcC");
+    });
+  });
+
+  describe("from", () => {
+    it("returns null for null input", () => {
+      const result = stringTransformer.from(null);
+      expect(result).toBeNull();
+    });
+
+    it("returns input string", () => {
+      const str = "abcABCaAbBcC";
+      const result = stringTransformer.from(str);
+      expect(result).toStrictEqual(str);
+    });
+  });
+});

--- a/packages/worker/src/transformers/string.transformer.ts
+++ b/packages/worker/src/transformers/string.transformer.ts
@@ -1,0 +1,14 @@
+import { ValueTransformer } from "typeorm";
+
+export const stringTransformer: ValueTransformer = {
+  to(str: string | null): string | null {
+    if (!str) {
+      return str;
+    }
+    // remove zero bytes as postgres can't store them in string
+    return str.replace(/\0/g, "");
+  },
+  from(str: string): string {
+    return str;
+  },
+};


### PR DESCRIPTION
# What ❔

Remove 0 bytes from strings before saving into DB

## Why ❔

Postgres can't save strings containing 0 bytes.

## Checklist

- [ +] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [+ ] Tests for the changes have been added / updated.
