### PR TITLE
fix: improve fetcher usage

### DIFF
--- a/packages/api/src/logger.ts
+++ b/packages/api/src/logger.ts
@@ -5,9 +5,11 @@ import { format, transports, Logform } from "winston";
 export const getLogger = (environment: string, logLevel: string): LoggerService => {
   let defaultLogLevel = "debug";
   const loggerFormatters: Logform.Format[] = [
-    format.timestamp({
-      format: "DD/MM/YYYY HH:mm:ss.SSS",
-    }),
+    environment === "production"
+      ? format.timestamp()
+      : format.timestamp({
+          format: "DD/MM/YYYY HH:mm:ss.SSS",
+        }),
     format.ms(),
     utilities.format.nestLike("API", {}),
   ];

--- a/packages/data-fetcher/src/logger.ts
+++ b/packages/data-fetcher/src/logger.ts
@@ -5,9 +5,11 @@ const { NODE_ENV, LOG_LEVEL } = process.env;
 
 let defaultLogLevel = "debug";
 const loggerFormatters: Logform.Format[] = [
-  format.timestamp({
-    format: "DD/MM/YYYY HH:mm:ss.SSS",
-  }),
+  NODE_ENV === "production"
+    ? format.timestamp()
+    : format.timestamp({
+        format: "DD/MM/YYYY HH:mm:ss.SSS",
+      }),
   format.ms(),
   utilities.format.nestLike("DataFetcher", {}),
 ];

--- a/packages/worker/src/config.spec.ts
+++ b/packages/worker/src/config.spec.ts
@@ -23,7 +23,7 @@ describe("config", () => {
       },
       dataFetcher: {
         url: "http://localhost:3040",
-        requestTimeout: 120_000,
+        requestTimeout: 60_000,
       },
       blocks: {
         waitForBlocksInterval: 1000,

--- a/packages/worker/src/config.ts
+++ b/packages/worker/src/config.ts
@@ -41,7 +41,7 @@ export default () => {
     },
     dataFetcher: {
       url: DATA_FETCHER_URL || "http://localhost:3040",
-      requestTimeout: parseInt(DATA_FETCHER_REQUEST_TIMEOUT, 10) || 120_000,
+      requestTimeout: parseInt(DATA_FETCHER_REQUEST_TIMEOUT, 10) || 60_000,
     },
     blocks: {
       waitForBlocksInterval: parseInt(WAIT_FOR_BLOCKS_INTERVAL, 10) || 1000,

--- a/packages/worker/src/dataFetcher/dataFetcher.service.ts
+++ b/packages/worker/src/dataFetcher/dataFetcher.service.ts
@@ -4,6 +4,9 @@ import { ConfigService } from "@nestjs/config";
 import { catchError, firstValueFrom } from "rxjs";
 import { AxiosError } from "axios";
 import { BlockData } from "./types";
+import { setTimeout } from "node:timers/promises";
+
+const DATA_FETCHER_RETRY_TIMEOUT = 1000;
 
 @Injectable()
 export class DataFetcherService {
@@ -18,8 +21,20 @@ export class DataFetcherService {
   }
 
   public async getBlockData(blockNumber: number): Promise<BlockData> {
-    const blocksData = await this.getBlocksData(blockNumber, blockNumber);
+    const blocksData = await this.getBlocksDataRetryable(blockNumber, blockNumber);
     return blocksData[0];
+  }
+
+  private async getBlocksDataRetryable(from: number, to: number): Promise<BlockData[]> {
+    try {
+      return await this.getBlocksData(from, to);
+    } catch {
+      this.logger.debug({
+        message: `Retrying to fetch data for blocks: [${from}, ${to}]`,
+      });
+      await setTimeout(DATA_FETCHER_RETRY_TIMEOUT);
+      return this.getBlocksDataRetryable(from, to);
+    }
   }
 
   private async getBlocksData(from: number, to: number): Promise<BlockData[]> {

--- a/packages/worker/src/logger.ts
+++ b/packages/worker/src/logger.ts
@@ -5,9 +5,11 @@ const { NODE_ENV, LOG_LEVEL } = process.env;
 
 let defaultLogLevel = "debug";
 const loggerFormatters: Logform.Format[] = [
-  format.timestamp({
-    format: "DD/MM/YYYY HH:mm:ss.SSS",
-  }),
+  NODE_ENV === "production"
+    ? format.timestamp()
+    : format.timestamp({
+        format: "DD/MM/YYYY HH:mm:ss.SSS",
+      }),
   format.ms(),
   utilities.format.nestLike("Worker", {}),
 ];


### PR DESCRIPTION
# What ❔

1. Log timestamp in ISO8601 format.
2. Internal retries for `DataFetcherService`.

## Why ❔

1. To have timestamps properly processed so logs are in the correct order.
2. Otherwise in case of an error the whole batch is retried which is unnecessary.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.