### PR TITLE
fix: ignore parse log errors

### DIFF
--- a/packages/app/src/utils/helpers.ts
+++ b/packages/app/src/utils/helpers.ts
@@ -92,20 +92,24 @@ export const mapOrder = (array: any[], order: string[], key: string) => {
   });
 };
 
-export function decodeLogWithABI(log: TransactionLogEntry, abi: AbiFragment[]): TransactionEvent {
+export function decodeLogWithABI(log: TransactionLogEntry, abi: AbiFragment[]): TransactionEvent | undefined {
   const contractInterface = new utils.Interface(abi);
-  const decodedLog = contractInterface.parseLog({
-    topics: log.topics,
-    data: log.data,
-  });
-  return {
-    name: decodedLog.name,
-    inputs: decodedLog.eventFragment.inputs.map((input) => ({
-      name: input.name,
-      type: input.type as InputType,
-      value: decodedLog.args[input.name]?.toString(),
-    })),
-  };
+  try {
+    const decodedLog = contractInterface.parseLog({
+      topics: log.topics,
+      data: log.data,
+    });
+    return {
+      name: decodedLog.name,
+      inputs: decodedLog.eventFragment.inputs.map((input) => ({
+        name: input.name,
+        type: input.type as InputType,
+        value: decodedLog.args[input.name]?.toString(),
+      })),
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 export function sortTokenTransfers(transfers: TokenTransfer[]): TokenTransfer[] {


### PR DESCRIPTION
# What ❔

- show logs without parsed event if it fails.

## Why ❔

- currently it shows no logs at all if even one of many logs is failed to parse.

This is a quick fix for now. The issue can be reproduced with proxy contracts if there are some events emitted which are defined in the implementation contract. To properly fix it we should use both proxy and implementation ABI.
