### PR TITLE
fix: update tests for removing duplicate portal links 

### DIFF
--- a/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
+++ b/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
@@ -4,41 +4,32 @@ Feature: Main Page
   Background:
     Given I am on main page
 
-  @id253 @featureEnv @testnet
+
+  @id253:I @productionEnv @goerli
   Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href
+    Given I go to page "/?network=goerli"
     Given I click by text "Tools"
     Given Element with "text" "<Sub-Section>" should be "visible"
     When Element with "text" "<Sub-Section>" should be "clickable"
     Then Element with "text" "<Sub-Section>" should have "<url>" value
 
     Examples:
-      | Sub-Section                 | url                                       |
-      | Smart Contract Verification | /contracts/verify                         |
-      #| Portal                      | https://goerli.staging-portal.zksync.dev/ |
+      | Sub-Section                 | url                                              |
+      | Smart Contract Verification | /contracts/verify                                |
+      | Bridge                      | https://portal.zksync.io/bridge/?network=goerli |
 
-  @id253 @featureEnv @mainnet
+  @id253:I @productionEnv @sepolia
   Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href
+    Given I go to page "/?network=sepolia"
     Given I click by text "Tools"
     Given Element with "text" "<Sub-Section>" should be "visible"
     When Element with "text" "<Sub-Section>" should be "clickable"
     Then Element with "text" "<Sub-Section>" should have "<url>" value
 
     Examples:
-      | Sub-Section                 | url                                       |
-      | Smart Contract Verification | /contracts/verify                         |
-      #| Portal                      | https://staging-portal.zksync.dev/        |
-
-  @id253:I @productionEnv @testnet
-  Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href
-    Given I click by text "Tools"
-    Given Element with "text" "<Sub-Section>" should be "visible"
-    When Element with "text" "<Sub-Section>" should be "clickable"
-    Then Element with "text" "<Sub-Section>" should have "<url>" value
-
-    Examples:
-      | Sub-Section                 | url                                       |
-      | Smart Contract Verification | /contracts/verify                         |
-      #| Portal                      | https://goerli.portal.zksync.io/          |
+      | Sub-Section                 | url                                              |
+      | Smart Contract Verification | /contracts/verify                                |
+      | Bridge                      | https://portal.zksync.io/bridge/?network=sepolia |
 
   @id253:I @productionEnv @mainnet
   Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href
@@ -48,9 +39,9 @@ Feature: Main Page
     Then Element with "text" "<Sub-Section>" should have "<url>" value
 
     Examples:
-      | Sub-Section                 | url                                       |
-      | Smart Contract Verification | /contracts/verify                         |
-      #| Portal                      | https://portal.zksync.io/                 |
+      | Sub-Section                 | url                                              |
+      | Smart Contract Verification | /contracts/verify                                |
+      | Bridge                      | https://portal.zksync.io/bridge/?network=mainnet |
 
   @id231
   Scenario Outline: Check social networks icon "<Value>" is available, clickable and have correct href
@@ -85,7 +76,7 @@ Feature: Main Page
       | zkSync Era Sepolia Testnet  | network  |
       | zkSync Era Goerli Testnet   | network  |
       | Goerli (Stage2)             | network  |
-  
+
   @id254:II @productionEnv
   Scenario Outline: Check dropdown "<Dropdown>" for "<Value>" and verify
     Given Set the "<Value>" value for "<Dropdown>" switcher
@@ -139,7 +130,7 @@ Feature: Main Page
     Given I go to page "/address/0x8f0F33583a56908F7F933cd6F0AaE382aC3fd8f6"
     Then Element with "id" "search" should be "visible"
 
-  @id209:I @testnet 
+  @id209:I @testnet
   Scenario Outline: Verify Transaction table contains "<Row>" row
     Given I go to page "/tx/0xe7a91cc9b270d062328ef995e0ef67195a3703d43ce4e1d375f87d5c64e51981"
     When Table contains row with "<Row>"
@@ -201,7 +192,7 @@ Feature: Main Page
       | Created            | 2023-05-14                                                         |
 
 
-  @id211 @testnet 
+  @id211 @testnet
   Scenario Outline: Verify Contract info table contains "<Row>" row
     Given I go to page "/address/0x3e7676937A7E96CFB7616f255b9AD9FF47363D4b"
     Then Element with "text" "<Row>" should be "visible"

