### PR TITLE
feat(debugger): add background color to instructions based on call count

### DIFF
--- a/packages/app/src/components/debugger/SourceViewer.vue
+++ b/packages/app/src/components/debugger/SourceViewer.vue
@@ -18,17 +18,8 @@
       <span
         class="instruction-list-item-text-container"
         :style="{
-          color:
-            traceCountPercentage[
-              `${address}_${Object.keys(pcLineMapping).find((key) => pcLineMapping[parseInt(key)] === item.index)}`
-            ] > 0.4
-              ? 'white'
-              : 'black',
-          backgroundColor: `rgba(200, 0, 0, ${
-            traceCountPercentage[
-              `${address}_${Object.keys(pcLineMapping).find((key) => pcLineMapping[parseInt(key)] === item.index)}`
-            ]
-          }`,
+          color: item.traceCountPercentage > 0.4 ? 'white' : 'black',
+          backgroundColor: `rgba(200, 0, 0, ${item.traceCountPercentage}`,
         }"
       >
         <span class="instruction-list-item-text" v-html="highlight(item.label, searchText)"></span>
@@ -86,9 +77,11 @@ const props = defineProps({
   },
   traceCountPercentage: {
     type: Object as PropType<{ [key: string]: number }>,
+    required: true,
   },
   pcLineMapping: {
     type: Object as PropType<{ [key: number]: number }>,
+    required: true,
   },
 });
 
@@ -100,7 +93,10 @@ type InstructionNode = {
   expandable: boolean;
 };
 
-type VirtualInstructionNode = InstructionNode & { index: number };
+type VirtualInstructionNode = InstructionNode & {
+  index: number;
+  traceCountPercentage: number;
+};
 
 const expanded = ref<number[]>([]);
 const isReady = ref(false);
@@ -155,7 +151,17 @@ watchEffect(() => {
       }
       return val;
     })
-    .map((item, index) => ({ ...item, index, line: item.line }));
+    .map((item, index) => ({
+      ...item,
+      index,
+      line: item.line,
+      traceCountPercentage:
+        props.traceCountPercentage[
+          `${props.address}_${Object.keys(props.pcLineMapping).find(
+            (key) => props.pcLineMapping[parseInt(key)] === index
+          )}`
+        ],
+    }));
   if (isReady.value) {
     rebuild();
   }

--- a/packages/app/src/components/debugger/SourceViewer.vue
+++ b/packages/app/src/components/debugger/SourceViewer.vue
@@ -15,7 +15,22 @@
       :data-testid="item.expandable ? 'instruction-list-item-expandable' : 'instruction-list-item'"
     >
       <label class="instruction-list-line">{{ item.line + 1 }}</label>
-      <span class="instruction-list-item-text-container">
+      <span
+        class="instruction-list-item-text-container"
+        :style="{
+          color:
+            traceCountPercentage[
+              `${address}_${Object.keys(pcLineMapping).find((key) => pcLineMapping[parseInt(key)] === item.index)}`
+            ] > 0.4
+              ? 'white'
+              : 'black',
+          backgroundColor: `rgba(200, 0, 0, ${
+            traceCountPercentage[
+              `${address}_${Object.keys(pcLineMapping).find((key) => pcLineMapping[parseInt(key)] === item.index)}`
+            ]
+          }`,
+        }"
+      >
         <span class="instruction-list-item-text" v-html="highlight(item.label, searchText)"></span>
         <span v-if="item.error" class="instruction-list-item-error" :title="item.error">{{ item.error }}</span>
       </span>
@@ -68,6 +83,12 @@ const props = defineProps({
   searchText: {
     type: String,
     default: "",
+  },
+  traceCountPercentage: {
+    type: Object as PropType<{ [key: string]: number }>,
+  },
+  pcLineMapping: {
+    type: Object as PropType<{ [key: number]: number }>,
   },
 });
 

--- a/packages/app/src/composables/useTrace.ts
+++ b/packages/app/src/composables/useTrace.ts
@@ -205,24 +205,18 @@ export function useTraceNavigation(trace: ComputedRef<TraceFile | null>, initial
       return {};
     }
 
