### PR TITLE
fix: don't save tokens whose symbols contain only special characters

### DIFF
--- a/packages/worker/src/token/token.service.spec.ts
+++ b/packages/worker/src/token/token.service.spec.ts
@@ -441,6 +441,20 @@ describe("TokenService", () => {
       });
     });
 
+    describe("if the token symbol has special symbols only", () => {
+      beforeEach(() => {
+        jest.spyOn(blockchainServiceMock, "getERC20TokenData").mockResolvedValueOnce({
+          ...tokenData,
+          symbol: "\0\0\0\0\0\0",
+        });
+      });
+
+      it("does not upsert the token", async () => {
+        await tokenService.saveERC20Token(deployedContractAddress, transactionReceipt);
+        expect(tokenRepositoryMock.upsert).toHaveBeenCalledTimes(0);
+      });
+    });
+
     describe("when transactionReceipt param is not provided", () => {
       it("upserts the token without l1Address when token is valid", async () => {
         await tokenService.saveERC20Token(deployedContractAddress);

--- a/packages/worker/src/token/token.service.ts
+++ b/packages/worker/src/token/token.service.ts
@@ -9,6 +9,7 @@ import { AddressRepository, TokenRepository } from "../repositories";
 import { GET_TOKEN_INFO_DURATION_METRIC_NAME } from "../metrics";
 import { ContractAddress } from "../address/interface/contractAddress.interface";
 import parseLog from "../utils/parseLog";
+import { stringTransformer } from "../transformers/string.transformer";
 import { CONTRACT_INTERFACES } from "../constants";
 
 export interface Token {
@@ -88,7 +89,7 @@ export class TokenService {
       }
     }
 
-    if (erc20Token?.symbol) {
+    if (this.removeSpecialChars(erc20Token?.symbol)) {
       this.logger.debug({
         message: "Adding ERC20 token to the DB",
         blockNumber: contractAddress.blockNumber,
@@ -108,6 +109,10 @@ export class TokenService {
         }),
       });
     }
+  }
+
+  private removeSpecialChars(str: string | null): string {
+    return stringTransformer.to(str);
   }
 
   public async saveERC20Tokens(tokenAddresses: string[]): Promise<void> {


### PR DESCRIPTION
# What ❔

Do not try to save tokens whose symbols contain only special characters.

## Why ❔

Because it violates the token DB constraint.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.