### PR TITLE
feat: add transaction type to transaction endpoints

### DIFF
--- a/packages/api/src/api/account/account.controller.spec.ts
+++ b/packages/api/src/api/account/account.controller.spec.ts
@@ -50,6 +50,7 @@ describe("AccountController", () => {
         cumulativeGasUsed: "1200000",
         gasUsed: "900000",
       },
+      type: 255,
     },
   };
 
@@ -92,6 +93,7 @@ describe("AccountController", () => {
         cumulativeGasUsed: "1200000",
         gasUsed: "900000",
       },
+      type: 255,
     },
   } as Transfer;
 
@@ -246,6 +248,7 @@ describe("AccountController", () => {
             transactionIndex: "10",
             txreceipt_status: "1",
             value: "1000000",
+            type: "255",
           },
         ],
       });
@@ -331,6 +334,7 @@ describe("AccountController", () => {
             traceId: "0",
             type: "call",
             value: "1000000",
+            transactionType: "255",
           },
         ],
       });
@@ -436,6 +440,7 @@ describe("AccountController", () => {
             tokenSymbol: "TKN",
             transactionIndex: "10",
             value: "1000000",
+            type: "255",
           },
         ],
       });
@@ -542,6 +547,7 @@ describe("AccountController", () => {
             tokenSymbol: "TKN",
             transactionIndex: "10",
             value: "1000000",
+            type: "255",
           },
         ],
       });

--- a/packages/api/src/api/mappers/internalTransactionMapper.spec.ts
+++ b/packages/api/src/api/mappers/internalTransactionMapper.spec.ts
@@ -38,6 +38,7 @@ describe("internalTransactionMapper", () => {
         cumulativeGasUsed: "1200000",
         gasUsed: "900000",
       },
+      type: 255,
     },
   } as Transfer;
 
@@ -60,6 +61,7 @@ describe("internalTransactionMapper", () => {
         traceId: "0",
         type: "call",
         value: "1000000",
+        transactionType: "255",
       });
     });
 

--- a/packages/api/src/api/mappers/internalTransactionMapper.ts
+++ b/packages/api/src/api/mappers/internalTransactionMapper.ts
@@ -17,6 +17,7 @@ export const mapInternalTransactionListItem = (transfer: Transfer) => ({
   fee: transfer.transaction?.fee ? BigNumber.from(transfer.transaction.fee).toString() : undefined,
   l1BatchNumber: transfer.transaction?.l1BatchNumber.toString(),
   traceId: "0",
+  transactionType: transfer.transaction?.type.toString(),
   isError: transfer.transaction?.status === TransactionStatus.Failed ? "1" : "0",
   errCode: "",
 });

--- a/packages/api/src/api/mappers/transactionMapper.spec.ts
+++ b/packages/api/src/api/mappers/transactionMapper.spec.ts
@@ -30,6 +30,7 @@ describe("transactionMapper", () => {
         cumulativeGasUsed: "1200000",
         gasUsed: "900000",
       },
+      type: 255,
     },
   } as AddressTransaction;
 
@@ -62,6 +63,7 @@ describe("transactionMapper", () => {
         transactionIndex: "10",
         txreceipt_status: "1",
         value: "1000000",
+        type: "255",
       });
     });
 

--- a/packages/api/src/api/mappers/transactionMapper.ts
+++ b/packages/api/src/api/mappers/transactionMapper.ts
@@ -29,6 +29,7 @@ export const mapTransactionListItem = (addressTransaction: AddressTransaction, l
   executeTxHash: addressTransaction.transaction.executeTxHash,
   isL1Originated: addressTransaction.transaction.isL1Originated ? "1" : "0",
   l1BatchNumber: addressTransaction.transaction.l1BatchNumber.toString(),
+  type: addressTransaction.transaction.type.toString(),
   methodId: getMethodId(addressTransaction.transaction.data),
   functionName: "",
 });

