### PR TITLE
fix: get db url from DATABASE_URL env var in worker

### DIFF
--- a/packages/worker/src/typeorm.config.ts
+++ b/packages/worker/src/typeorm.config.ts
@@ -3,13 +3,19 @@ import { config } from "dotenv";
 
 config();
 
+let dbUrl = process.env.DATABASE_URL;
+if (!dbUrl) {
+  const host = process.env.DATABASE_HOST || "localhost";
+  const port = parseInt(process.env.DATABASE_PORT) || 5432;
+  const username = process.env.DATABASE_USER || "postgres";
+  const password = process.env.DATABASE_PASSWORD || "postgres";
+  const database = process.env.DATABASE_NAME || "block-explorer";
+  dbUrl = `postgres://${username}:${password}@${host}:${port}/${database}`;
+}
+
 export const typeOrmModuleOptions: DataSourceOptions = {
   type: "postgres",
-  host: process.env.DATABASE_HOST || "localhost",
-  port: parseInt(process.env.DATABASE_PORT) || 5432,
-  username: process.env.DATABASE_USER || "postgres",
-  password: process.env.DATABASE_PASSWORD || "postgres",
-  database: process.env.DATABASE_NAME || "block-explorer",
+  url: dbUrl,
   poolSize: parseInt(process.env.DATABASE_CONNECTION_POOL_SIZE, 10) || 100,
   extra: {
     idleTimeoutMillis: parseInt(process.env.DATABASE_CONNECTION_IDLE_TIMEOUT_MS, 10) || 12000,


### PR DESCRIPTION
# What ❔

Get DB URL from DATABASE_URL env var in the Worker service.

## Why ❔

To make it consistent with the API service and simplify infrastructure automation.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).