### PR TITLE
fix: update goerli deprecation message

### DIFF
--- a/packages/app/src/components/NetworkDeprecated.vue
+++ b/packages/app/src/components/NetworkDeprecated.vue
@@ -1,7 +1,8 @@
 <template v-if="newNetworkUrl">
   <SystemAlert>
     <span
-      >We are ending our support of Goerli testnet. Please <a :href="newNetworkUrl!">use Sepolia</a>. For more info see
+      >zkSync Era Goerli Testnet will be shutdown on March 31st. Please use
+      <a :href="newNetworkUrl!">zkSync Era Sepolia Testnet</a> instead. For more info see
       <a target="_blank" href="https://github.com/zkSync-Community-Hub/zksync-developers/discussions/228"
         >this announcement</a
       >.</span


### PR DESCRIPTION
# What ❔

New goerli deprecation message with a specific deprecation date:
<img width="1143" alt="image" src="https://github.com/matter-labs/block-explorer/assets/6553665/3bb8b99e-4998-40c4-8100-e4144fa8aa81">

## Why ❔

To notify users when the deprecation is gonna happen.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).