### PR TITLE
feat: add multi-pagesize support

### DIFF
--- a/packages/app/src/components/balances/Table.vue
+++ b/packages/app/src/components/balances/Table.vue
@@ -1,6 +1,6 @@
 <template>
   <Table class="balances-table" :loading="loading || isTokenLibraryRequestPending" :items="displayedBalances">
-    <template v-if="validBalances.length" #table-head>
+    <template v-if="validBalances.length" #table-body-head>
       <table-head-column>{{ t("balances.table.asset") }}</table-head-column>
       <table-head-column>{{ t("balances.table.balance") }}</table-head-column>
       <table-head-column>{{ t("balances.table.address") }}</table-head-column>

--- a/packages/app/src/components/batches/Table.vue
+++ b/packages/app/src/components/batches/Table.vue
@@ -1,6 +1,9 @@
 <template>
   <Table class="batches-table" :class="{ loading }" :items="batches" :loading="loading">
     <template v-if="batches?.length || loading" #table-head>
+      <slot name="table-head"></slot>
+    </template>
+    <template v-if="batches?.length || loading" #table-body-head>
       <TableHeadColumn v-if="columns.includes('status')">{{ t("batches.table.status") }}</TableHeadColumn>
       <TableHeadColumn v-if="columns.includes('txnBatch')">{{ t("batches.table.txnBatch") }}</TableHeadColumn>
       <TableHeadColumn v-if="columns.includes('size')">{{ t("batches.table.size") }}</TableHeadColumn>