--- a/packages/api/src/api/mappers/transferMapper.spec.ts
+++ b/packages/api/src/api/mappers/transferMapper.spec.ts
@@ -37,6 +37,7 @@ describe("transferMapper", () => {
       executeTxHash: "0x5e018d2a81dbd1ef80ff45171dd241cb10670dcb091e324401ff8f52293841b3",
       isL1Originated: true,
       l1BatchNumber: 3,
+      type: 255,
       transactionReceipt: {
         contractAddress: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35E",
         cumulativeGasUsed: "1200000",
@@ -69,6 +70,7 @@ describe("transferMapper", () => {
         tokenSymbol: "TKN",
         transactionIndex: "10",
         value: "1000000",
+        type: "255",
       });
     });
 
@@ -157,6 +159,7 @@ describe("transferMapper", () => {
           tokenSymbol: "TKN",
           transactionIndex: "10",
           value: "1000000",
+          type: "255",
         });
       });
     });

--- a/packages/api/src/api/mappers/transferMapper.ts
+++ b/packages/api/src/api/mappers/transferMapper.ts
@@ -24,4 +24,5 @@ export const mapTransferListItem = (transfer: Transfer, lastBlockNumber: number)
   confirmations: (lastBlockNumber - transfer.blockNumber).toString(),
   fee: transfer.transaction?.fee ? BigNumber.from(transfer.transaction.fee).toString() : undefined,
   l1BatchNumber: transfer.transaction?.l1BatchNumber.toString(),
+  type: transfer.transaction?.type.toString(),
 });