--- a/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
+++ b/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
@@ -5,7 +5,7 @@ Feature: Main Page
     Given I am on main page
 
 
-  @id253:I @testnet
+  @id253:I @testnetSmokeSuite
   Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href (Goerli)
     Given I go to page "/?network=goerli"
     Given I click by text "Tools"
@@ -18,7 +18,7 @@ Feature: Main Page
       | Smart Contract Verification | /contracts/verify                                |
       | Bridge                      | https://portal.zksync.io/bridge/?network=goerli  |
 
-  @id253:I @testnet
+  @id253:I @testnetSmokeSuite
   Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href (Sepolia)
     Given I go to page "/?network=sepolia"
     Given I click by text "Tools"

--- a/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
+++ b/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
@@ -5,22 +5,8 @@ Feature: Main Page
     Given I am on main page
 
 
-  @id253:I @testnetSmokeSuite
-  Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href (Goerli)
-    Given I go to page "/?network=goerli"
-    Given I click by text "Tools"
-    Given Element with "text" "<Sub-Section>" should be "visible"
-    When Element with "text" "<Sub-Section>" should be "clickable"
-    Then Element with "text" "<Sub-Section>" should have "<url>" value
-
-    Examples:
-      | Sub-Section                 | url                                              |
-      | Smart Contract Verification | /contracts/verify                                |
-      | Bridge                      | https://portal.zksync.io/bridge/?network=goerli  |
-
-  @id253:I @testnetSmokeSuite
+  @id253:I @featureEnv @testnetSmokeSuite
   Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href (Sepolia)
-    Given I go to page "/?network=sepolia"
     Given I click by text "Tools"
     Given Element with "text" "<Sub-Section>" should be "visible"
     When Element with "text" "<Sub-Section>" should be "clickable"
@@ -31,7 +17,7 @@ Feature: Main Page
       | Smart Contract Verification | /contracts/verify                                |
       | Bridge                      | https://portal.zksync.io/bridge/?network=sepolia |
 
-  @id253:I @mainnet
+  @id253:II @mainnet
   Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href
     Given I click by text "Tools"
     Given Element with "text" "<Sub-Section>" should be "visible"

--- a/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
+++ b/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
@@ -5,7 +5,7 @@ Feature: Main Page
     Given I am on main page
 
 
-  @id253:I @productionEnv @testnet
+  @id253:I @testnet
   Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href (Goerli)
     Given I go to page "/?network=goerli"
     Given I click by text "Tools"
@@ -18,7 +18,7 @@ Feature: Main Page
       | Smart Contract Verification | /contracts/verify                                |
       | Bridge                      | https://portal.zksync.io/bridge/?network=goerli  |
 
-  @id253:I @productionEnv @testnet
+  @id253:I @testnet
   Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href (Sepolia)
     Given I go to page "/?network=sepolia"
     Given I click by text "Tools"
@@ -31,7 +31,7 @@ Feature: Main Page
       | Smart Contract Verification | /contracts/verify                                |
       | Bridge                      | https://portal.zksync.io/bridge/?network=sepolia |
 
-  @id253:I @productionEnv @mainnet
+  @id253:I @mainnet
   Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href
     Given I click by text "Tools"
     Given Element with "text" "<Sub-Section>" should be "visible"

--- a/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
+++ b/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
@@ -5,8 +5,8 @@ Feature: Main Page
     Given I am on main page
 
 
-  @id253:I @productionEnv @goerli
-  Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href
+  @id253:I @productionEnv @testnet
+  Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href (Goerli)
     Given I go to page "/?network=goerli"
     Given I click by text "Tools"
     Given Element with "text" "<Sub-Section>" should be "visible"
@@ -16,10 +16,10 @@ Feature: Main Page
     Examples:
       | Sub-Section                 | url                                              |
       | Smart Contract Verification | /contracts/verify                                |
-      | Bridge                      | https://portal.zksync.io/bridge/?network=goerli |
+      | Bridge                      | https://portal.zksync.io/bridge/?network=goerli  |
 
