### PR TITLE
test: remove extra symbols to avoid 404 pages redirection

### DIFF
--- a/packages/testing-docs/docs/BE Tests/ Common /Header /id231 - Header - Common - External links SN icons.md
+++ b/packages/testing-docs/docs/BE Tests/ Common /Header /id231 - Header - Common - External links SN icons.md
@@ -2,7 +2,7 @@
 tags: ['automated', 'ExternalLinks', 'Full test', 'Header', 'Redirection', 'Automated']
 ---
 
-# id231 Header - Common - External links (SN icons)
+# id231 Header - Common - External links - SN icons
 
 ## Description
 

--- a/packages/testing-docs/docs/BE Tests/ Common /Header /id705 - Header - Common - Artifacts Network Drop Down.md
+++ b/packages/testing-docs/docs/BE Tests/ Common /Header /id705 - Header - Common - Artifacts Network Drop Down.md
@@ -2,7 +2,7 @@
 tags: ['Artifacts', 'DropDown', 'Full test', 'Header', 'manual', 'regression', 'ZKF-3179', 'Active']
 ---
 
-# id705 Header - Common - Artifacts (Network Drop Down)
+# id705 Header - Common - Artifacts - Network Drop Down
 
 ## Description
   - https://explorer.zksync.io/

--- a/packages/testing-docs/docs/BE Tests/ Common /Networks navigation - Production/id565 - Networks navigation Prod - Common - Navigation to Sepolia.md
+++ b/packages/testing-docs/docs/BE Tests/ Common /Networks navigation - Production/id565 - Networks navigation Prod - Common - Navigation to Sepolia.md
@@ -2,7 +2,7 @@
 tags: ['Full test', 'manual', 'Navigation', 'Network', 'regression', 'To Automate', 'ZKF-2507', 'Active']
 ---
 
-# id565 Networks navigation (Prod) - Common - Navigation to Sepolia
+# id565 Networks navigation Production - Common - Navigation to Sepolia
 
 ## Description
   - Preconditions: user opens any production BE page (https://explorer.zksync.io/) with zkSync Era Mainnet network selected

--- a/packages/testing-docs/docs/BE Tests/ Common /Networks navigation - Production/id566 - Networks navigation Prod - Common - Navigation to Mainnet.md
+++ b/packages/testing-docs/docs/BE Tests/ Common /Networks navigation - Production/id566 - Networks navigation Prod - Common - Navigation to Mainnet.md
@@ -2,7 +2,7 @@
 tags: ['Full test', 'manual', 'Navigation', 'Network', 'regression', 'To Automate', 'ZKF-2507', 'Active']
 ---
 
-# id566 Networks navigation (Prod) - Common - Navigation to Mainnet
+# id566 Networks navigation Production - Common - Navigation to Mainnet
 
 ## Description
   - Preconditions: user opens any production BE page (https://explorer.zksync.io/) with zkSync Era Sepolia network selected

--- a/packages/testing-docs/docs/BE Tests/ Common /Networks navigation - Staging/id561 - Networks navigation Staging - Common - Navigation to Goerli Stage2.md
+++ b/packages/testing-docs/docs/BE Tests/ Common /Networks navigation - Staging/id561 - Networks navigation Staging - Common - Navigation to Goerli Stage2.md
@@ -2,7 +2,7 @@
 tags: ['Full test', 'manual', 'Navigation', 'Network', 'Smoke test', 'ZKF-2507', 'Automated']
 ---
 
-# id561 Networks navigation (Staging) - Common - Navigation to Goerli (Stage2)
+# id561 Networks navigation Staging - Common - Navigation to Goerli - Stage 2
 
 ## Description
   - Preconditions: user opens any BE page with zkSync Era Mainnet or local network selected

--- a/packages/testing-docs/docs/BE Tests/ Common /Networks navigation - Staging/id562 - Networks navigation Staging - Common - Navigation to zkSync Era Testnet.md
+++ b/packages/testing-docs/docs/BE Tests/ Common /Networks navigation - Staging/id562 - Networks navigation Staging - Common - Navigation to zkSync Era Testnet.md
@@ -2,7 +2,7 @@
 tags: ['Full test', 'manual', 'Navigation', 'Network', 'Smoke test', 'ZKF-2507', 'Automated']
 ---
 
-# id562 Networks navigation (Staging) - Common - Navigation to zkSync Era Testnet
+# id562 Networks navigation Staging - Common - Navigation to zkSync Era Testnet
 
 ## Description
   - Preconditions: user opens any BE page with zkSync Era Mainnet or Goerli (Stage2) network selected

--- a/packages/testing-docs/docs/BE Tests/ Common /Networks navigation - Staging/id563 - Networks navigation Staging - Common - Navigation to Mainnet.md
+++ b/packages/testing-docs/docs/BE Tests/ Common /Networks navigation - Staging/id563 - Networks navigation Staging - Common - Navigation to Mainnet.md
@@ -2,7 +2,7 @@
 tags: ['Full test', 'manual', 'Navigation', 'Network', 'Smoke test', 'ZKF-2507', 'Automated']
 ---
 
-# id563 Networks navigation (Staging) - Common - Navigation to Mainnet
+# id563 Networks navigation Staging - Common - Navigation to Mainnet
 
 ## Description
   - Preconditions: user opens any BE page with zkSync Era Testnet or Goerli (Stage2) network selected


### PR DESCRIPTION
# What ❔

Removing extra symbols that prevents page from loading.
After the test cases were imported from Allure project - some of the pages didn't load because of the different symbols.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
