### PR TITLE
fix: preserve apiUrl path segment

### DIFF
--- a/packages/app/src/composables/useBatches.ts
+++ b/packages/app/src/composables/useBatches.ts
@@ -5,6 +5,6 @@ export type BatchListItem = Api.Response.BatchListItem;
 
 export default (context = useContext()) => {
   return useFetchCollection<Api.Response.BatchListItem>(
-    new URL(`/batches?toDate=${new Date().toISOString()}`, context.currentNetwork.value.apiUrl)
+    new URL(`${context.currentNetwork.value.apiUrl}/batches?toDate=${new Date().toISOString()}`)
   );
 };

--- a/packages/app/src/composables/useBlocks.ts
+++ b/packages/app/src/composables/useBlocks.ts
@@ -5,6 +5,6 @@ import type { BlockListItem } from "@/composables/useBlock";
 
 export default (context = useContext()) => {
   return useFetchCollection<BlockListItem>(
-    new URL(`/blocks?toDate=${new Date().toISOString()}`, context.currentNetwork.value.apiUrl)
+    new URL(`${context.currentNetwork.value.apiUrl}/blocks?toDate=${new Date().toISOString()}`)
   );
 };

--- a/packages/app/src/composables/useContractEvents.ts
+++ b/packages/app/src/composables/useContractEvents.ts
@@ -41,7 +41,7 @@ export default (context = useContext()) => {
     isRequestFailed.value = false;
 
     try {
-      const url = new URL(`/address/${params.contractAddress}/logs`, context.currentNetwork.value.apiUrl);
+      const url = new URL(`${context.currentNetwork.value.apiUrl}/address/${params.contractAddress}/logs`);
       if (params.toDate && +new Date(params.toDate) > 0) {
         url.searchParams.set("toDate", params.toDate.toISOString());
       }

--- a/packages/app/src/composables/useTransactions.ts
+++ b/packages/app/src/composables/useTransactions.ts
@@ -19,6 +19,6 @@ export default (searchParams: ComputedRef<TransactionSearchParams>, context = us
         .filter(([, value]) => !!value || value === 0)
         .map(([key, value]) => [key, value.toString()])
     );
-    return new URL(`/transactions?${new URLSearchParams(requestParams)}`, context.currentNetwork.value.apiUrl);
+    return new URL(`${context.currentNetwork.value.apiUrl}/transactions?${new URLSearchParams(requestParams)}`);
   });
 };

--- a/packages/app/src/composables/useTransfers.ts
+++ b/packages/app/src/composables/useTransfers.ts
@@ -13,8 +13,7 @@ export default (address: ComputedRef<string>, context = useContext()) => {
   return useFetchCollection<Transfer, Api.Response.Transfer>(
     () =>
       new URL(
-        `/address/${address.value}/transfers?toDate=${new Date().toISOString()}`,
-        context.currentNetwork.value.apiUrl
+        `${context.currentNetwork.value.apiUrl}/address/${address.value}/transfers?toDate=${new Date().toISOString()}`
       ),
     (transfer: Api.Response.Transfer): Transfer => ({
       ...transfer,


### PR DESCRIPTION
# What ❔
Replaced `URL(path, apiUrl)` with `URL(\`${apiUrl}/${path}\`)` to ensure the apiUrl's path segment is preserved during URL construction.

## Why ❔
The existing code did not properly handle cases where the apiUrl includes a path (e.g., "https://.../api"). The original method of using `URL(path, apiUrl)` incorrectly stripped away the path segment (e.g., `/api`) from the apiUrl, leading to incorrect URLs. This change also enhances the codebase's consistency, as this method of constructing URLs is used in most other places.