### PR TITLE
feat: add transfer type filter for address transfers BFF API

### DIFF
--- a/packages/api/src/address/address.controller.ts
+++ b/packages/api/src/address/address.controller.ts
@@ -17,7 +17,7 @@ import { AddressService } from "./address.service";
 import { BlockService } from "../block/block.service";
 import { TransactionService } from "../transaction/transaction.service";
 import { BalanceService } from "../balance/balance.service";
-import { AddressType, ContractDto, AccountDto, TokenAddressDto } from "./dtos";
+import { AddressType, ContractDto, AccountDto, TokenAddressDto, FilterAddressTransfersOptionsDto } from "./dtos";
 import { LogDto } from "../log/log.dto";
 import { LogService } from "../log/log.service";
 import { ParseAddressPipe, ADDRESS_REGEX_PATTERN } from "../common/pipes/parseAddress.pipe";
@@ -140,19 +140,26 @@ export class AddressController {
   })
   public async getAddressTransfers(
     @Param("address", new ParseAddressPipe()) address: string,
+    @Query() filterAddressTransferOptions: FilterAddressTransfersOptionsDto,
     @Query() listFilterOptions: ListFiltersDto,
     @Query() pagingOptions: PagingOptionsWithMaxItemsLimitDto
   ): Promise<Pagination<TransferDto>> {
-    const filterTransactionsListOptions = buildDateFilter(listFilterOptions.fromDate, listFilterOptions.toDate);
+    const filterTransfersListOptions = buildDateFilter(listFilterOptions.fromDate, listFilterOptions.toDate);
 
     return await this.transferService.findAll(
       {
         address,
-        isFeeOrRefund: false,
-        ...filterTransactionsListOptions,
+        ...filterTransfersListOptions,
+        ...(filterAddressTransferOptions.type
+          ? {
+              type: filterAddressTransferOptions.type,
+            }
+          : {
+              isFeeOrRefund: false,
+            }),
       },
       {
-        filterOptions: listFilterOptions,
+        filterOptions: { ...filterAddressTransferOptions, ...listFilterOptions },
         ...pagingOptions,
         route: `${entityName}/${address}/transfers`,
       }

--- a/packages/api/src/address/dtos/filterAddressTransfersOptions.dto.ts
+++ b/packages/api/src/address/dtos/filterAddressTransfersOptions.dto.ts
@@ -1,0 +1,13 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { IsOptional } from "class-validator";
+import { TransferType } from "../../transfer/transfer.entity";
+
+export class FilterAddressTransfersOptionsDto {
+  @ApiPropertyOptional({
+    description: "Transfer type to filter transfers by",
+    example: TransferType.Transfer,
+    enum: TransferType,
+  })
+  @IsOptional()
+  public readonly type?: TransferType;
+}

--- a/packages/api/src/address/dtos/index.ts
+++ b/packages/api/src/address/dtos/index.ts
@@ -1,3 +1,4 @@
 export * from "./account.dto";
 export * from "./baseAddress.dto";
 export * from "./contract.dto";
+export * from "./filterAddressTransfersOptions.dto";

--- a/packages/api/src/common/types.ts
+++ b/packages/api/src/common/types.ts
@@ -1,4 +1,5 @@
 import { IPaginationOptions as NestIPaginationOptions, IPaginationMeta } from "nestjs-typeorm-paginate";
+import { TransferType } from "../transfer/transfer.entity";
 
 interface IPaginationFilterOptions {
   fromDate?: string;
@@ -7,6 +8,7 @@ interface IPaginationFilterOptions {
   address?: string;
   l1BatchNumber?: number;
   minLiquidity?: number;
+  type?: TransferType;
 }
 
 export interface IPaginationOptions<CustomMetaType = IPaginationMeta> extends NestIPaginationOptions<CustomMetaType> {

--- a/packages/api/src/transfer/addressTransfer.entity.ts
+++ b/packages/api/src/transfer/addressTransfer.entity.ts
@@ -1,12 +1,13 @@
 import { Entity, Column, Index, ManyToOne, JoinColumn, PrimaryColumn } from "typeorm";
 import { BaseEntity } from "../common/entities/base.entity";
-import { Transfer } from "./transfer.entity";
+import { Transfer, TransferType } from "./transfer.entity";
 import { TokenType } from "../token/token.entity";
 import { bigIntNumberTransformer } from "../common/transformers/bigIntNumber.transformer";
 import { normalizeAddressTransformer } from "../common/transformers/normalizeAddress.transformer";
 
 @Entity({ name: "addressTransfers" })
 @Index(["address", "isFeeOrRefund", "timestamp", "logIndex"])
+@Index(["address", "type", "timestamp", "logIndex"])
 @Index(["address", "tokenType", "blockNumber", "logIndex"])
 @Index(["address", "tokenAddress", "blockNumber", "logIndex"])
 export class AddressTransfer extends BaseEntity {
@@ -33,6 +34,9 @@ export class AddressTransfer extends BaseEntity {
 
   @Column({ type: "timestamp" })
   public readonly timestamp: Date;
+
+  @Column({ type: "enum", enum: TransferType, default: TransferType.Transfer })
+  public readonly type: TransferType;
 
   @Column({ type: "enum", enum: TokenType, default: TokenType.ETH })
   public readonly tokenType: TokenType;

--- a/packages/api/src/transfer/transfer.service.ts
+++ b/packages/api/src/transfer/transfer.service.ts
@@ -4,7 +4,7 @@ import { Repository, FindOperator, MoreThanOrEqual, LessThanOrEqual } from "type
 import { Pagination } from "nestjs-typeorm-paginate";
 import { paginate } from "../common/utils";
 import { IPaginationOptions, SortingOrder } from "../common/types";
-import { Transfer } from "./transfer.entity";
+import { Transfer, TransferType } from "./transfer.entity";
 import { TokenType } from "../token/token.entity";
 import { AddressTransfer } from "./addressTransfer.entity";
 import { normalizeAddressTransformer } from "../common/transformers/normalizeAddress.transformer";
@@ -15,6 +15,7 @@ export interface FilterTransfersOptions {
   address?: string;
   timestamp?: FindOperator<Date>;
   isFeeOrRefund?: boolean;
+  type?: TransferType;
 }
 
 export interface FilterTokenTransfersOptions {

--- a/packages/worker/src/entities/addressTransfer.entity.ts
+++ b/packages/worker/src/entities/addressTransfer.entity.ts
@@ -1,7 +1,7 @@
 import { Entity, Column, ManyToOne, JoinColumn, Index, PrimaryColumn } from "typeorm";
 import { BaseEntity } from "./base.entity";
 import { Block } from "./block.entity";
-import { Transfer } from "./transfer.entity";
+import { Transfer, TransferType } from "./transfer.entity";
 import { TokenType } from "./token.entity";
 import { hexTransformer } from "../transformers/hex.transformer";
 import { bigIntNumberTransformer } from "../transformers/bigIntNumber.transformer";
@@ -9,6 +9,7 @@ import { TransferFields } from "../dataFetcher/types";
 
 @Entity({ name: "addressTransfers" })
 @Index(["address", "isFeeOrRefund", "timestamp", "logIndex"])
+@Index(["address", "type", "timestamp", "logIndex"])
 @Index(["address", "tokenAddress", "blockNumber", "logIndex"])
 @Index(["address", "tokenType", "blockNumber", "logIndex"])
 @Index(["address", "isInternal", "blockNumber", "logIndex"])
@@ -40,6 +41,9 @@ export class AddressTransfer extends BaseEntity {
 
   @Column({ type: "timestamp" })
   public readonly timestamp: string;
+
+  @Column({ type: "enum", enum: TransferType, default: TransferType.Transfer })
+  public readonly type: TransferType;
 
   @Column({ type: "enum", enum: TokenType, default: TokenType.ETH })
   public readonly tokenType: TokenType;

--- a/packages/worker/src/migrations/1709722093204-AddAddressTransferType.ts
+++ b/packages/worker/src/migrations/1709722093204-AddAddressTransferType.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddAddressTransferType1709722093204 implements MigrationInterface {
+  name = "AddAddressTransferType1709722093204";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."addressTransfers_type_enum" AS ENUM('deposit', 'transfer', 'withdrawal', 'fee', 'mint', 'refund')`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "addressTransfers" ADD "type" "public"."addressTransfers_type_enum" NOT NULL DEFAULT 'transfer'`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_aa5a147f1f6a4acde1a13de594" ON "addressTransfers" ("address", "type", "timestamp", "logIndex") `
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_aa5a147f1f6a4acde1a13de594"`);
+    await queryRunner.query(`ALTER TABLE "addressTransfers" DROP COLUMN "type"`);
+    await queryRunner.query(`DROP TYPE "public"."addressTransfers_type_enum"`);
+  }
+}


### PR DESCRIPTION
# What ❔

Add filter by transfer type to the address transfers endpoint

## Why ❔

It is useful to be able to get a list of transfers of certain type for address. For example get list of withdrawals.