+    let maxCount = 0;
     const countDictionary = trace.value.steps.reduce((acc: { [key: string]: number }, step) => {
       const key = `${step.contract_address}_${step.pc}`;
-      if (acc[key]) {
-        acc[key] += 1;
-      } else {
-        acc[key] = 1;
-      }
+      acc[key] = (acc[key] || 0) + 1;
+      maxCount = Math.max(maxCount, acc[key]);
       return acc;
     }, {});
 
     const countPercentageDictionary: { [key: string]: number } = {};
 
     for (const [key, value] of Object.entries(countDictionary)) {
-      countPercentageDictionary[key] =
-        value /
-        Object.entries(countDictionary)
-          .map((x) => x[1])
-          .reduce((a, b) => Math.max(a, b));
+      countPercentageDictionary[key] = value / maxCount;
     }
 
     return countPercentageDictionary;

--- a/packages/app/src/composables/useTrace.ts
+++ b/packages/app/src/composables/useTrace.ts
@@ -200,6 +200,34 @@ export function useTraceNavigation(trace: ComputedRef<TraceFile | null>, initial
     }
   };
 
+  const traceCountPercentage = computed<{ [key: string]: number }>(() => {
+    if (!trace.value || !trace.value.steps || !trace.value.sources || index.value === null) {
+      return {};
+    }
+
+    const countDictionary = trace.value.steps.reduce((acc: { [key: string]: number }, step) => {
+      const key = `${step.contract_address}_${step.pc}`;
+      if (acc[key]) {
+        acc[key] += 1;
+      } else {
+        acc[key] = 1;
+      }
+      return acc;
+    }, {});
+
+    const countPercentageDictionary: { [key: string]: number } = {};
+
+    for (const [key, value] of Object.entries(countDictionary)) {
+      countPercentageDictionary[key] =
+        value /
+        Object.entries(countDictionary)
+          .map((x) => x[1])
+          .reduce((a, b) => Math.max(a, b));
+    }
+
+    return countPercentageDictionary;
+  });
+
   watch(trace, () => {
     index.value = null;
   });