-  @id253:I @productionEnv @sepolia
-  Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href
+  @id253:I @productionEnv @testnet
+  Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href (Sepolia)
     Given I go to page "/?network=sepolia"
     Given I click by text "Tools"
     Given Element with "text" "<Sub-Section>" should be "visible"

--- a/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
+++ b/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
@@ -5,7 +5,7 @@ Feature: Main Page
     Given I am on main page
 
 
-  @id253:I @featureEnv @testnetSmokeSuite
+  @id253:I @featureEnv @testnetSmokeSuite @tesnet
   Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href (Sepolia)
     Given I click by text "Tools"
     Given Element with "text" "<Sub-Section>" should be "visible"

--- a/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
+++ b/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
@@ -17,7 +17,7 @@ Feature: Main Page
       | Smart Contract Verification | /contracts/verify                                |
       | Bridge                      | https://portal.zksync.io/bridge/?network=sepolia |
 
-  @id253:II @featureEnv @mainnet
+  @id253:II @mainnet
   Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href (Mainnet)
     Given I click by text "Tools"
     Given Element with "text" "<Sub-Section>" should be "visible"

--- a/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
+++ b/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
@@ -17,7 +17,7 @@ Feature: Main Page
       | Smart Contract Verification | /contracts/verify                                |
       | Bridge                      | https://portal.zksync.io/bridge/?network=sepolia |
 
-  @id253:II @mainnet
+  @id253:II @featureEnv @mainnet
   Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href
     Given I click by text "Tools"
     Given Element with "text" "<Sub-Section>" should be "visible"

--- a/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
+++ b/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
@@ -5,7 +5,7 @@ Feature: Main Page
     Given I am on main page
 
 
-  @id253:I @featureEnv @testnetSmokeSuite @tesnet
+  @id253:I @featureEnv @testnetSmokeSuite @testnet
   Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href (Sepolia)
     Given I click by text "Tools"
     Given Element with "text" "<Sub-Section>" should be "visible"
@@ -18,7 +18,7 @@ Feature: Main Page
       | Bridge                      | https://portal.zksync.io/bridge/?network=sepolia |
 
   @id253:II @featureEnv @mainnet
-  Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href
+  Scenario Outline: Check the element "<Sub-Section>" in Tools section is available, clickable and have correct href (Mainnet)
     Given I click by text "Tools"
     Given Element with "text" "<Sub-Section>" should be "visible"
     When Element with "text" "<Sub-Section>" should be "clickable"

--- a/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
+++ b/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
@@ -45,7 +45,7 @@ Feature: Redirection
       | Blocks       | /blocks/       |
       | Transactions | /transactions/ |
 
-  @id253:II
+  @id253:I
   Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu
     Given I click by text "Tools "
     When I click by element with partial href "<url>" and text "<Sub-Section>"
@@ -56,47 +56,39 @@ Feature: Redirection
       | Smart Contract Verification | /contracts/verify |
       # | zkEVM Debugger              | /tools/debugger   |
 
-  @id253:III @featureEnv @testnet
+
+  @id253:II @productionEnv @goerli
   Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu
-    Given I click by text "Tools "
-    When I click by element with partial href "<url>" and text "<Sub-Section>"
-    Then New page have "<url>" address
-
-    Examples:
-      | Sub-Section | url                                           |
-      #| Portal      | https://goerli.staging-portal.zksync.dev/     |
-
-
-  @id253:IIII @productionEnv @testnet
-  Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu
+    Given I go to page "/?network=goerli"
     Given I click by text "Tools "
     When I click by element with partial href "<redirect_url>" and text "<Sub-Section>"
     Then New page have "<url>" address
 
     Examples:
-      | Sub-Section | url                                 | redirect_url                    |
-      #| Portal      | https://zksync.io/explore#bridges   | https://goerli.portal.zksync.io |
+      | Sub-Section | url                                             | redirect_url                    |
+      | Portal      | https://portal.zksync.io/bridge/?network=goerli | https://goerli.portal.zksync.io |
+
+  @id253:III @productionEnv @sepolia
+  Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu
+    Given I go to page "/?network=sepolia"
+    Given I click by text "Tools "
+    When I click by element with partial href "<redirect_url>" and text "<Sub-Section>"
+    Then New page have "<url>" address
+
+    Examples:
+      | Sub-Section | url                                              | redirect_url                    |
+      | Portal      | https://portal.zksync.io/bridge/?network=sepolia | https://goerli.portal.zksync.io |
 
   @id253:IV @featureEnv @mainnet
   Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu
+    Given I go to page "/?network=mainnet"
     Given I click by text "Tools "
     When I click by element with partial href "<url>" and text "<Sub-Section>"
     Then New page have "<url>" address
 
     Examples:
-      | Sub-Section | url                                           |
-      #| Portal      | https://staging-portal.zksync.dev/     |
-
-
-  @id253:IV @productionEnv @mainnet
-  Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu
-    Given I click by text "Tools "
-    When I click by element with partial href "<redirect_url>" and text "<Sub-Section>"
-    Then New page have "<url>" address
-
-    Examples:
-      | Sub-Section | url                                 | redirect_url              |
-      #| Portal      | https://zksync.io/explore#bridges   | https://portal.zksync.io  |
+      | Sub-Section | url                                              |
+      | Portal      | https://portal.zksync.io/bridge/?network=mainnet |
 
   #Account page
   @id259 @testnet

--- a/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
+++ b/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
@@ -57,8 +57,8 @@ Feature: Redirection
       # | zkEVM Debugger              | /tools/debugger   |
 
 
-  @id253:II @productionEnv @goerli
-  Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu
+  @id253:II @productionEnv @testnet
+  Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu (Goerli)
     Given I go to page "/?network=goerli"
     Given I click by text "Tools "
     When I click by element with partial href "<redirect_url>" and text "<Sub-Section>"
@@ -68,8 +68,8 @@ Feature: Redirection
       | Sub-Section | url                                             | redirect_url                    |
       | Portal      | https://portal.zksync.io/bridge/?network=goerli | https://goerli.portal.zksync.io |
 
-  @id253:III @productionEnv @sepolia
-  Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu
+  @id253:III @productionEnv @testnet
+  Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu (Sepolia)
     Given I go to page "/?network=sepolia"
     Given I click by text "Tools "
     When I click by element with partial href "<redirect_url>" and text "<Sub-Section>"

--- a/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
+++ b/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
@@ -57,7 +57,7 @@ Feature: Redirection
       # | zkEVM Debugger              | /tools/debugger   |
 
 
-  @id253:II @productionEnv @testnet
+  @id253:II @testnet
   Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu (Goerli)
     Given I go to page "/?network=goerli"
     Given I click by text "Tools "
@@ -68,7 +68,7 @@ Feature: Redirection
       | Sub-Section | url                                             | redirect_url                    |
       | Portal      | https://portal.zksync.io/bridge/?network=goerli | https://goerli.portal.zksync.io |
 
-  @id253:III @productionEnv @testnet
+  @id253:III @testnet
   Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu (Sepolia)
     Given I go to page "/?network=sepolia"
     Given I click by text "Tools "
@@ -79,7 +79,7 @@ Feature: Redirection
       | Sub-Section | url                                              | redirect_url                    |
       | Portal      | https://portal.zksync.io/bridge/?network=sepolia | https://goerli.portal.zksync.io |
 
-  @id253:IV @productionEnv @mainnet
+  @id253:IV @mainnet
   Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu
     Given I go to page "/?network=mainnet"
     Given I click by text "Tools "

--- a/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
+++ b/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
@@ -79,7 +79,7 @@ Feature: Redirection
       | Sub-Section | url                                              | redirect_url                    |
       | Portal      | https://portal.zksync.io/bridge/?network=sepolia | https://goerli.portal.zksync.io |
 
-  @id253:IV @featureEnv @mainnet
+  @id253:IV @productionEnv @mainnet
   Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu
     Given I go to page "/?network=mainnet"
     Given I click by text "Tools "

--- a/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
+++ b/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
@@ -66,7 +66,7 @@ Feature: Redirection
 
     Examples:
       | Sub-Section | url                                             | redirect_url                    |
-      | Portal      | https://portal.zksync.io/bridge/?network=goerli | https://goerli.portal.zksync.io |
+      | Bridge      | https://portal.zksync.io/bridge/?network=goerli | https://goerli.portal.zksync.io |
 
   @id253:III @testnet
   Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu (Sepolia)
