### PR TITLE
feat: add min liquidity filter for tokens list API

### DIFF
--- a/packages/api/src/token/token.controller.spec.ts
+++ b/packages/api/src/token/token.controller.spec.ts
@@ -50,9 +50,9 @@ describe("TokenController", () => {
     });
 
     it("queries tokens with the specified options", async () => {
-      await controller.getTokens(pagingOptions);
+      await controller.getTokens(pagingOptions, 1000);
       expect(serviceMock.findAll).toHaveBeenCalledTimes(1);
-      expect(serviceMock.findAll).toHaveBeenCalledWith({ ...pagingOptions, route: "tokens" });
+      expect(serviceMock.findAll).toHaveBeenCalledWith({ minLiquidity: 1000 }, { ...pagingOptions, route: "tokens" });
     });
 
     it("returns the tokens", async () => {

--- a/packages/api/src/token/token.service.ts
+++ b/packages/api/src/token/token.service.ts
@@ -1,9 +1,13 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository, FindOptionsSelect } from "typeorm";
+import { Repository, FindOptionsSelect, MoreThanOrEqual } from "typeorm";
 import { Pagination, IPaginationOptions } from "nestjs-typeorm-paginate";
 import { paginate } from "../common/utils";
 import { Token, ETH_TOKEN } from "./token.entity";
+
+export interface FilterTokensOptions {
+  minLiquidity?: number;
+}
 
 @Injectable()
 export class TokenService {
@@ -34,8 +38,16 @@ export class TokenService {
     return tokenExists;
   }
 
-  public async findAll(paginationOptions: IPaginationOptions): Promise<Pagination<Token>> {
+  public async findAll(
+    { minLiquidity }: FilterTokensOptions,
+    paginationOptions: IPaginationOptions
+  ): Promise<Pagination<Token>> {
     const queryBuilder = this.tokenRepository.createQueryBuilder("token");
+    if (minLiquidity > 0) {
+      queryBuilder.where({
+        liquidity: MoreThanOrEqual(minLiquidity),
+      });
+    }
     queryBuilder.orderBy("token.liquidity", "DESC", "NULLS LAST");
     queryBuilder.addOrderBy("token.blockNumber", "DESC");
     queryBuilder.addOrderBy("token.logIndex", "DESC");


### PR DESCRIPTION
# What ❔

- Adds min liquidity filters for /tokens API

## Why ❔

- front-end will be able to fetch all tokens with liquidity
