### PR TITLE
fix: remove tokens minLiquidity filter when value is 0

### DIFF
--- a/packages/worker/src/token/tokenOffChainData/providers/portalsFiTokenOffChainDataProvider.spec.ts
+++ b/packages/worker/src/token/tokenOffChainData/providers/portalsFiTokenOffChainDataProvider.spec.ts
@@ -9,7 +9,7 @@ import { PortalsFiTokenOffChainDataProvider } from "./portalsFiTokenOffChainData
 
 const MIN_TOKENS_LIQUIDITY_FILTER = 0;
 const TOKENS_INFO_API_URL = "https://api.portals.fi/v2/tokens";
-const TOKENS_INFO_API_QUERY = `networks=ethereum&limit=250&sortBy=liquidity&minLiquidity=${MIN_TOKENS_LIQUIDITY_FILTER}&sortDirection=desc`;
+const TOKENS_INFO_API_QUERY = `networks=ethereum&limit=250&sortBy=liquidity&sortDirection=desc`;
 
 const providerTokensResponse = [
   {
@@ -138,6 +138,25 @@ describe("PortalsFiTokenOffChainDataProvider", () => {
           iconURL: "http://image2.com",
         },
       ]);
+    });
+
+    it("includes minLiquidity filter when provided minLiquidity filter > 0", async () => {
+      pipeMock.mockReturnValueOnce(
+        new rxjs.Observable((subscriber) => {
+          subscriber.next({
+            data: {
+              more: false,
+              tokens: [providerTokensResponse[0]],
+            },
+          });
+        })
+      );
+
+      await provider.getTokensOffChainData(1000000);
+      expect(httpServiceMock.get).toBeCalledTimes(1);
+      expect(httpServiceMock.get).toBeCalledWith(
+        `${TOKENS_INFO_API_URL}?${TOKENS_INFO_API_QUERY}&page=0&minLiquidity=1000000`
+      );
     });
 
     it("retries when provider API call fails", async () => {

--- a/packages/worker/src/token/tokenOffChainData/providers/portalsFiTokenOffChainDataProvider.ts
+++ b/packages/worker/src/token/tokenOffChainData/providers/portalsFiTokenOffChainDataProvider.ts
@@ -91,7 +91,17 @@ export class PortalsFiTokenOffChainDataProvider implements TokenOffChainDataProv
     page: number;
     minLiquidity: number;
   }): Promise<ITokensOffChainDataPage> {
-    const queryString = `networks=ethereum&limit=250&sortBy=liquidity&minLiquidity=${minLiquidity}&sortDirection=desc&page=${page}`;
+    const query = {
+      networks: "ethereum",
+      limit: "250",
+      sortBy: "liquidity",
+      sortDirection: "desc",
+      page: page.toString(),
+      ...(minLiquidity && {
+        minLiquidity: minLiquidity.toString(),
+      }),
+    };
+    const queryString = new URLSearchParams(query).toString();
 
     const { data } = await firstValueFrom<{ data: ITokensOffChainDataProviderResponse }>(
       this.httpService.get(`${TOKENS_INFO_API_URL}?${queryString}`).pipe(


### PR DESCRIPTION
# What ❔

- remove tokens minLiquidity filter when value is 0 as provider doesn't return 0 liquidity tokens when filter is set to 0