@@ -208,6 +236,7 @@ export function useTraceNavigation(trace: ComputedRef<TraceFile | null>, initial
     index,
     total: computed(() => trace.value?.steps.length),
 
+    traceCountPercentage,
     activeStep,
     activeLines,
 

--- a/packages/app/src/views/DebuggerView.vue
+++ b/packages/app/src/views/DebuggerView.vue
@@ -60,6 +60,8 @@ SourceNode
               :activeStep="activeStep"
               :searchText="searchText"
               :active-lines="activeLines[item.address]"
+              :traceCountPercentage="traceCountPercentage"
+              :pcLineMapping="item.pcLineMapping"
               @nav:navigateToLine="navigateToLine"
             />
             <MetadataBlockPopup
@@ -214,6 +216,7 @@ const {
   activeStep,
   goTo,
   index: activeIndex,
+  traceCountPercentage,
   activeLines,
   total,
   navigateToLine,
@@ -225,6 +228,9 @@ type SourceNode = {
   source: string[];
   errors: Array<undefined | string>;
   expanded: boolean;
+  pcLineMapping: {
+    [key: number]: number;
+  };
 };
 const collection = ref<SourceNode[]>();
 const opened = ref(false);
@@ -353,6 +359,7 @@ watchEffect(() => {
         source,
         errors,
         expanded: false,
+        pcLineMapping: item.pc_line_mapping,
       };
     });
   } else {

--- a/packages/app/tests/components/debugger/SourceViewer.spec.ts
+++ b/packages/app/tests/components/debugger/SourceViewer.spec.ts
@@ -31,6 +31,8 @@ describe("SourceViewer:", () => {
         address: "0x00",
         source: ["Hello World"],
         container,
+        traceCountPercentage: {},
+        pcLineMapping: {},
       },
       global: {
         plugins: [i18n],
@@ -49,6 +51,8 @@ describe("SourceViewer:", () => {
         source: ["Hello World"],
         errors: ["Error text"],
         container,
+        traceCountPercentage: {},
+        pcLineMapping: {},
       },
       global: {
         plugins: [i18n],
@@ -68,6 +72,8 @@ describe("SourceViewer:", () => {
         address: "0x00",
         source: ["Hello", "", "World"],
         container,
+        traceCountPercentage: {},
+        pcLineMapping: {},
       },
       global: {
         plugins: [i18n],
@@ -85,6 +91,8 @@ describe("SourceViewer:", () => {
         address: "0x00",
         source: ["foo", ".func_begin", "Hello", "World", "!", ".func_end"],
         container,
+        traceCountPercentage: {},
+        pcLineMapping: {},
       },
       global: {
         plugins: [i18n],
@@ -107,6 +115,8 @@ describe("SourceViewer:", () => {
         address: "0x00",
         source: ["foo", ".func_begin", "Hello", "World", "!", ".func_end"],
         container,
+        traceCountPercentage: {},
+        pcLineMapping: {},
       },
       global: {
         plugins: [i18n],
@@ -133,6 +143,8 @@ describe("SourceViewer:", () => {
         address: "0x00",
         source: ["foo", ".func_begin", "Hello", "World", "!", ".func_end"],
         container,
+        traceCountPercentage: {},
+        pcLineMapping: {},
       },
       global: {
         plugins: [i18n],
@@ -159,6 +171,8 @@ describe("SourceViewer:", () => {
         address: "0x00",
         source,
         container,
+        traceCountPercentage: {},
+        pcLineMapping: {},
       },
       global: {
         plugins: [i18n],
@@ -184,6 +198,8 @@ describe("SourceViewer:", () => {
         address: "0x00",
         source,
         container,
+        traceCountPercentage: {},
+        pcLineMapping: {},
       },
       global: {
         plugins: [i18n],
@@ -218,6 +234,8 @@ describe("SourceViewer:", () => {
           line: 2,
           step: {},
         },
+        traceCountPercentage: {},
+        pcLineMapping: {},
       },
       global: {
         plugins: [i18n],
@@ -242,6 +260,8 @@ describe("SourceViewer:", () => {
         source,
         container: container as unknown as HTMLElement,
         activeStep: { address: "0x00", line: 2, step: {} } as ActiveStep,
+        traceCountPercentage: {},
+        pcLineMapping: {},
       },
       global: {
         plugins: [i18n],
@@ -268,6 +288,8 @@ describe("SourceViewer:", () => {
         },
         container,
         searchText: "Wo",
+        traceCountPercentage: {},
+        pcLineMapping: {},
       },
       global: {
         plugins: [i18n],
@@ -294,6 +316,8 @@ describe("SourceViewer:", () => {
         },
         container,
         searchText: "o",
+        traceCountPercentage: {},
+        pcLineMapping: {},
       },
       global: {
         plugins: [i18n],
@@ -315,6 +339,8 @@ describe("SourceViewer:", () => {
         container: container as unknown as HTMLElement,
         activeStep: { address: "0x00", line: 2, step: {} } as ActiveStep,
         activeLines: [1, 3],
+        traceCountPercentage: {},
+        pcLineMapping: {},
       },
       global: {
         plugins: [i18n],
@@ -342,6 +368,8 @@ describe("SourceViewer:", () => {
         container: container as unknown as HTMLElement,
         activeStep: { address: "0x00", line: 2, step: {} } as ActiveStep,
         activeLines: [1],
+        traceCountPercentage: {},
+        pcLineMapping: {},
       },
       global: {
         plugins: [i18n],

--- a/packages/app/tests/views/DebuggerView.spec.ts
+++ b/packages/app/tests/views/DebuggerView.spec.ts
@@ -441,6 +441,7 @@ describe("DebuggerView:", () => {
       }),
       index: ref(0),
       total: computed(() => 2),
+      traceCountPercentage: computed(() => ({})),
     });
     const { unmount, container } = render(DebuggerView, {
       global: {
@@ -486,6 +487,7 @@ describe("DebuggerView:", () => {
       }),
       index: ref(1),
       total: computed(() => 2),
+      traceCountPercentage: computed(() => ({})),
     });
     const { unmount, container } = render(DebuggerView, {
       global: {


### PR DESCRIPTION
# What ❔

Add background color to instructions in Debugger Tool based on instruction call count

## Why ❔

To make it easier for compiler team to optimize pre-compiles

## Evidence

https://github.com/matter-labs/block-explorer/assets/1890113/08ba8a1e-6567-4c6e-a213-2f2ff894edac



## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
