### PR TITLE
fix: contract path placeholder

### DIFF
--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -437,8 +437,8 @@
             "contractPath": {
                 "label": "Contract Path",
                 "underline": "Relative path to your contract at the moment of compilation",
-                "solcPlaceholder": "/contracts/ContractFile.sol",
-                "vyperPlaceholder": "/contracts/ContractFile.vy",
+                "solcPlaceholder": "contracts/ContractFile.sol",
+                "vyperPlaceholder": "contracts/ContractFile.vy",
                 "validation": {
                     "required": "Contract path is required"
                 }

--- a/packages/app/src/locales/uk.json
+++ b/packages/app/src/locales/uk.json
@@ -239,6 +239,15 @@
                     "required": "Імʼя контракту є обовʼязковим"
                 }
             },
+            "contractPath": {
+                "label": "Шлях до контракту",
+                "underline": "Відносний шлях до вашого контракту на момент компіляції",
+                "solcPlaceholder": "contracts/ContractFile.sol",
+                "vyperPlaceholder": "contracts/ContractFile.vy",
+                "validation": {
+                    "required": "Шлях до контракту є обов'язковим"
+                }
+            },
             "optimizationUsed": {
                 "label": "Оптимізація",
                 "options": {
@@ -364,7 +373,7 @@
         "second": "сек.",
         "secondPlural": "сек."
     },
-    "addressView" : {
+    "addressView": {
         "title": "Адреса"
     },
     "accountView": {
@@ -421,7 +430,7 @@
         "orDropHere": "або перенесіть сюди",
         "unableToParseTrace": "На жаль, не вдалося проаналізувати цей файл трасування",
         "transaction": "Транзакція: з файлу трасування",
-        "executionStepNavigation":"Стрілка Вліво/Вправо",
+        "executionStepNavigation": "Стрілка Вліво/Вправо",
         "searchPlaceholder": "Пошук",
         "metadataBlock": {
             "contract": "Контракт",


### PR DESCRIPTION
# What ❔

Removes initial "/" from "Contract Path" placeholder.

## Why ❔

Contract verification fails if path "/contracts/Greeter.sol" is provided instead of "contracts/Greeter.sol"

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