@@ -77,7 +77,7 @@ Feature: Redirection
 
     Examples:
       | Sub-Section | url                                              | redirect_url                    |
-      | Portal      | https://portal.zksync.io/bridge/?network=sepolia | https://goerli.portal.zksync.io |
+      | Bridge      | https://portal.zksync.io/bridge/?network=sepolia | https://goerli.portal.zksync.io |
 
   @id253:IV @mainnet
   Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu
@@ -88,7 +88,7 @@ Feature: Redirection
 
     Examples:
       | Sub-Section | url                                              |
-      | Portal      | https://portal.zksync.io/bridge/?network=mainnet |
+      | Bridge      | https://portal.zksync.io/bridge/?network=mainnet |
 
   #Account page
   @id259 @testnet

--- a/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
+++ b/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
@@ -70,7 +70,7 @@ Feature: Redirection
 
   @id253:III @testnet
   Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu (Sepolia)
-    Given I go to page "/?network=sepolia"
+    #Given I go to page "/?network=sepolia"
     Given I click by text "Tools "
     When I click by element with partial href "<redirect_url>" and text "<Sub-Section>"
     Then New page have "<url>" address
@@ -81,7 +81,7 @@ Feature: Redirection
 
   @id253:IV @mainnet
   Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu
-    Given I go to page "/?network=mainnet"
+    #Given I go to page "/?network=mainnet"
     Given I click by text "Tools "
     When I click by element with partial href "<url>" and text "<Sub-Section>"
     Then New page have "<url>" address

--- a/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
+++ b/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
@@ -56,21 +56,8 @@ Feature: Redirection
       | Smart Contract Verification | /contracts/verify |
       # | zkEVM Debugger              | /tools/debugger   |
 
-
-  @id253:II @testnet
-  Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu (Goerli)
-    Given I go to page "/?network=goerli"
-    Given I click by text "Tools "
-    When I click by element with partial href "<redirect_url>" and text "<Sub-Section>"
-    Then New page have "<url>" address
-
-    Examples:
-      | Sub-Section | url                                             | redirect_url                    |
-      | Bridge      | https://portal.zksync.io/bridge/?network=goerli | https://goerli.portal.zksync.io |
-
-  @id253:III @testnet
+  @id253:III @featureEnv @testnetSmokeSuite
   Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu (Sepolia)
-    #Given I go to page "/?network=sepolia"
     Given I click by text "Tools "
     When I click by element with partial href "<redirect_url>" and text "<Sub-Section>"
     Then New page have "<url>" address

--- a/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
+++ b/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
@@ -64,11 +64,10 @@ Feature: Redirection
 
     Examples:
       | Sub-Section | url                                              | redirect_url                    |
-      | Bridge      | https://portal.zksync.io/bridge/?network=sepolia | https://goerli.portal.zksync.io |
+      | Bridge      | https://portal.zksync.io/bridge/?network=sepolia | https://portal.zksync.io/bridge/?network=sepolia |
 
-  @id253:IV @mainnet
+  @id253:IV @featureEnv @mainnet
   Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu
-    #Given I go to page "/?network=mainnet"
     Given I click by text "Tools "
     When I click by element with partial href "<url>" and text "<Sub-Section>"
     Then New page have "<url>" address

--- a/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
+++ b/packages/app/tests/e2e/features/redirection/redirectionSet1.feature
@@ -56,7 +56,7 @@ Feature: Redirection
       | Smart Contract Verification | /contracts/verify |
       # | zkEVM Debugger              | /tools/debugger   |
 
-  @id253:III @featureEnv @testnetSmokeSuite
+  @id253:III @featureEnv @testnetSmokeSuite @testnet
   Scenario Outline: Verify redirection for "<Sub-Section>" in Tools menu (Sepolia)
     Given I click by text "Tools "
     When I click by element with partial href "<redirect_url>" and text "<Sub-Section>"


### PR DESCRIPTION
# What ❔

In the scope of this PR several changes to automation tests were performed. Based on the [PR](https://github.com/matter-labs/block-explorer/pull/159). Where Portal links were removed and replaced with one solid approach - to display link to Bridge as unified platform that we currently use.

## Why ❔

To have automation tests coverage up-to-date with recent changes and not to block ci/cd run with incorrect behaviour for old link.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
