### PR TITLE
fix: use liquidity tokens filter only on mainnet

### DIFF
--- a/packages/app/src/components/header/TheHeader.vue
+++ b/packages/app/src/components/header/TheHeader.vue
@@ -173,8 +173,8 @@ const blockExplorerLinks = reactive([
     to: { name: "transactions" },
   },
   {
-    label: computed(() => t("tokenListView.title")),
-    to: { name: "token-list" },
+    label: computed(() => t("tokensView.title")),
+    to: { name: "tokens" },
   },
 ]);
 

--- a/packages/app/src/components/token/TokenListTable.vue
+++ b/packages/app/src/components/token/TokenListTable.vue
@@ -1,12 +1,12 @@
 <template>
   <Table :data-testid="$testId.tokensTable" :loading="loading" :items="tokens" ref="table">
     <template #table-head>
-      <table-head-column>{{ t("tokenListView.table.tokenName") }}</table-head-column>
-      <table-head-column>{{ t("tokenListView.table.price") }}</table-head-column>
-      <table-head-column>{{ t("tokenListView.table.tokenAddress") }}</table-head-column>
+      <table-head-column>{{ t("tokensView.table.tokenName") }}</table-head-column>
+      <table-head-column>{{ t("tokensView.table.price") }}</table-head-column>
+      <table-head-column>{{ t("tokensView.table.tokenAddress") }}</table-head-column>
     </template>
     <template #table-row="{ item }: { item: any }">
-      <TableBodyColumn :data-heading="t('tokenListView.table.tokenName')">
+      <TableBodyColumn :data-heading="t('tokensView.table.tokenName')">
         <TokenIconLabel
           :symbol="item.symbol"
           icon-size="xl"
@@ -15,10 +15,10 @@
           :icon-url="item.iconURL"
         />
       </TableBodyColumn>
-      <TableBodyColumn :data-heading="t('tokenListView.table.price')">
+      <TableBodyColumn :data-heading="t('tokensView.table.price')">
         <TokenPrice :address="item.l2Address" />
       </TableBodyColumn>
-      <TableBodyColumn :data-heading="t('tokenListView.table.tokenAddress')">
+      <TableBodyColumn :data-heading="t('tokensView.table.tokenAddress')">
         <div class="token-address-container max-w-sm">
           <TransactionNetworkSquareBlock network="L2" />
           <AddressLink

--- a/packages/app/src/components/transactions/infoTable/GeneralInfo.vue
+++ b/packages/app/src/components/transactions/infoTable/GeneralInfo.vue
@@ -186,28 +186,6 @@
         </TableBodyColumn>
         <TableBodyColumn class="transaction-table-value">{{ transaction.gasPerPubdata }}</TableBodyColumn>
       </tr>
-      <tr class="transaction-table-row" v-if="transaction?.maxFeePerGas">
-        <TableBodyColumn class="transaction-table-label">
-          <span class="transaction-info-field-label">{{ t("transactions.table.maxFeePerGas") }}</span>
-          <InfoTooltip class="transaction-info-field-tooltip">
-            {{ t("transactions.table.maxFeePerGasTooltip") }}
-          </InfoTooltip>
-        </TableBodyColumn>
-        <TableBodyColumn class="transaction-table-value">
-          <EthAmountPrice :amount="transaction.maxFeePerGas"></EthAmountPrice>
-        </TableBodyColumn>
-      </tr>
-      <tr class="transaction-table-row" v-if="transaction?.maxPriorityFeePerGas">
-        <TableBodyColumn class="transaction-table-label">
-          <span class="transaction-info-field-label">{{ t("transactions.table.maxPriorityFeePerGas") }}</span>
-          <InfoTooltip class="transaction-info-field-tooltip">
-            {{ t("transactions.table.maxPriorityFeePerGasTooltip") }}
-          </InfoTooltip>
-        </TableBodyColumn>
-        <TableBodyColumn class="transaction-table-value">
-          <EthAmountPrice :amount="transaction.maxPriorityFeePerGas"></EthAmountPrice>
-        </TableBodyColumn>
-      </tr>
       <tr class="transaction-table-row">
         <TableBodyColumn class="transaction-table-label">
           <span class="transaction-info-field-label">{{ t("transactions.table.nonce") }}</span>

