### PR TITLE
fix: default hyperchain base address

### DIFF
--- a/scripts/setup-hyperchain-config.ts
+++ b/scripts/setup-hyperchain-config.ts
@@ -18,7 +18,7 @@ const buildAppConfig = (zkSyncEnvs: { [key: string]: string }) => ({
     name: zkSyncEnvs.CHAIN_ETH_ZKSYNC_NETWORK || "",
     published: true,
     rpcUrl: zkSyncEnvs.API_WEB3_JSON_RPC_HTTP_URL || "",
-    baseTokenAddress: zkSyncEnvs.ETH_TOKEN_L2_ADDRESS || "0x000000000000000000000000000000000000800A",
+    baseTokenAddress: "0x000000000000000000000000000000000000800A",
   }]
 });
 


### PR DESCRIPTION
# What ❔
Fixing default base token address value in hyperchain setup script.

## Why ❔
Base token address on L2 is always "800A". This script might not work for hyperchains with custom L1 base token.

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
