### PR TITLE
fix: calldata encoding fails for tuple params

### DIFF
--- a/packages/app/src/utils/helpers.ts
+++ b/packages/app/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { format } from "date-fns";
-import { Interface } from "ethers";
+import { AbiCoder, Interface } from "ethers";
 import { utils } from "zksync-ethers";
 
 import { DEPLOYER_CONTRACT_ADDRESS } from "./constants";
@@ -8,8 +8,12 @@ import type { DecodingType } from "@/components/transactions/infoTable/HashViewe
 import type { AbiFragment } from "@/composables/useAddress";
 import type { InputType, TransactionEvent, TransactionLogEntry } from "@/composables/useEventLog";
 import type { TokenTransfer } from "@/composables/useTransaction";
+import type { InputData } from "@/composables/useTransactionData";
+import type { ParamType, Result } from "ethers";
 
 const { BOOTLOADER_FORMAL_ADDRESS } = utils;
+
+export const DefaultAbiCoder: AbiCoder = AbiCoder.defaultAbiCoder();
 
 export function utcStringFromUnixTimestamp(timestamp: number) {
   const isoDate = new Date(+`${timestamp}000`).toISOString();
@@ -114,6 +118,56 @@ export function decodeLogWithABI(log: TransactionLogEntry, abi: AbiFragment[]): 
   } catch {
     return undefined;
   }