--- a/packages/app/src/composables/useTokenLibrary.ts
+++ b/packages/app/src/composables/useTokenLibrary.ts
@@ -8,16 +8,22 @@ import useContext, { type Context } from "@/composables/useContext";
 const retrieveTokens = useMemoize(
   async (context: Context): Promise<Api.Response.Token[]> => {
     const tokens = [];
+    const tokensParams = {
+      ...(context.currentNetwork.value.tokensMinLiquidity != null && {
+        minLiquidity: context.currentNetwork.value.tokensMinLiquidity.toString(),
+      }),
+      limit: "100",
+    };
     let page = 1;
     let hasMore = true;
 
     while (hasMore) {
       const tokensResponse = await $fetch<Api.Response.Collection<Api.Response.Token>>(
-        `${context.currentNetwork.value.apiUrl}/tokens?minLiquidity=0&limit=100&page=${page}`
+        `${context.currentNetwork.value.apiUrl}/tokens?${new URLSearchParams(tokensParams).toString()}&page=${page}`
       );
       tokens.push(...tokensResponse.items);
       page++;
-      hasMore = tokensResponse.meta.totalPages > tokensResponse.meta.currentPage;
+      hasMore = !!tokensParams.minLiquidity && tokensResponse.meta.totalPages > tokensResponse.meta.currentPage;
     }
 
     return tokens;

--- a/packages/app/src/configs/dev.config.json
+++ b/packages/app/src/configs/dev.config.json
@@ -78,7 +78,8 @@
       "maintenance": false,
       "name": "mainnet",
       "published": true,
-      "rpcUrl": "https://mainnet.era.zksync.io"
+      "rpcUrl": "https://mainnet.era.zksync.io",
+      "tokensMinLiquidity": 0
     }
   ]
 }

--- a/packages/app/src/configs/index.ts
+++ b/packages/app/src/configs/index.ts
@@ -12,6 +12,7 @@ export type NetworkConfig = {
   maintenance: boolean;
   published: boolean;
   hostnames: string[];
+  tokensMinLiquidity?: number;
 };
 
 export type EnvironmentConfig = {

--- a/packages/app/src/configs/production.config.json
+++ b/packages/app/src/configs/production.config.json
@@ -49,7 +49,8 @@
       "maintenance": false,
       "name": "mainnet",
       "published": true,
-      "rpcUrl": "https://mainnet.era.zksync.io"
+      "rpcUrl": "https://mainnet.era.zksync.io",
+      "tokensMinLiquidity": 0
     }
   ]
 }

--- a/packages/app/src/configs/staging.config.json
+++ b/packages/app/src/configs/staging.config.json
@@ -65,7 +65,8 @@
       "maintenance": false,
       "name": "mainnet",
       "published": true,
-      "rpcUrl": "https://mainnet.era.zksync.io"
+      "rpcUrl": "https://mainnet.era.zksync.io",
+      "tokensMinLiquidity": 0
     }
   ]
 }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -164,11 +164,7 @@
             "gasLimitAndUsed": "Gas limit & used",
             "gasLimitAndUsedTooltip": "Maximum amount of gas allocated for the transaction & the amount eventually used.",
             "gasPerPubdata": "Gas per pubdata",