@@ -113,7 +116,7 @@ function getBadgeIconByStatus(status: BatchListItem["status"]) {
   }
 
   .table-body {
-    @apply rounded-t-lg;
+    // @apply rounded-t-lg;
 
     td {
       @apply relative flex flex-col items-end justify-end whitespace-normal text-right md:table-cell md:text-left;

--- a/packages/app/src/components/blocks/Table.vue
+++ b/packages/app/src/components/blocks/Table.vue
@@ -1,6 +1,9 @@
 <template>
   <Table class="blocks-table" :class="{ loading }" :items="blocks" :loading="loading">
-    <template v-if="blocks?.length || loading" #table-head>
+    <template v-if="$slots['table-head']" #table-head>
+      <slot name="table-head"></slot>
+    </template>
+    <template v-if="blocks?.length || loading" #table-body-head>
       <TableHeadColumn>{{ t("blocks.table.block") }}</TableHeadColumn>
       <TableHeadColumn>{{ t("blocks.table.status") }}</TableHeadColumn>
       <TableHeadColumn>{{ t("blocks.table.age") }}</TableHeadColumn>
@@ -129,7 +132,7 @@ defineProps({
     @apply text-xs font-bold capitalize text-gray-700;
   }
   .table-body {
-    @apply rounded-t-lg;
+    // @apply rounded-t-lg;
 
     td {
       @apply relative flex flex-col items-end justify-end whitespace-normal text-right md:table-cell md:text-left;

--- a/packages/app/src/components/common/Pagination.vue
+++ b/packages/app/src/components/common/Pagination.vue
@@ -1,42 +1,69 @@
 <template>
-  <nav class="pagination-container" :class="{ disabled }" aria-label="Pagination">
-    <PaginationButton
-      :use-route="useQuery"
-      :to="{ query: backButtonQuery, hash: currentHash }"
-      class="pagination-page-button arrow left"
-      :aria-disabled="isFirstPage"
-      :class="{ disabled: isFirstPage }"
-      @click="currentPage = Math.max(currentPage - 1, 1)"
-    >
-      <span class="sr-only">Previous</span>
-      <ChevronLeftIcon class="chevron-icon" aria-hidden="true" />
-    </PaginationButton>
-    <template v-for="(item, index) in pagesData" :key="index">
+  <nav class="pagination-container" :class="{ disabled, header: header, footer: !header }" aria-label="Pagination">
+    <div class="pagination-dropdown-container">
+      <div class="pagination-text" v-if="header">Showing {{ pageSize }} of {{ totalItems }} Records</div>
+      <div class="pagination-text" v-if="!header">Show:</div>
+      <Menu class="dropdown-container" as="div" v-if="!header" v-slot="{ open }">
+        <MenuButton>
+          <div class="navigation-link" :class="{ active: open }">
+            {{ currentPageSize }}
+            <ChevronDownIcon class="dropdown-icon" aria-hidden="true" />
+          </div>
+        </MenuButton>
+        <MenuItems class="dropdown-items">
+          <MenuItem
+            v-for="page in pageSizes"
+            :key="page.label"
+            :use-route="useQuery"
+            :to="{ pageSizeButtonQuery }"
+            class="dropdown-item"
+            @click="currentPageSize = page.value"
+          >
+            <div>{{ page.label }}</div>
+          </MenuItem>
+        </MenuItems>
+      </Menu>
+      <div class="pagination-text" v-if="!header">Records</div>
+    </div>
+    <div class="pagination-number-container !ml-auto">
       <PaginationButton
-        v-if="item.type === 'page'"
         :use-route="useQuery"
-        :to="{ query: item.number > 1 ? { page: item.number } : {}, hash: currentHash }"
-        :aria-current="activePage === item.number ? 'page' : 'false'"
-        :class="[{ active: activePage === item.number }, item.hiddenOnMobile ? 'hidden sm:flex' : 'flex']"
-        class="pagination-page-button page"
-        @click="currentPage = item.number"
+        :to="{ query: backButtonQuery, hash: currentHash }"
+        class="pagination-page-button arrow left"
+        :aria-disabled="isFirstPage"
+        :class="{ disabled: isFirstPage }"
+        @click="currentPage = Math.max(currentPage - 1, 1)"
       >
-        {{ item.number }}
+        <span class="sr-only">Previous</span>
+        <ChevronLeftIcon class="chevron-icon" aria-hidden="true" />
       </PaginationButton>
-      <span v-else class="pagination-page-button dots">...</span>
-    </template>
+      <template v-for="(item, index) in pagesData" :key="index">
+        <PaginationButton
+          v-if="item.type === 'page'"
+          :use-route="useQuery"
+          :to="{ query: item.number > 1 ? { page: item.number } : {}, hash: currentHash }"
+          :aria-current="activePage === item.number ? 'page' : 'false'"
+          :class="[{ active: activePage === item.number }, item.hiddenOnMobile ? 'hidden sm:flex' : 'flex']"
+          class="pagination-page-button page"
+          @click="currentPage = item.number"
+        >
+          {{ item.number }}
+        </PaginationButton>
+        <span v-else class="pagination-page-button dots">...</span>
+      </template>
 
-    <PaginationButton
-      :use-route="useQuery"
-      :to="{ query: nextButtonQuery, hash: currentHash }"
-      class="pagination-page-button arrow right"
-      :aria-disabled="isLastPage"
-      :class="{ disabled: isLastPage }"
-      @click="currentPage = Math.min(currentPage + 1, pageCount)"
-    >
-      <span class="sr-only">Next</span>
-      <ChevronRightIcon class="chevron-icon" aria-hidden="true" />
-    </PaginationButton>
+      <PaginationButton
+        :use-route="useQuery"
+        :to="{ query: nextButtonQuery, hash: currentHash }"
+        class="pagination-page-button arrow right"
+        :aria-disabled="isLastPage"
+        :class="{ disabled: isLastPage }"
+        @click="currentPage = Math.min(currentPage + 1, pageCount)"
+      >
+        <span class="sr-only">Next</span>
+        <ChevronRightIcon class="chevron-icon" aria-hidden="true" />
+      </PaginationButton>
+    </div>
   </nav>
 </template>
 
@@ -44,10 +71,13 @@
 import { computed, type UnwrapNestedRefs } from "vue";
 import { useRoute } from "vue-router";
 
-import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/vue/outline";
+import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";
+import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon } from "@heroicons/vue/outline";
 import { useOffsetPagination, type UseOffsetPaginationReturn } from "@vueuse/core";
 
 import PaginationButton from "@/components/common/PaginationButton.vue";
+
+import { DEFAULT_PAGE_SIZE } from "@/utils/constants";
 
 const route = useRoute();
 
@@ -64,7 +94,7 @@ const props = defineProps({
   },
   pageSize: {
     type: Number,
-    default: 10,
+    default: DEFAULT_PAGE_SIZE,
   },
   useQuery: {
     type: Boolean,
@@ -74,14 +104,27 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  header: {
+    type: Boolean,
+    default: false,
+  },
 });
+
+const pageSizes = [
+  { label: "10", value: 10 },
+  { label: "20", value: 20 },
+  { label: "50", value: 50 },
+  { label: "100", value: 100 },
+];
 
 const emit = defineEmits<{
   (eventName: "update:activePage", value: number): void;
+  (eventName: "update:pageSize", value: number): void;
   (eventName: "onPageChange", value: UnwrapNestedRefs<UseOffsetPaginationReturn>): void;
+  (eventName: "onPageSizeChange", value: UnwrapNestedRefs<UseOffsetPaginationReturn>): void;
 }>();
 
-const { currentPage, pageCount, isFirstPage, isLastPage } = useOffsetPagination({
+const { currentPage, currentPageSize, pageCount, isFirstPage, isLastPage } = useOffsetPagination({
   total: computed(() => props.totalItems),
   page: computed({
     get: () => props.activePage,
@@ -89,9 +132,10 @@ const { currentPage, pageCount, isFirstPage, isLastPage } = useOffsetPagination(
   }),
   pageSize: computed({
     get: () => props.pageSize,
-    set: () => undefined,
+    set: (val) => emit("update:pageSize", val),
   }),
   onPageChange: (data) => emit("onPageChange", data),
+  onPageSizeChange: (data) => emit("onPageSizeChange", data),
 });
 
 const pagesData = computed(() => {
@@ -123,36 +167,85 @@ const pagesData = computed(() => {
   return [...first, ...middle, ...last];
 });
 
-const backButtonQuery = computed(() => (currentPage.value > 2 ? { page: currentPage.value - 1 } : {}));
+const backButtonQuery = computed(() => {
+  return currentPage.value > 2 ? { page: currentPage.value - 1 } : {};
+});
 const nextButtonQuery = computed(() => ({ page: Math.min(currentPage.value + 1, pageCount.value) }));
+
+const pageSizeButtonQuery = computed(() => {
+  return { pageSize: currentPageSize.value };
+});
 </script>
 
 <style lang="scss">
 .pagination-container {
-  @apply flex space-x-1 transition-opacity;
+  @apply flex space-x-1 w-full transition-opacity justify-between bg-white p-0;
   &.disabled {
     @apply pointer-events-none opacity-50;
   }
+  &.header {
+    @apply rounded-t-lg opacity-100;
+  }
+  &.footer {
+    @apply rounded-b-lg;
+  }
 
-  .pagination-page-button {
-    @apply rounded-md bg-white px-1.5 py-1 font-mono text-sm font-medium text-neutral-700 no-underline sm:px-2;
-    &:not(.disabled):not(.active):not(.dots) {
-      @apply hover:bg-neutral-50;
-    }
-    &.disabled {
-      @apply cursor-not-allowed text-neutral-400;
-    }
-    &.active {
-      @apply z-10 bg-neutral-100;
-    }
-    &.dots {
-      @apply font-sans text-neutral-400 hover:bg-white;
-    }
-    &.arrow {
-      @apply flex items-center;
+  .pagination-dropdown-container {
+    @apply flex space-x-4;
 
-      .chevron-icon {
-        @apply h-4 w-4;
+    .pagination-text {
+      @apply flex items-center text-sm font-medium text-neutral-700;
+    }
+    .dropdown-container {
+      @apply relative rounded-md bg-slate-100 px-1.5 py-1 font-mono text-sm font-medium text-neutral-700 no-underline sm:px-2;
+
+      .navigation-link {
+        @apply flex items-center;
+        &.active {
+          // @apply bg-primary-800;
+
+          .dropdown-icon {
+            @apply -rotate-180;
+          }
+        }
+
+        .dropdown-icon {
+          @apply -mr-1 ml-2 h-4 w-4;
+        }
+      }
+      .dropdown-items {
+        @apply absolute left-0 mt-1 grid w-20 z-10 origin-top-left grid-flow-row gap-4 rounded-md bg-white p-4 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none;
+
+        .dropdown-item {
+          @apply block rounded-md p-2 text-sm text-black no-underline cursor-pointer;
+        }
+      }
+    }
+  }
+
+  .pagination-number-container {
+    @apply flex space-x-1;
+
+    .pagination-page-button {
+      @apply rounded-md bg-white px-1.5 py-1 font-mono text-sm font-medium text-neutral-700 no-underline sm:px-2;
+      &:not(.disabled):not(.active):not(.dots) {
+        @apply hover:bg-neutral-50;
+      }
+      &.disabled {
+        @apply cursor-not-allowed text-neutral-400;
+      }
+      &.active {
+        @apply z-10 bg-neutral-100;
+      }
+      &.dots {
+        @apply font-sans text-neutral-400 hover:bg-white;
+      }
+      &.arrow {
+        @apply flex items-center;
+
+        .chevron-icon {
+          @apply h-4 w-4;
+        }
       }
     }
   }

--- a/packages/app/src/components/common/table/Table.vue
+++ b/packages/app/src/components/common/table/Table.vue
@@ -1,10 +1,20 @@
 <template>
-  <div class="table-container" :class="[{ 'has-head': !!$slots['table-head'] }, { 'has-footer': !!$slots['footer'] }]">
+  <div
+    class="table-container"
+    :class="[
+      { 'has-head': !!$slots['table-head'] },
+      { 'has-body-head': !!$slots['table-body-head'] },
+      { 'has-footer': !!$slots['footer'] },
+    ]"
+  >
+    <div v-if="$slots['table-head']" class="table-head" :class="[items?.length! % 2 ? 'bg-neutral-50' : 'bg-white']">
+      <slot name="table-head"></slot>
+    </div>
     <div class="table-body">
       <table cellspacing="0" cellpadding="0">
-        <thead v-if="$slots['table-head']">
+        <thead v-if="$slots['table-body-head']">
           <tr>
-            <slot name="table-head"></slot>
+            <slot name="table-body-head"></slot>
           </tr>
         </thead>
         <tbody v-if="!loading">
@@ -64,11 +74,19 @@ defineProps({
     }
   }
   &.has-head {
-    table thead tr th {
-      @apply first:rounded-tl-lg last:rounded-tr-lg;
+    .table-head {
+      @apply rounded-t-lg;
     }
   }
-  &:not(.has-head) {
+  &.has-body-head:not(.has-head) {
+    // table thead tr th {
+    //   @apply first:rounded-tl-lg last:rounded-tr-lg;
+    // }
+    .table-body {
+      @apply rounded-t-lg;
+    }
+  }
+  &:not(.has-head):not(.has-body-head) {
     table tbody tr:first-child td {
       @apply first:rounded-tl-lg last:rounded-tr-lg;
     }

--- a/packages/app/src/components/event/ContractEvents.vue
+++ b/packages/app/src/components/event/ContractEvents.vue
@@ -5,7 +5,18 @@
     :loading="isRequestPending"
     :class="{ empty: !collection?.length }"
   >
-    <template v-if="total > 0 && collection?.length" #table-head>
+    <template v-if="total > DEFAULT_PAGE_SIZE && collection?.length" #table-head>
+      <div class="pagination">
+        <Pagination
+          v-model:active-page="activePage"
+          v-model:page-size="pageSize"
+          :use-query="false"
+          :total-items="total"
+          :disabled="isRequestPending"
+        />
+      </div>
+    </template>
+    <template v-if="total > 0 && collection?.length" #table-body-head>
       <TableHeadColumn v-for="item in tableHead" :key="item">{{ item }}</TableHeadColumn>
     </template>
 
@@ -84,6 +95,8 @@ import useContractEvents from "@/composables/useContractEvents";
 
 import type { Contract } from "@/composables/useAddress";
 
+import { DEFAULT_PAGE_SIZE } from "@/utils/constants";
+
 const { t } = useI18n();
 
 const props = defineProps({
@@ -106,13 +119,13 @@ const tableHead = computed(() => [
 const activePage = ref(1);
 const toDate = new Date();
 watch(
-  [activePage, () => props.contract.address],
-  ([page]) => {
+  [activePage, pageSize, () => props.contract.address],
+  ([page, size]) => {
     getCollection(
       {
         contractAddress: props.contract.address,
         page: page,
-        pageSize: pageSize.value,
+        pageSize: size,
         toDate: toDate,
       },
       props.contract.verificationInfo?.artifacts.abi

--- a/packages/app/src/components/token/TokenListTable.vue
+++ b/packages/app/src/components/token/TokenListTable.vue
@@ -1,6 +1,6 @@
 <template>
   <Table :data-testid="$testId.tokensTable" :loading="loading" :items="tokens" ref="table">
-    <template #table-head>
+    <template #table-body-head>
       <table-head-column>{{ t("tokensView.table.tokenName") }}</table-head-column>
       <table-head-column>{{ t("tokensView.table.price") }}</table-head-column>
       <table-head-column>{{ t("tokensView.table.tokenAddress") }}</table-head-column>

--- a/packages/app/src/components/transactions/infoTable/Logs.vue
+++ b/packages/app/src/components/transactions/infoTable/Logs.vue
@@ -76,6 +76,7 @@
           :active-page="activePage"
           :total-items="logs?.length"
           :page-size="pageSize"
+          :header="false"
           @on-page-change="scrollPageToTop"
         />
       </div>

--- a/packages/app/src/utils/constants.ts
+++ b/packages/app/src/utils/constants.ts
@@ -2,6 +2,8 @@ import { checksumAddress } from "./formatters";
 
 export const ETH_TOKEN_L2_ADDRESS = checksumAddress("0x000000000000000000000000000000000000800A");
 
+export const DEFAULT_PAGE_SIZE = 10;
+
 export const PROXY_CONTRACT_IMPLEMENTATION_ABI = [
   {
     inputs: [],

--- a/packages/app/src/views/HomeView.vue
+++ b/packages/app/src/views/HomeView.vue
@@ -66,6 +66,8 @@ import TransactionsTable from "@/components/transactions/Table.vue";
 import useBatches from "@/composables/useBatches";
 import useNetworkStats from "@/composables/useNetworkStats";
 
+import { DEFAULT_PAGE_SIZE } from "@/utils/constants";
+
 const { t } = useI18n();
 const { fetch: fetchNetworkStats, pending: networkStatsPending, item: networkStats } = useNetworkStats();
 const { load: getBatches, pending: isBatchesPending, failed: isBatchesFailed, data: batches } = useBatches();
@@ -76,7 +78,7 @@ const displayedBatches = computed(() => {
 
 fetchNetworkStats();
 
-getBatches(1, new Date());
+getBatches(1, DEFAULT_PAGE_SIZE, new Date());
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## Background
- #215 

### Changes
- `DEFAULT_PAGE_SIZE`: 10 is defined across all table views (except `Logs` & `ContractEvents` using 25)
- `load()` => `useFetchCollection.ts` passes the additional `pageSize` param (optional) 
  - `searchParams` set to `limit` instead of `pageSize`, due to the redundant `pageSize` param in `api` endpoints
- Support PageSize selection on Table Footer
  - Configurable with `<Pagination>` component `header` set to `false`
  - `watch()` monitors additional `pageSize` & refetch data upon any `pageSize` changes
- Support Pagination on Table Header
  - Configurable with `<Pagination>` component `header` set to `true`
  - Display total record figures & pagination for better UX
  - Slot `#table-head` is used. Original slot for Table Head Columns is now using `#table-body-head` instead



#### 📝 Description
Existing table view data are all having pagination of page size 10.
- [Blocks page](https://explorer.zksync.io/blocks/)
- [Block Detail page](https://explorer.zksync.io/block/29803480)
- [Batches page](https://explorer.zksync.io/batches/)
- [Batch Detail page](https://explorer.zksync.io/batch/467190)
- [Transactions page](https://explorer.zksync.io/transactions/)
- [Transaction Detail page](https://explorer.zksync.io/tx/0x2830764dcd8a7f9de11624d1b0d95f9b5e8ae12768bd9206efafc411a0e472f4)
- [Address Detail page](https://explorer.zksync.io/address/0x38eeC803Ca7f66FbB446F5E3E980595e6F640aeA#transactions) => `Transaction` & `Transfers` Tab

Suggested additional page size: 
- 10
- 20
- 50
- 100

#### 🤔 Rationale
A pagination of selectable page size is practical & common to be supported.
e.g. https://etherscan.io/txs?a=0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5

