### PR TITLE
fix: don't do prefetch request for tx search

### DIFF
--- a/packages/app/src/composables/useSearch.ts
+++ b/packages/app/src/composables/useSearch.ts
@@ -20,18 +20,21 @@ export default (context = useContext()) => {
           apiRoute: "address",
           isValid: () => isAddress(param),
           routeName: "address",
+          prefetch: true,
         },
         {
           routeParam: { id: param },
           apiRoute: "batches",
           isValid: () => isBlockNumber(param),
           routeName: "batch",
+          prefetch: true,
         },
         {
           routeParam: { hash: param },
           apiRoute: "transactions",
           isValid: () => isTransactionHash(param),
           routeName: "transaction",
+          prefetch: false,
         },
       ];
 
@@ -46,7 +49,9 @@ export default (context = useContext()) => {
     const searchRoute = getSearchRoute(param);
     if (searchRoute) {
       try {
-        await $fetch(`${context.currentNetwork.value.apiUrl}/${searchRoute.apiRoute}/${param}`);
+        if (searchRoute.prefetch) {
+          await $fetch(`${context.currentNetwork.value.apiUrl}/${searchRoute.apiRoute}/${param}`);
+        }
         await router.push({ name: searchRoute.routeName, params: searchRoute.routeParam });
         return;
       } catch (error) {


### PR DESCRIPTION
# What ❔

Remove prefetch reuest when search by tx hash.

## Why ❔

To be able to see search for tx that are in blockchain but hasn't been indexed yet.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).