-            "gasPerPubdataTooltip": "Maximum amount of gas the user is willing to pay for a single byte of published data (pubdata).",
-            "maxFeePerGas": "Max fee",
-            "maxFeePerGasTooltip": "Maximum amount a user is willing to pay for their tx.",
-            "maxPriorityFeePerGas": "Max priority fee",
-            "maxPriorityFeePerGasTooltip": "Maximum amount a user is willing to give to the block producer."
+            "gasPerPubdataTooltip": "Maximum amount of gas the user is willing to pay for a single byte of published data (pubdata)."
         },
         "logs": {
             "name": "Name",
@@ -584,9 +580,9 @@
     "transactionsView": {
         "title": "Transactions"
     },
-    "tokenListView": {
-        "title": "Top tokens",
-        "heading": "Top tokens",
+    "tokensView": {
+        "title": "Tokens",
+        "heading": "Tokens",
         "offChainDataPoweredBy": "Off-chain data powered by",
         "table": {
             "tokenName": "Token Name",

--- a/packages/app/src/locales/uk.json
+++ b/packages/app/src/locales/uk.json
@@ -104,11 +104,7 @@
             "gasLimitAndUsed": "Газ ліміт & використано",
             "gasLimitAndUsedTooltip": "Максимальна кількість виділеного газу для транзакції та кількість фактично використаного газу.",
             "gasPerPubdata": "Газ за pubdata",
-            "gasPerPubdataTooltip": "Максимальна кількість газу, яку користувач готовий сплатити за один байт опублікованих даних (pubdata).",
-            "maxFeePerGas": "Макс комісія",
-            "maxFeePerGasTooltip": "Максимальна комісія, яку користувач готовий заплатити за свою транзакцію.",
-            "maxPriorityFeePerGas": "Макс пріоритетна комісія",
-            "maxPriorityFeePerGasTooltip": "Максимальна комісія, яку користувач готовий віддати блок-продюсеру."
+            "gasPerPubdataTooltip": "Максимальна кількість газу, яку користувач готовий сплатити за один байт опублікованих даних (pubdata)."
         },
         "logs": {
             "address": "Адреса",
@@ -333,7 +329,7 @@
     "transactionsView": {
         "title": "Транзакції"
     },
-    "tokenListView": {
+    "tokensView": {
         "title": "Top токени",
         "heading": "Top токени",
         "offChainDataPoweredBy": "Off-chain дані взяті з",

--- a/packages/app/src/router/routes.ts
+++ b/packages/app/src/router/routes.ts
@@ -68,10 +68,14 @@ export default [
   },
   {
     path: "/tokenlist",
-    name: "token-list",
+    redirect: "tokens",
+  },
+  {
+    path: "/tokens",
+    name: "tokens",
     component: () => import("@/views/TokensView.vue"),
     meta: {
-      title: "tokenListView.title",
+      title: "tokensView.title",
     },
   },
   {

--- a/packages/app/src/views/TokensView.vue
+++ b/packages/app/src/views/TokensView.vue
@@ -5,9 +5,9 @@
       <SearchForm class="search-form" />
     </div>
     <div class="tokens-header">
-      <h1>{{ t("tokenListView.heading") }}</h1>
+      <h1>{{ t("tokensView.heading") }}</h1>
       <div v-if="tokens[0]?.iconURL" class="coingecko-attribution">
-        <span>{{ t("tokenListView.offChainDataPoweredBy") }}{{ " " }}</span>
+        <span>{{ t("tokensView.offChainDataPoweredBy") }}{{ " " }}</span>
         <a href="https://www.coingecko.com/en/api" target="_blank">CoinGecko API</a>
       </div>
     </div>
@@ -39,7 +39,7 @@ const breadcrumbItems = computed((): BreadcrumbItem[] => [
     to: { name: "home" },
   },
   {
-    text: `${t("tokenListView.title")}`,
+    text: `${t("tokensView.title")}`,
   },
 ]);
 

--- a/packages/app/tests/components/TheHeader.spec.ts
+++ b/packages/app/tests/components/TheHeader.spec.ts
@@ -53,7 +53,7 @@ describe("TheHeader:", () => {
     expect(blockExplorerLinks[0].props().to.name).toBe("blocks");
     expect(blockExplorerLinks[1].props().to.name).toBe("batches");
     expect(blockExplorerLinks[2].props().to.name).toBe("transactions");
-    expect(blockExplorerLinks[3].props().to.name).toBe("token-list");
+    expect(blockExplorerLinks[3].props().to.name).toBe("tokens");
 
     await fireEvent.click(dropdown[1].find("button")!.element);
     const toolsLinksRouter = dropdown[1].findAllComponents(RouterLinkStub);

--- a/packages/app/tests/components/transactions/GeneralInfo.spec.ts
+++ b/packages/app/tests/components/transactions/GeneralInfo.spec.ts
@@ -225,8 +225,6 @@ describe("Transaction info table", () => {
       fee,
       gasLimitAndUsed,
       gasPerPubdata,
-      maxFee,
-      maxFeePriority,
       nonce,
       createdAt,
     ] = wrapper.findAll("tbody tr td:nth-child(2)");
@@ -273,12 +271,6 @@ describe("Transaction info table", () => {
 
     expect(gasLimitAndUsed.text()).toBe("5000 | 3000 (60%)");
     expect(gasPerPubdata.text()).toBe("800");
-    expect(`${maxFee.find(".token-amount").text()} ${maxFee.find(".token-symbol").text()}`).toBe(
-      "0.000000000000007 ETH"
-    );
-    expect(`${maxFeePriority.find(".token-amount").text()} ${maxFeePriority.find(".token-symbol").text()}`).toBe(
-      "0.000000000000008 ETH"
-    );
     expect(nonce.text()).toBe("24");
     expect(createdAt.find(".full-date").text()).toBe("2023-02-28 11:42");
 
@@ -295,8 +287,6 @@ describe("Transaction info table", () => {
       feeTooltip,
       gasLimitAndUsedTooltip,
       gasPerPubdataTooltip,
-      maxFeeTooltip,
-      maxPriorityFeeTooltip,
       nonceTooltip,
       createdAtTooltip,
     ] = wrapper.findAll("tbody .transaction-info-field-tooltip").map((e) => e.text());
@@ -312,8 +302,6 @@ describe("Transaction info table", () => {
     expect(feeTooltip).toBe(i18n.global.t("transactions.table.feeTooltip"));
     expect(gasLimitAndUsedTooltip).toBe(i18n.global.t("transactions.table.gasLimitAndUsedTooltip"));
     expect(gasPerPubdataTooltip).toBe(i18n.global.t("transactions.table.gasPerPubdataTooltip"));
-    expect(maxFeeTooltip).toBe(i18n.global.t("transactions.table.maxFeePerGasTooltip"));
-    expect(maxPriorityFeeTooltip).toBe(i18n.global.t("transactions.table.maxPriorityFeePerGasTooltip"));
     expect(nonceTooltip).toBe(i18n.global.t("transactions.table.nonceTooltip"));
     expect(createdAtTooltip).toBe(i18n.global.t("transactions.table.createdTooltip"));
   });


### PR DESCRIPTION
# What ❔

Use liquidity tokens filter only on mainnet.

## Why ❔

To show tokens without liquidity on testnets, local envs and hyperchains.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.