### PR TITLE
fix for default max gas on payable functions

### DIFF
--- a/packages/app/src/composables/useContractInteraction.ts
+++ b/packages/app/src/composables/useContractInteraction.ts
@@ -55,7 +55,6 @@ export default (context = useContext()) => {
         });
       const methodOptions = {
         value: ethers.utils.parseEther((params.value as string) ?? "0")
-        //gasLimit: "10000000",
       };
       const res = await method(
         ...[

--- a/packages/app/src/composables/useContractInteraction.ts
+++ b/packages/app/src/composables/useContractInteraction.ts
@@ -54,8 +54,8 @@ export default (context = useContext()) => {
           return inputValue;
         });
       const methodOptions = {
-        value: ethers.utils.parseEther((params.value as string) ?? "0"),
-        gasLimit: "10000000",
+        value: ethers.utils.parseEther((params.value as string) ?? "0")
+        //gasLimit: "10000000",
       };
       const res = await method(
         ...[


### PR DESCRIPTION
# What ❔

Removed the gasLimit override for payable functions.

## Why ❔

The explorer sets the gas limit to 10000000 by default for payable functions, preventing connected wallets like MetaMask from setting their own correct gas estimates.
