### PR TITLE
chore: publish preview url only for the base repo prs

### DIFF
--- a/.github/workflows/app-deploy-feature-branch.yml
+++ b/.github/workflows/app-deploy-feature-branch.yml
@@ -80,6 +80,7 @@ jobs:
           firebase --project staging-scan-v2 hosting:channel:deploy ${{ env.CHANNEL_NAME }}
 
       - name: Publish preview url
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: thollander/actions-comment-pull-request@v2
         with:
           comment_tag: preview_url


### PR DESCRIPTION
# What ❔

Publish preview url only for the base repo PRs.

## Why ❔

Even though `pull-requests: write` permissions are specified for the `Build and Test App` GitHub workflow, forked PRs are executed under `pull-requests: read` permissions. This causes the `Publish preview URL` action to fail, as it attempts to add a comment to the PR. Using the `pull_request_target` event instead of `pull_request` is not an option, as the workflow builds and runs code from the pull request context. To resolve this, the `Publish preview URL` action was modified to run only for base repository PRs. This should not be a problem for the forked PRs, as the URL is still output to the GitHub Action logs.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).