### PR TITLE
refactor: take API URL from env var

### DIFF
--- a/scripts/setup-hyperchain-config.ts
+++ b/scripts/setup-hyperchain-config.ts
@@ -6,7 +6,7 @@ import { parse as parseConnectionString } from "pg-connection-string";
 
 const buildAppConfig = (zkSyncEnvs: { [key: string]: string }) => ({
   networks: [{
-    apiUrl: "http://localhost:3020",
+    apiUrl: process.env.API_URL || "http://localhost:3020",
     verificationApiUrl: zkSyncEnvs.API_CONTRACT_VERIFICATION_URL || "",
     hostnames: ["localhost"],
     icon: "/images/icons/zksync-arrows.svg",


### PR DESCRIPTION
# What ❔

Take the API URL from env var when running `npm run hyperchain:configure`
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Currently, if you run `npm run hyperchain:configure`, a `hyperchain.config.json` file is created with `apiUrl` field hardcoded to `localhost:3020`. This force you to change the autogenerated file by hand with your own domain or IP address
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
