### PR TITLE
fix: make tx receipt root field nullable

### DIFF
--- a/packages/worker/src/entities/transactionReceipt.entity.ts
+++ b/packages/worker/src/entities/transactionReceipt.entity.ts
@@ -34,8 +34,8 @@ export class TransactionReceipt extends CountableEntity {
   @Column({ type: "int" })
   public readonly type: number;
 
-  @Column({ type: "bytea", transformer: hexTransformer })
-  public readonly root: string;
+  @Column({ type: "bytea", transformer: hexTransformer, nullable: true })
+  public readonly root?: string;
 
   @Column({ type: "varchar", length: 128 })
   public readonly gasUsed: string;

--- a/packages/worker/src/entities/transactionReceipt.entity.ts
+++ b/packages/worker/src/entities/transactionReceipt.entity.ts
@@ -34,6 +34,8 @@ export class TransactionReceipt extends CountableEntity {
   @Column({ type: "int" })
   public readonly type: number;
 
+  // this field is only relevant on L1 pre byzantium fork (EIP658),
+  // but was present in ZKsync API before, so it cannot be just dropped.
   @Column({ type: "bytea", transformer: hexTransformer, nullable: true })
   public readonly root?: string;
 

--- a/packages/worker/src/migrations/1730806000905-TxReceiptRootColumnNullable.ts
+++ b/packages/worker/src/migrations/1730806000905-TxReceiptRootColumnNullable.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class TxReceiptRootColumnNullable1730806000905 implements MigrationInterface {
+  name = "TxReceiptRootColumnNullable1730806000905";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "transactionReceipts" ALTER COLUMN "root" DROP NOT NULL`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "transactionReceipts" ALTER COLUMN "root" SET NOT NULL`);
+  }
+}


### PR DESCRIPTION
# What ❔

Make tx receipt root field nullable.

## Why ❔

RPC doesn't return this field anymore. Here is the corresponding [PR](https://github.com/matter-labs/zksync-era/pull/3187).

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.