+}
+
+export function decodeInputData(input: ParamType, args: Result): InputData[] {
+  if (input.isArray()) {
+    return decodeArrayInputData(input, args);
+  }
+
+  if (input.isTuple()) {
+    return decodeTupleInputData(input, args);
+  }
+
+  return [
+    {
+      name: input.name,
+      type: input.type as InputType,
+      value: args.toString(),
+      encodedValue: DefaultAbiCoder.encode([input.type], [args]).split("0x")[1],
+      inputs: [],
+    },
+  ];
+}
+
+function decodeArrayInputData(input: ParamType, args: Result): InputData[] {
+  const inputs = args.flatMap((arg) => decodeInputData(input.arrayChildren!, arg));
+
+  return [
+    {
+      name: input.name,
+      type: `${inputs[0]?.type ? `${inputs[0]?.type}[]` : input.type}`,
+      value: `[${inputs.map((input) => input.value).join(",")}]`,
+      inputs: inputs,
+      encodedValue: `[${inputs.map((input) => input.encodedValue).join(",")}]`,
+    },
+  ];
+}
+
+function decodeTupleInputData(input: ParamType, args: Result): InputData[] {
+  const inputs = input.components!.flatMap((component: ParamType, index: number) =>
+    decodeInputData(component, args[index])
+  );
+
+  return [
+    {
+      name: input.name,
+      type: `tuple(${inputs.map((input) => input.type).join(",")})`,
+      value: `(${inputs.map((input) => input.value).join(",")})`,
+      inputs,
+      encodedValue: `(${inputs.map((input) => input.encodedValue).join(",")})`,
+    },
+  ];
 }
 
 export function sortTokenTransfers(transfers: TokenTransfer[]): TokenTransfer[] {

--- a/packages/app/tests/composables/useTransactionData.spec.ts
+++ b/packages/app/tests/composables/useTransactionData.spec.ts
@@ -53,12 +53,14 @@ const transactionDataDecodedMethod = {
   inputs: [
     {
       name: "recipient",
+      inputs: [],
       type: "address",
       value: "0xa1cf087DB965Ab02Fb3CFaCe1f5c63935815f044",
       encodedValue: "000000000000000000000000a1cf087db965ab02fb3cface1f5c63935815f044",
     },
     {
       name: "amount",
+      inputs: [],
       type: "uint256",
       value: "1",
       encodedValue: "0000000000000000000000000000000000000000000000000000000000000001",
@@ -175,12 +177,14 @@ describe("useTransactionData:", () => {
         inputs: [
           {
             encodedValue: "000000000000000000000000a1cf087db965ab02fb3cface1f5c63935815f044",
+            inputs: [],
             name: "recipient",
             type: "address",
             value: "0xa1cf087DB965Ab02Fb3CFaCe1f5c63935815f044",
           },
           {
             encodedValue: "0000000000000000000000000000000000000000000000000000000000000001",
+            inputs: [],
             name: "amount",
             type: "uint256",
             value: "1",

--- a/packages/app/tests/utils/helpers.spec.ts
+++ b/packages/app/tests/utils/helpers.spec.ts
@@ -1,17 +1,20 @@
 import { describe, expect, it } from "vitest";
 
 import { format } from "date-fns";
+import { ParamType } from "ethers";
 import { utils } from "zksync-ethers";
 
 import ExecuteTx from "@/../mock/transactions/Execute.json";
 
 import type { InputType } from "@/composables/useEventLog";
 import type { TokenTransfer } from "@/composables/useTransaction";
+import type { Result } from "ethers";
 
 import {
   arrayHalfDivider,
   camelCaseFromSnakeCase,
   contractInputTypeToHumanType,
+  decodeInputData,
   getRawFunctionType,
   getRequiredArrayLength,
   getTypeFromEvent,
@@ -176,6 +179,166 @@ describe("helpers:", () => {
     });
     it("returns the value if the decimals of the number are less than the given decimal attribute", () => {
       expect(truncateNumber("0.02", 5)).toEqual("0.02");
+    });
+  });
+  describe("decodeInputData:", () => {
+    it("decodes a simple input type", () => {
+      const input = ParamType.from({
+        name: "value",
+        type: "uint256",
+        baseType: "scalar",
+        isArray: () => true,
+        isTuple: () => false,
+      });
+      const args = 42;
+
+      const result = decodeInputData(input, args as unknown as Result);
+
+      expect(result).toEqual([
+        {
+          name: "value",
+          type: "uint256",
+          value: "42",
+          encodedValue: expect.any(String),
+          inputs: [],
+        },
+      ]);
+    });
+
+    it("decodes an array input type", () => {
+      const input = ParamType.from({
+        name: "values",
+        baseType: "array",
+        type: "uint256[]",
+        arrayChildren: { name: "value", type: "uint256" },
+      });
+      const args = [42, 43];
+
+      const result = decodeInputData(input, args as unknown as Result);
+
+      expect(result).toEqual([
+        {
+          name: "values",
+          type: "uint256[]",
+          value: "[42,43]",
+          inputs: [
+            {
+              name: "",
+              type: "uint256",
+              value: "42",
+              encodedValue: "000000000000000000000000000000000000000000000000000000000000002a",
+              inputs: [],
+            },
+            {
+              name: "",
+              type: "uint256",
+              value: "43",
+              encodedValue: "000000000000000000000000000000000000000000000000000000000000002b",
+              inputs: [],
+            },
+          ],
+          encodedValue:
+            "[000000000000000000000000000000000000000000000000000000000000002a,000000000000000000000000000000000000000000000000000000000000002b]",
+        },
+      ]);
+    });
+
+    it("decodes a tuple input type", () => {
+      const input = ParamType.from({
+        name: "tupleValue",
+        type: "tuple",
+        baseType: "tuple",
+        components: [
+          { name: "value1", type: "uint256", baseType: "scalar" },
+          { name: "value2", type: "string", baseType: "scalar" },
+        ],
+      });
+      const args = ["42", "test"];
+
+      const result = decodeInputData(input, args as unknown as Result);
+      expect(result).toEqual([
+        {
+          name: "tupleValue",
+          type: "tuple(uint256,string)",
+          value: "(42,test)",
+          inputs: [
+            {
+              name: "value1",
+              type: "uint256",
+              value: "42",
+              encodedValue: "000000000000000000000000000000000000000000000000000000000000002a",
+              inputs: [],
+            },
+            {
+              name: "value2",
+              type: "string",
+              value: "test",
+              encodedValue:
+                "000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000047465737400000000000000000000000000000000000000000000000000000000",
+              inputs: [],
+            },
+          ],
+          encodedValue:
+            "(000000000000000000000000000000000000000000000000000000000000002a,000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000047465737400000000000000000000000000000000000000000000000000000000)",
+        },
+      ]);
+    });
+
+    it("decodes a tuple with an array", () => {
+      const input = ParamType.from({
+        name: "tupleValue",
+        type: "tuple",
+        baseType: "tuple",
+        components: [
+          { name: "value1", type: "uint256", baseType: "scalar" },
+          { name: "value2", type: "uint256[]", baseType: "array", arrayChildren: { name: "value", type: "uint256" } },
+        ],
+      });
+      const args = [42, [43, 44]];
+
+      const result = decodeInputData(input, args as unknown as Result);
+
+      expect(result).toEqual([
+        {
+          name: "tupleValue",
+          type: "tuple(uint256,uint256[])",
+          value: "(42,[43,44])",
+          inputs: [
+            {
+              name: "value1",
+              type: "uint256",
+              value: "42",
+              encodedValue: "000000000000000000000000000000000000000000000000000000000000002a",
+              inputs: [],
+            },
+            {
+              name: "value2",
+              type: "uint256[]",
+              value: "[43,44]",
+              inputs: [
+                {
+                  name: "",
+                  type: "uint256",
+                  value: "43",
+                  encodedValue: "000000000000000000000000000000000000000000000000000000000000002b",
+                  inputs: [],
+                },
+                {
+                  name: "",
+                  type: "uint256",
+                  value: "44",
+                  encodedValue: "000000000000000000000000000000000000000000000000000000000000002c",
+                  inputs: [],
+                },
+              ],
+              encodedValue:
+                "[000000000000000000000000000000000000000000000000000000000000002b,000000000000000000000000000000000000000000000000000000000000002c]",
+            },
+          ],
+          encodedValue:
+            "(000000000000000000000000000000000000000000000000000000000000002a,[000000000000000000000000000000000000000000000000000000000000002b,000000000000000000000000000000000000000000000000000000000000002c])",
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
# What ❔

This PR implements support for encoding non-primitive input types. With this update, all input data, including tuples, arrays, and combinations of various types, will be correctly encoded.

## Why ❔

In the current version of the block explorer, users encounter an error when input data includes complex objects or arrays. 

For show we will use: https://explorer.zksync.io/tx/0xe39dbc98b41bb22620b78e3a3848ab34982310f9564f27d1e809cfdd461fa54e

Example without fix: 
![image](https://github.com/user-attachments/assets/ece3ffcc-ff03-4eb1-9dd2-d380a4655695)

Example with fix: 
![image](https://github.com/user-attachments/assets/549059ae-a304-4fb7-9a69-bd3753cc9972)

fixes https://github.com/matter-labs/block-explorer/issues/321

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [+ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [+ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
