### PR TITLE
fix: docker compose on linux

### DIFF
--- a/docker-compose-cli.yaml
+++ b/docker-compose-cli.yaml
@@ -26,6 +26,8 @@ services:
       - DATA_FETCHER_URL=http://data-fetcher:3040
       - BATCHES_PROCESSING_POLLING_INTERVAL=1000
     restart: unless-stopped
+    extra_hosts:
+          - "host.docker.internal:host-gateway"
 
   data-fetcher:
     platform: linux/amd64
@@ -38,6 +40,8 @@ services:
     ports:
       - '3040:3040'
     restart: unless-stopped
+    extra_hosts:
+          - "host.docker.internal:host-gateway"
 
   api:
     platform: linux/amd64


### PR DESCRIPTION
On Linux, `extra_hosts` stanza is required for services inside the containers to be able to connect to those ports on the host.

# What ❔

Fixes container connectivity when running on Linux.

## Why ❔

Similar fix was already applied in [zkcli-block-explorer repo](https://github.com/matter-labs/zkcli-block-explorer/commit/193069913c57398f7c881bd71afbdaca01822f14).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
