### PR TITLE
fix: retryable contract retry functionality

### DIFF
--- a/packages/data-fetcher/src/blockchain/retryableContract.spec.ts
+++ b/packages/data-fetcher/src/blockchain/retryableContract.spec.ts
@@ -100,13 +100,8 @@ describe("RetryableContract", () => {
 
     describe("when throws a permanent call exception function error", () => {
       const callExceptionError = {
-        code: "CALL_EXCEPTION",
-        method: "contractFn(address)",
-        transaction: {
-          data: "0x00",
-          to: "to",
-        },
-        message: "call revert exception ....",
+        code: 3,
+        shortMessage: "execution reverted...",
       };
 
       beforeEach(() => {
@@ -209,7 +204,7 @@ describe("RetryableContract", () => {
     describe("when throws a few errors with no method or message before returning a result", () => {
       const functionResult = "functionResult";
       const error = new Error();
-      (error as any).code = "CALL_EXCEPTION";
+      (error as any).code = 3;
 
       beforeEach(() => {
         let countOfFailedRequests = 0;

--- a/packages/worker/src/blockchain/retryableContract.spec.ts
+++ b/packages/worker/src/blockchain/retryableContract.spec.ts
@@ -92,13 +92,8 @@ describe("RetryableContract", () => {
 
     describe("when throws a permanent call exception function error", () => {
       const callExceptionError = {
-        code: "CALL_EXCEPTION",
-        method: "contractFn(address)",
-        transaction: {
-          data: "0x00",
-          to: "to",
-        },
-        message: "call revert exception ....",
+        code: 3,
+        shortMessage: "execution reverted ....",
       };
 
       beforeEach(() => {

--- a/packages/worker/src/blockchain/retryableContract.ts
+++ b/packages/worker/src/blockchain/retryableContract.ts
@@ -1,15 +1,10 @@
 import { Logger } from "@nestjs/common";
 import { setTimeout } from "timers/promises";
-import { Contract, Interface, ContractRunner, ErrorCode } from "ethers";
+import { Contract, Interface, ContractRunner, ErrorCode, isError } from "ethers";
 
 interface EthersError {
-  code: ErrorCode;
-  method: string;
-  transaction: {
-    data: string;
-    to: string;
-  };
-  message: string;
+  code: ErrorCode | number;
+  shortMessage: string;
 }
 
 const MAX_RETRY_INTERVAL = 60000;
@@ -21,16 +16,9 @@ const PERMANENT_ERRORS: ErrorCode[] = [
   "NOT_IMPLEMENTED",
 ];
 
-const shouldRetry = (calledFunctionName: string, error: EthersError): boolean => {
-  return (
-    !PERMANENT_ERRORS.includes(error.code) &&
-    !(
-      error.code === "CALL_EXCEPTION" &&
-      error.method?.startsWith(`${calledFunctionName}(`) &&
-      !!error.transaction &&
-      error.message?.startsWith("call revert exception")
-    )
-  );
+const shouldRetry = (error: EthersError): boolean => {
+  const isPermanentErrorCode = PERMANENT_ERRORS.find((errorCode) => isError(error, errorCode));
+  return !isPermanentErrorCode && !(error.code === 3 && error.shortMessage?.startsWith("execution reverted"));
 };
 
 const retryableFunctionCall = async (
@@ -44,7 +32,7 @@ const retryableFunctionCall = async (
   try {
     return await result;
   } catch (error) {
-    const isRetryable = shouldRetry(functionName, error);
+    const isRetryable = shouldRetry(error);
     logger.warn({
       message: `Requested contract function ${functionName} failed to execute, ${
         isRetryable ? "retrying..." : "not retryable"


### PR DESCRIPTION
# What ❔

Fix for the retryable contract retry functionality.

## Why ❔

Ethers v6 returns errors differently than Ethers v5, so the function that parses an error and determines whether the request should be retried needs to be fixed.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.