### PR TITLE
fix: json rpc provider timeout config

### DIFF
--- a/packages/data-fetcher/src/rpcProvider/jsonRpcProviderExtended.ts
+++ b/packages/data-fetcher/src/rpcProvider/jsonRpcProviderExtended.ts
@@ -1,4 +1,5 @@
 import { Provider } from "zksync-ethers";
+import { FetchRequest } from "ethers";
 import { ProviderState, JsonRpcProviderBase } from "./jsonRpcProviderBase";
 import logger from "../logger";
 
@@ -18,13 +19,17 @@ export class JsonRpcProviderExtended extends Provider implements JsonRpcProvider
     batchMaxSizeBytes: number,
     batchStallTimeMs: number
   ) {
-    super(providerUrl, undefined, {
+    const fetchRequest = new FetchRequest(providerUrl);
+    fetchRequest.timeout = connectionTimeout;
+
+    super(fetchRequest, undefined, {
       timeout: connectionTimeout,
       batchMaxSize: batchMaxSizeBytes,
       batchMaxCount: batchMaxCount,
       staticNetwork: true,
       batchStallTime: batchStallTimeMs,
     });
+
     this.connectionQuickTimeout = connectionQuickTimeout;
   }
 

--- a/packages/worker/src/rpcProvider/jsonRpcProviderExtended.ts
+++ b/packages/worker/src/rpcProvider/jsonRpcProviderExtended.ts
@@ -1,4 +1,5 @@
 import { Provider } from "zksync-ethers";
+import { FetchRequest } from "ethers";
 import { ProviderState, JsonRpcProviderBase } from "./jsonRpcProviderBase";
 import logger from "../logger";
 
@@ -18,13 +19,17 @@ export class JsonRpcProviderExtended extends Provider implements JsonRpcProvider
     batchMaxSizeBytes: number,
     batchStallTimeMs: number
   ) {
-    super(providerUrl, undefined, {
+    const fetchRequest = new FetchRequest(providerUrl);
+    fetchRequest.timeout = connectionTimeout;
+
+    super(fetchRequest, undefined, {
       timeout: connectionTimeout,
       batchMaxSize: batchMaxSizeBytes,
       batchMaxCount: batchMaxCount,
       staticNetwork: true,
       batchStallTime: batchStallTimeMs,
     });
+
     this.connectionQuickTimeout = connectionQuickTimeout;
   }
 


### PR DESCRIPTION
# What ❔

Fix JSON RPC Provider timeout configuration.

## Why ❔

This was overlooked when the explorer was migrated from an old SDK with ethers v5 to a new SDK with ethers v6.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.