### PR TITLE
fix: rename tokens page title to top tokens

### DIFF
--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -581,8 +581,8 @@
         "title": "Transactions"
     },
     "tokenListView": {
-        "title": "Token List",
-        "heading": "Tokens",
+        "title": "Top tokens",
+        "heading": "Top tokens",
         "offChainDataPoweredBy": "Off-chain data powered by",
         "table": {
             "tokenName": "Token Name",

--- a/packages/app/src/locales/uk.json
+++ b/packages/app/src/locales/uk.json
@@ -323,8 +323,8 @@
         "title": "Транзакції"
     },
     "tokenListView": {
-        "title": "Список Токенів",
-        "heading": "Токени",
+        "title": "Top токени",
+        "heading": "Top токени",
         "offChainDataPoweredBy": "Off-chain дані взяті з",
         "table": {
             "tokenName": "Назва Токена",


### PR DESCRIPTION
# What ❔

Renamed tokens page title to "To tokens"

## Why ❔

We show only top tokens there, not all of them