--- a/packages/api/src/transaction/dtos/transaction.dto.ts
+++ b/packages/api/src/transaction/dtos/transaction.dto.ts
@@ -132,6 +132,13 @@ export class TransactionDto {
   public readonly isL1BatchSealed: boolean;
 
   @ApiProperty({
+    type: Number,
+    description: "The type of the transaction",
+    example: 255,
+  })
+  public readonly type: number;
+
+  @ApiProperty({
     enum: TransactionStatus,
     description: "The status of the transaction",
     example: "verified",

--- a/packages/api/src/transaction/entities/transaction.entity.ts
+++ b/packages/api/src/transaction/entities/transaction.entity.ts
@@ -80,6 +80,9 @@ export class Transaction extends BaseEntity {
   public readonly blockHash: string;
 
   @Column({ type: "int" })
+  public readonly type: number;
+
+  @Column({ type: "int" })
   public readonly transactionIndex: number;
 
   @Column({ type: "timestamp" })

--- a/packages/api/src/transfer/transfer.service.spec.ts
+++ b/packages/api/src/transfer/transfer.service.spec.ts
@@ -257,9 +257,25 @@ describe("TransferService", () => {
 
       it("joins transactions and transaction receipts records to the transfers", async () => {
         await service.findTokenTransfers(filterOptions);
-        expect(queryBuilderMock.leftJoin).toBeCalledTimes(2);
+        expect(queryBuilderMock.leftJoin).toHaveBeenCalledTimes(2);
+        expect(queryBuilderMock.addSelect).toHaveBeenCalledTimes(2);
         expect(queryBuilderMock.leftJoin).toHaveBeenCalledWith("transfer.transaction", "transaction");
+        expect(queryBuilderMock.addSelect).toHaveBeenCalledWith([
+          "transaction.nonce",
+          "transaction.blockHash",
+          "transaction.transactionIndex",
+          "transaction.gasLimit",
+          "transaction.gasPrice",
+          "transaction.data",
+          "transaction.fee",
+          "transaction.l1BatchNumber",
+          "transaction.type",
+        ]);
         expect(queryBuilderMock.leftJoin).toHaveBeenCalledWith("transaction.transactionReceipt", "transactionReceipt");
+        expect(queryBuilderMock.addSelect).toHaveBeenCalledWith([
+          "transactionReceipt.gasUsed",
+          "transactionReceipt.cumulativeGasUsed",
+        ]);
       });
 
       it("adds start block filter when startBlock is specified", async () => {
@@ -407,11 +423,27 @@ describe("TransferService", () => {
       it("joins transactions and transaction receipts records to the transfers", async () => {
         await service.findTokenTransfers(filterOptions);
         expect(addressTransfersQueryBuilderMock.leftJoin).toBeCalledTimes(2);
+        expect(addressTransfersQueryBuilderMock.addSelect).toBeCalledTimes(2);
         expect(addressTransfersQueryBuilderMock.leftJoin).toHaveBeenCalledWith("transfer.transaction", "transaction");
+        expect(addressTransfersQueryBuilderMock.addSelect).toHaveBeenCalledWith([
+          "transaction.nonce",
+          "transaction.blockHash",
+          "transaction.transactionIndex",
+          "transaction.gasLimit",
+          "transaction.gasPrice",
+          "transaction.data",
+          "transaction.fee",
+          "transaction.l1BatchNumber",
+          "transaction.type",
+        ]);
         expect(addressTransfersQueryBuilderMock.leftJoin).toHaveBeenCalledWith(
           "transaction.transactionReceipt",
           "transactionReceipt"
         );
+        expect(addressTransfersQueryBuilderMock.addSelect).toHaveBeenCalledWith([
+          "transactionReceipt.gasUsed",
+          "transactionReceipt.cumulativeGasUsed",
+        ]);
       });
 
       it("adds start block filter when startBlock is specified", async () => {
@@ -527,8 +559,20 @@ describe("TransferService", () => {
       it("joins transactions and transaction receipts records to the transfers", async () => {
         await service.findInternalTransfers(filterOptions);
         expect(queryBuilderMock.leftJoin).toBeCalledTimes(2);
+        expect(queryBuilderMock.addSelect).toBeCalledTimes(2);
         expect(queryBuilderMock.leftJoin).toHaveBeenCalledWith("transfer.transaction", "transaction");
+        expect(queryBuilderMock.addSelect).toHaveBeenCalledWith([
+          "transaction.receiptStatus",
+          "transaction.gasLimit",
+          "transaction.fee",
+          "transaction.l1BatchNumber",
+          "transaction.type",
+        ]);
         expect(queryBuilderMock.leftJoin).toHaveBeenCalledWith("transaction.transactionReceipt", "transactionReceipt");
+        expect(queryBuilderMock.addSelect).toHaveBeenCalledWith([
+          "transactionReceipt.gasUsed",
+          "transactionReceipt.contractAddress",
+        ]);
       });
 
       it("adds start block filter when startBlock is specified", async () => {
@@ -631,11 +675,23 @@ describe("TransferService", () => {
       it("joins transactions and transaction receipts records to the transfers", async () => {
         await service.findInternalTransfers(filterOptions);
         expect(addressTransfersQueryBuilderMock.leftJoin).toBeCalledTimes(2);
+        expect(addressTransfersQueryBuilderMock.addSelect).toBeCalledTimes(2);
         expect(addressTransfersQueryBuilderMock.leftJoin).toHaveBeenCalledWith("transfer.transaction", "transaction");
+        expect(addressTransfersQueryBuilderMock.addSelect).toHaveBeenCalledWith([
+          "transaction.receiptStatus",
+          "transaction.gasLimit",
+          "transaction.fee",
+          "transaction.l1BatchNumber",
+          "transaction.type",
+        ]);
         expect(addressTransfersQueryBuilderMock.leftJoin).toHaveBeenCalledWith(
           "transaction.transactionReceipt",
           "transactionReceipt"
         );
+        expect(addressTransfersQueryBuilderMock.addSelect).toHaveBeenCalledWith([
+          "transactionReceipt.gasUsed",
+          "transactionReceipt.contractAddress",
+        ]);
       });
 
       it("adds start block filter when startBlock is specified", async () => {

--- a/packages/api/src/transfer/transfer.service.ts
+++ b/packages/api/src/transfer/transfer.service.ts
@@ -99,6 +99,7 @@ export class TransferService {
         "transaction.data",
         "transaction.fee",
         "transaction.l1BatchNumber",
+        "transaction.type",
       ]);
       queryBuilder.leftJoin("transaction.transactionReceipt", "transactionReceipt");
       queryBuilder.addSelect(["transactionReceipt.gasUsed", "transactionReceipt.cumulativeGasUsed"]);
@@ -147,6 +148,7 @@ export class TransferService {
       "transaction.data",
       "transaction.fee",
       "transaction.l1BatchNumber",
+      "transaction.type",
     ]);
     queryBuilder.leftJoin("transaction.transactionReceipt", "transactionReceipt");
     queryBuilder.addSelect(["transactionReceipt.gasUsed", "transactionReceipt.cumulativeGasUsed"]);
@@ -191,6 +193,7 @@ export class TransferService {
         "transaction.gasLimit",
         "transaction.fee",
         "transaction.l1BatchNumber",
+        "transaction.type",
       ]);
       queryBuilder.leftJoin("transaction.transactionReceipt", "transactionReceipt");
       queryBuilder.addSelect(["transactionReceipt.gasUsed", "transactionReceipt.contractAddress"]);
@@ -223,6 +226,7 @@ export class TransferService {
       "transaction.gasLimit",
       "transaction.fee",
       "transaction.l1BatchNumber",
+      "transaction.type",
     ]);
     queryBuilder.leftJoin("transaction.transactionReceipt", "transactionReceipt");
     queryBuilder.addSelect(["transactionReceipt.gasUsed", "transactionReceipt.contractAddress"]);

--- a/packages/api/test/account-api.e2e-spec.ts
+++ b/packages/api/test/account-api.e2e-spec.ts
@@ -92,6 +92,7 @@ describe("Account API (e2e)", () => {
       receiptStatus: 0,
       gasLimit: "1000000",
       gasPrice: "100",
+      type: 255,
     });
 
     await transactionReceiptRepository.insert({
@@ -253,6 +254,7 @@ describe("Account API (e2e)", () => {
                 transactionIndex: "1",
                 txreceipt_status: "0",
                 value: "0x2386f26fc10000",
+                type: "255",
               },
             ],
           })
@@ -304,6 +306,7 @@ describe("Account API (e2e)", () => {
                 tokenSymbol: "TKN",
                 transactionIndex: "1",
                 value: "105",
+                type: "255",
               },
               {
                 blockHash: "0x4f86d6647711915ac90e5ef69c29845946f0a55b3feaa0488aece4a359f79cb1",
@@ -327,6 +330,7 @@ describe("Account API (e2e)", () => {
                 tokenSymbol: "TKN",
                 transactionIndex: "1",
                 value: "103",
+                type: "255",
               },
               {
                 blockHash: "0x4f86d6647711915ac90e5ef69c29845946f0a55b3feaa0488aece4a359f79cb1",
@@ -350,6 +354,7 @@ describe("Account API (e2e)", () => {
                 tokenSymbol: "TKN",
                 transactionIndex: "1",
                 value: "101",
+                type: "255",
               },
             ],
             status: "1",
@@ -389,6 +394,7 @@ describe("Account API (e2e)", () => {
                 tokenSymbol: "ETH",
                 transactionIndex: "1",
                 value: "104",
+                type: "255",
               },
               {
                 blockHash: "0x4f86d6647711915ac90e5ef69c29845946f0a55b3feaa0488aece4a359f79cb1",
@@ -412,6 +418,7 @@ describe("Account API (e2e)", () => {
                 tokenSymbol: "ETH",
                 transactionIndex: "1",
                 value: "102",
+                type: "255",
               },
               {
                 blockHash: "0x4f86d6647711915ac90e5ef69c29845946f0a55b3feaa0488aece4a359f79cb1",
@@ -435,6 +442,7 @@ describe("Account API (e2e)", () => {
                 tokenSymbol: "ETH",
                 transactionIndex: "1",
                 value: "100",
+                type: "255",
               },
             ],
             status: "1",
@@ -472,6 +480,7 @@ describe("Account API (e2e)", () => {
                 tokenSymbol: "TKN",
                 transactionIndex: "1",
                 value: "105",
+                type: "255",
               },
               {
                 blockHash: "0x4f86d6647711915ac90e5ef69c29845946f0a55b3feaa0488aece4a359f79cb1",
@@ -495,6 +504,7 @@ describe("Account API (e2e)", () => {
                 tokenSymbol: "TKN",
                 transactionIndex: "1",
                 value: "103",
+                type: "255",
               },
             ],
             status: "1",
@@ -532,6 +542,7 @@ describe("Account API (e2e)", () => {
                 tokenSymbol: "TKN",
                 transactionIndex: "1",
                 value: "101",
+                type: "255",
               },
             ],
             status: "1",

--- a/packages/api/test/address.e2e-spec.ts
+++ b/packages/api/test/address.e2e-spec.ts
@@ -110,6 +110,7 @@ describe("AddressController (e2e)", () => {
         receiptStatus: 1,
         gasLimit: "1000000",
         gasPrice: "100",
+        type: 255,
       };
 
       await transactionRepository.insert(transactionSpec);

--- a/packages/api/test/log-api.e2e-spec.ts
+++ b/packages/api/test/log-api.e2e-spec.ts
@@ -91,6 +91,7 @@ describe("Logs API (e2e)", () => {
       receiptStatus: 0,
       gasLimit: "1000000",
       gasPrice: "100",
+      type: 255,
     });
 
     await transactionReceiptRepository.insert({

--- a/packages/api/test/stats.e2e-spec.ts
+++ b/packages/api/test/stats.e2e-spec.ts
@@ -86,6 +86,7 @@ describe("StatsController (e2e)", () => {
         receiptStatus: 1,
         gasLimit: "1000000",
         gasPrice: "100",
+        type: 255,
       });
     }
 

--- a/packages/api/test/token.e2e-spec.ts
+++ b/packages/api/test/token.e2e-spec.ts
@@ -82,6 +82,7 @@ describe("TokenController (e2e)", () => {
       receiptStatus: 1,
       gasLimit: "1000000",
       gasPrice: "100",
+      type: 255,
     });
 
     let tokenIndex = 0;

--- a/packages/api/test/transaction-api.e2e-spec.ts
+++ b/packages/api/test/transaction-api.e2e-spec.ts
@@ -71,6 +71,7 @@ describe("Transaction API (e2e)", () => {
       receiptStatus: 0,
       gasLimit: "1000000",
       gasPrice: "100",
+      type: 255,
     });
 
     await transactionRepository.insert({
@@ -90,6 +91,7 @@ describe("Transaction API (e2e)", () => {
       receiptStatus: 1,
       gasLimit: "1000000",
       gasPrice: "100",
+      type: 255,
     });
 
     await transactionReceiptRepository.insert({

--- a/packages/api/test/transaction.e2e-spec.ts
+++ b/packages/api/test/transaction.e2e-spec.ts
@@ -89,6 +89,7 @@ describe("TransactionController (e2e)", () => {
       isL1Originated: true,
       gasLimit: "1000000",
       gasPrice: "100",
+      type: 255,
     };
 
     for (let i = 0; i < 10; i++) {
@@ -241,6 +242,7 @@ describe("TransactionController (e2e)", () => {
               status: "failed",
               to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
               transactionIndex: 3233106,
+              type: 255,
               value: "0x2386f26fc10000",
             },
             {
@@ -263,6 +265,7 @@ describe("TransactionController (e2e)", () => {
               status: "verified",
               to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
               transactionIndex: 3233105,
+              type: 255,
               value: "0x2386f26fc10000",
             },
             {
@@ -285,6 +288,7 @@ describe("TransactionController (e2e)", () => {
               status: "verified",
               to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
               transactionIndex: 3233104,
+              type: 255,
               value: "0x2386f26fc10000",
             },
             {
@@ -307,6 +311,7 @@ describe("TransactionController (e2e)", () => {
               status: "proved",
               to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
               transactionIndex: 3233103,
+              type: 255,
               value: "0x2386f26fc10000",
             },
             {
@@ -329,6 +334,7 @@ describe("TransactionController (e2e)", () => {
               status: "proved",
               to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
               transactionIndex: 3233102,
+              type: 255,
               value: "0x2386f26fc10000",
             },
             {
@@ -351,6 +357,7 @@ describe("TransactionController (e2e)", () => {
               status: "committed",
               to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
               transactionIndex: 3233101,
+              type: 255,
               value: "0x2386f26fc10000",
             },
             {
@@ -373,6 +380,7 @@ describe("TransactionController (e2e)", () => {
               status: "committed",
               to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
               transactionIndex: 3233100,
+              type: 255,
               value: "0x2386f26fc10000",
             },
             {
@@ -395,6 +403,7 @@ describe("TransactionController (e2e)", () => {
               status: "included",
               to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
               transactionIndex: 3233099,
+              type: 255,
               value: "0x2386f26fc10000",
             },
             {
@@ -417,6 +426,7 @@ describe("TransactionController (e2e)", () => {
               status: "included",
               to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
               transactionIndex: 3233098,
+              type: 255,
               value: "0x2386f26fc10000",
             },
             {
@@ -439,6 +449,7 @@ describe("TransactionController (e2e)", () => {
               status: "included",
               to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
               transactionIndex: 3233097,
+              type: 255,
               value: "0x2386f26fc10000",
             },
           ])
@@ -471,6 +482,7 @@ describe("TransactionController (e2e)", () => {
               status: "verified",
               to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
               transactionIndex: 3233105,
+              type: 255,
               value: "0x2386f26fc10000",
             },
             {
@@ -493,6 +505,7 @@ describe("TransactionController (e2e)", () => {
               status: "verified",
               to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
               transactionIndex: 3233104,
+              type: 255,
               value: "0x2386f26fc10000",
             },
             {
@@ -515,6 +528,7 @@ describe("TransactionController (e2e)", () => {
               status: "proved",
               to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
               transactionIndex: 3233103,
+              type: 255,
               value: "0x2386f26fc10000",
             },
           ])
@@ -593,6 +607,7 @@ describe("TransactionController (e2e)", () => {
                 status: "included",
                 to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
                 transactionIndex: 3233098,
+                type: 255,
                 value: "0x2386f26fc10000",
               },
             ],
@@ -640,6 +655,7 @@ describe("TransactionController (e2e)", () => {
                 status: "included",
                 to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
                 transactionIndex: 3233098,
+                type: 255,
                 value: "0x2386f26fc10000",
               },
             ],
@@ -687,6 +703,7 @@ describe("TransactionController (e2e)", () => {
                 status: "verified",
                 to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
                 transactionIndex: 3233104,
+                type: 255,
                 value: "0x2386f26fc10000",
               },
               {
@@ -709,6 +726,7 @@ describe("TransactionController (e2e)", () => {
                 status: "proved",
                 to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
                 transactionIndex: 3233103,
+                type: 255,
                 value: "0x2386f26fc10000",
               },
             ],
@@ -792,6 +810,7 @@ describe("TransactionController (e2e)", () => {
             status: "verified",
             to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
             transactionIndex: 3233105,
+            type: 255,
             value: "0x2386f26fc10000",
           })
         );
@@ -822,6 +841,7 @@ describe("TransactionController (e2e)", () => {
             status: "proved",
             to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
             transactionIndex: 3233102,
+            type: 255,
             value: "0x2386f26fc10000",
           })
         );
@@ -852,6 +872,7 @@ describe("TransactionController (e2e)", () => {
             status: "committed",
             to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
             transactionIndex: 3233100,
+            type: 255,
             value: "0x2386f26fc10000",
           })
         );
@@ -882,6 +903,7 @@ describe("TransactionController (e2e)", () => {
             status: "included",
             to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
             transactionIndex: 3233097,
+            type: 255,
             value: "0x2386f26fc10000",
           })
         );
@@ -912,6 +934,7 @@ describe("TransactionController (e2e)", () => {
             status: "failed",
             to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
             transactionIndex: 3233106,
+            type: 255,
             value: "0x2386f26fc10000",
           })
         );
@@ -942,6 +965,7 @@ describe("TransactionController (e2e)", () => {
             status: "included",
             to: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35C",
             transactionIndex: 3233097,
+            type: 255,
             value: "0x2386f26fc10000",
           })
         );


### PR DESCRIPTION
# What ❔

Add transaction `type` to all endpoints where transaction data is returned. For _get internal transactions_ endpoint, the field is named `transactionType` since `type` is already used for other purpose.

## Why ❔

This was requested by developers who are integrating their products with zkSync so they don't need to fetch transaction types separately from the RPC. As it makes sense to return this data anyway, it was added to all endpoints that return transaction data.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
