### PR TITLE
test: covering Contract API and Logs API endpoints

### DIFF
--- a/packages/integration-tests/src/entities.ts
+++ b/packages/integration-tests/src/entities.ts
@@ -7,6 +7,7 @@ export enum Buffer {
   L2 = "./buffer/L2.txt",
   L2deposited = "./buffer/L2deposited.txt",
   paymaster = "./buffer/paymaster.txt",
+  paymasterDeployTx = "./buffer/paymasterDeployTx.txt",
   paymasterTx = "./buffer/paymasterTx.txt",
   addressMultiTransferETH = "./buffer/multiTransferETH.txt",
   txMultiTransferETH = "./buffer/txMultiTransferETH.txt",

--- a/packages/integration-tests/src/playbook/deploy/deploy-paymaster.ts
+++ b/packages/integration-tests/src/playbook/deploy/deploy-paymaster.ts
@@ -31,6 +31,7 @@ export default async function (hre: HardhatRuntimeEnvironment) {
 
   const deployTransaction = await paymaster.deployTransaction;
   console.log(`Paymaster deploy transaction: ${deployTransaction.hash}`);
+  await fs.writeFile(Buffer.paymasterDeployTx, deployTransaction.hash);
 
   await (
     await deployer.zkWallet.sendTransaction({

--- a/packages/integration-tests/tests/api/contracts.test.ts
+++ b/packages/integration-tests/tests/api/contracts.test.ts
@@ -1,0 +1,43 @@
+import * as request from "supertest";
+import { setTimeout } from "timers/promises";
+
+import { environment } from "../../src/config";
+import { localConfig } from "../../src/config";
+import { Buffer, Wallets } from "../../src/entities";
+import { Helper } from "../../src/helper";
+
+describe("Contracts", () => {
+  jest.setTimeout(localConfig.standardTimeout);
+
+  const helper = new Helper();
+  const bufferFile = "src/playbook/";
+  let paymasterContract: string;
+  let paymasterTx: string;
+
+  beforeAll(async () => {
+    paymasterContract = await helper.getStringFromFile(bufferFile + Buffer.paymaster);
+    paymasterTx = await helper.getStringFromFile(bufferFile + Buffer.paymasterDeployTx);
+  });
+
+  describe("/api?module=contract&action=getcontractcreation", () => {
+    jest.setTimeout(localConfig.standardTimeout); //works unstable without timeout
+
+    //@id1696
+    it("Verify the response via /api?module=contract&action=getcontractcreation", async () => {
+      await setTimeout(localConfig.extendedPause); //works unstable without timeout
+      const apiRoute = `/api?module=contract&action=getcontractcreation&contractaddresses=${paymasterContract}`;
+      return request(environment.blockExplorerAPI)
+        .get(apiRoute)
+        .expect(200)
+        .expect((res) =>
+          expect(res.body.result[0]).toStrictEqual(expect.objectContaining({ contractAddress: paymasterContract }))
+        )
+        .expect((res) =>
+          expect(res.body.result[0]).toStrictEqual(
+            expect.objectContaining({ contractCreator: Wallets.richWalletAddress })
+          )
+        )
+        .expect((res) => expect(res.body.result[0]).toStrictEqual(expect.objectContaining({ txHash: paymasterTx })));
+    });
+  });
+});

--- a/packages/integration-tests/tests/api/logs.test.ts
+++ b/packages/integration-tests/tests/api/logs.test.ts
@@ -1,0 +1,43 @@
+import * as request from "supertest";
+import { setTimeout } from "timers/promises";
+
+import { environment } from "../../src/config";
+import { localConfig } from "../../src/config";
+import { Buffer, Wallets } from "../../src/entities";
+import { Helper } from "../../src/helper";
+
+describe("Logs", () => {
+  jest.setTimeout(localConfig.standardTimeout); //works unstable without timeout
+  const helper = new Helper();
+  const bufferFile = "src/playbook/";
+  let contractAddress: string;
+
+  beforeAll(async () => {
+    contractAddress = await helper.getStringFromFile(bufferFile + Buffer.customToken);
+  });
+
+  describe("/api?module=logs&action=getLogs", () => {
+    //@id1808
+    it("Verify the response via /api?module=logs&action=getLogs", async () => {
+      await setTimeout(localConfig.extendedPause); //works unstable without timeout
+
+      const apiRoute = `/api?module=logs&action=getLogs&page=1&offset=1&toBlock=1000&fromBlock=1&address=${contractAddress}`;
+
+      return request(environment.blockExplorerAPI)
+        .get(apiRoute)
+        .expect(200)
+        .expect((res) =>
+          expect(res.body.result[0]).toStrictEqual(expect.objectContaining({ address: contractAddress }))
+        )
+        .expect((res) => expect(typeof res.body.result[0].topics[0]).toStrictEqual("string"))
+        .expect((res) => expect(typeof res.body.result[0].data).toStrictEqual("string"))
+        .expect((res) => expect(typeof res.body.result[0].blockNumber).toStrictEqual("string"))
+        .expect((res) => expect(typeof res.body.result[0].timeStamp).toStrictEqual("string"))
+        .expect((res) => expect(typeof res.body.result[0].gasPrice).toStrictEqual("string"))
+        .expect((res) => expect(typeof res.body.result[0].gasUsed).toStrictEqual("string"))
+        .expect((res) => expect(typeof res.body.result[0].logIndex).toStrictEqual("string"))
+        .expect((res) => expect(typeof res.body.result[0].transactionHash).toStrictEqual("string"))
+        .expect((res) => expect(typeof res.body.result[0].transactionIndex).toStrictEqual("string"));
+    });
+  });
+});


### PR DESCRIPTION
# What ❔

- Added test for TC id1696 /api?module=contract&action=getcontractcreation endpoint (Contract API)
- Added test for TC id1808 /api?module=logs&action=getLogs endpoint (Logs API)

## Why ❔

Expand test coverage - id1696 and id1808 weren't covered by autotest
