### PR TITLE
feat: Add page size support for pagination

### DIFF
--- a/packages/app/src/components/common/Dropdown.vue
+++ b/packages/app/src/components/common/Dropdown.vue
@@ -17,7 +17,7 @@
         <ChevronDownIcon class="toggle-button-icon" :class="{ 'toggle-button-opened': open }" />
       </span>
     </ListboxButton>
-    <ListboxOptions class="options-list-container">
+    <ListboxOptions class="options-list-container" :class="showAbove ? 'mb-1 bottom-full' : 'top-full'">
       <ListboxOption
         as="template"
         v-for="option in options"
@@ -75,6 +75,10 @@ const props = defineProps({
     type: String,
     default: "",
   },
+  showAbove: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const emit = defineEmits<{
@@ -124,7 +128,7 @@ const selected = computed({
   @apply mt-0.5 text-sm text-error-500;
 }
 .options-list-container {
-  @apply absolute z-10 mt-1 max-h-[180px] w-full cursor-pointer overflow-hidden overflow-y-auto rounded-md border-neutral-300 bg-white text-sm shadow-md focus:outline-none;
+  @apply absolute z-20 mt-1 max-h-[180px] w-full cursor-pointer overflow-hidden overflow-y-auto rounded-md border-neutral-300 bg-white text-sm shadow-md focus:outline-none;
   .options-list-item {
     @apply px-3 py-3 hover:bg-neutral-100;
 

--- a/packages/app/src/components/common/Pagination.vue
+++ b/packages/app/src/components/common/Pagination.vue
@@ -1,57 +1,92 @@
 <template>
-  <nav class="pagination-container" :class="{ disabled }" aria-label="Pagination">
-    <PaginationButton
-      :use-route="useQuery"
-      :to="{ query: backButtonQuery, hash: currentHash }"
-      class="pagination-page-button arrow left"
-      :aria-disabled="isFirstPage"
-      :class="{ disabled: isFirstPage }"
-      @click="currentPage = Math.max(currentPage - 1, 1)"
-    >
-      <span class="sr-only">Previous</span>
-      <ChevronLeftIcon class="chevron-icon" aria-hidden="true" />
-    </PaginationButton>
-    <template v-for="(item, index) in pagesData" :key="index">
-      <PaginationButton
-        v-if="item.type === 'page'"
-        :use-route="useQuery"
-        :to="{ query: item.number > 1 ? { page: item.number } : {}, hash: currentHash }"
-        :aria-current="activePage === item.number ? 'page' : 'false'"
-        :class="[{ active: activePage === item.number }, item.hiddenOnMobile ? 'hidden sm:flex' : 'flex']"
-        class="pagination-page-button page"
-        @click="currentPage = item.number"
-      >
-        {{ item.number }}
-      </PaginationButton>
-      <span v-else class="pagination-page-button dots">...</span>
-    </template>
+  <div class="pagination-container">
+    <div class="page-size-container">
+      <Dropdown class="page-size-dropdown" v-model="computedPageSize" :options="pageSizeOptions" :show-above="true" />
+      <span class="page-size-text">{{ t("pagination.records") }}</span>
+    </div>
 
-    <PaginationButton
-      :use-route="useQuery"
-      :to="{ query: nextButtonQuery, hash: currentHash }"
-      class="pagination-page-button arrow right"
-      :aria-disabled="isLastPage"
-      :class="{ disabled: isLastPage }"
-      @click="currentPage = Math.min(currentPage + 1, pageCount)"
-    >
-      <span class="sr-only">Next</span>
-      <ChevronRightIcon class="chevron-icon" aria-hidden="true" />
-    </PaginationButton>
-  </nav>
+    <nav class="page-numbers-container" :class="{ disabled }" aria-label="Pagination">
+      <PaginationButton
+        :use-route="useQuery"
+        :to="{ query: backButtonQuery, hash: currentHash }"
+        class="pagination-page-button arrow left"
+        :aria-disabled="isFirstPage"
+        :class="{ disabled: isFirstPage }"
+        @click="currentPage = Math.max(currentPage - 1, 1)"
+      >
+        <span class="sr-only">Previous</span>
+        <ChevronLeftIcon class="chevron-icon" aria-hidden="true" />
+      </PaginationButton>
+      <template v-for="(item, index) in pagesData" :key="index">
+        <PaginationButton
+          v-if="item.type === 'page'"
+          :use-route="useQuery"
+          :to="{
+            query: item.number > 1 ? { page: item.number, pageSize: computedPageSize } : { pageSize: computedPageSize },
+            hash: currentHash,
+          }"
+          :aria-current="activePage === item.number ? 'page' : 'false'"
+          :class="[{ active: activePage === item.number }, item.hiddenOnMobile ? 'hidden sm:flex' : 'flex']"
+          class="pagination-page-button page"
+          @click="currentPage = item.number"
+        >
+          {{ item.number }}
+        </PaginationButton>
+        <span v-else class="pagination-page-button dots">...</span>
+      </template>
+
+      <PaginationButton
+        :use-route="useQuery"
+        :to="{ query: nextButtonQuery, hash: currentHash }"
+        class="pagination-page-button arrow right"
+        :aria-disabled="isLastPage"
+        :class="{ disabled: isLastPage }"
+        @click="currentPage = Math.min(currentPage + 1, pageCount)"
+      >
+        <span class="sr-only">Next</span>
+        <ChevronRightIcon class="chevron-icon" aria-hidden="true" />
+      </PaginationButton>
+    </nav>
+  </div>
 </template>
 
 <script setup lang="ts">
 import { computed, type UnwrapNestedRefs } from "vue";
-import { useRoute } from "vue-router";
+import { useI18n } from "vue-i18n";
+import { useRoute, useRouter } from "vue-router";
 
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/vue/outline";
 import { useOffsetPagination, type UseOffsetPaginationReturn } from "@vueuse/core";
 
+import Dropdown from "@/components/common/Dropdown.vue";
 import PaginationButton from "@/components/common/PaginationButton.vue";
 
 const route = useRoute();
+const router = useRouter();
+const { t } = useI18n();
 
 const currentHash = computed(() => route?.hash);
+
+const pageSizeOptions = ["10", "20", "50", "100"];
+const computedPageSize = computed({
+  get() {
+    return currentPageSize.value.toString();
+  },
+  set(newValue) {
+    const parsedValue = parseInt(newValue, 10);
+    if (parsedValue !== currentPageSize.value) {
+      currentPageSize.value = parsedValue;
+
+      router.push({
+        query: {
+          page: currentPage.value,
+          pageSize: parsedValue,
+        },
+        hash: currentHash.value,
+      });
+    }
+  },
+});
 
 const props = defineProps({
   activePage: {
@@ -78,10 +113,12 @@ const props = defineProps({
 
 const emit = defineEmits<{
   (eventName: "update:activePage", value: number): void;
+  (eventName: "update:pageSize", value: number): void;
   (eventName: "onPageChange", value: UnwrapNestedRefs<UseOffsetPaginationReturn>): void;
+  (eventName: "onPageSizeChange", value: UnwrapNestedRefs<UseOffsetPaginationReturn>): void;
 }>();
 
-const { currentPage, pageCount, isFirstPage, isLastPage } = useOffsetPagination({
+const { currentPage, currentPageSize, pageCount, isFirstPage, isLastPage } = useOffsetPagination({
   total: computed(() => props.totalItems),
   page: computed({
     get: () => props.activePage,
@@ -89,9 +126,10 @@ const { currentPage, pageCount, isFirstPage, isLastPage } = useOffsetPagination(
   }),
   pageSize: computed({
     get: () => props.pageSize,
-    set: () => undefined,
+    set: (val) => emit("update:pageSize", val),
   }),
   onPageChange: (data) => emit("onPageChange", data),
+  onPageSizeChange: (data) => emit("onPageSizeChange", data),
 });
 
 const pagesData = computed(() => {
@@ -123,36 +161,58 @@ const pagesData = computed(() => {
   return [...first, ...middle, ...last];
 });
 
-const backButtonQuery = computed(() => (currentPage.value > 2 ? { page: currentPage.value - 1 } : {}));
-const nextButtonQuery = computed(() => ({ page: Math.min(currentPage.value + 1, pageCount.value) }));
+const backButtonQuery = computed(() =>
+  currentPage.value > 2
+    ? { page: currentPage.value - 1, pageSize: computedPageSize.value }
+    : { pageSize: computedPageSize.value }
+);
+const nextButtonQuery = computed(() => ({
+  page: Math.min(currentPage.value + 1, pageCount.value),
+  pageSize: computedPageSize.value,
+}));
 </script>
 
 <style lang="scss">
 .pagination-container {
-  @apply flex space-x-1 transition-opacity;
-  &.disabled {
-    @apply pointer-events-none opacity-50;
-  }
-
-  .pagination-page-button {
-    @apply rounded-md bg-white px-1.5 py-1 font-mono text-sm font-medium text-neutral-700 no-underline sm:px-2;
-    &:not(.disabled):not(.active):not(.dots) {
-      @apply hover:bg-neutral-50;
-    }
+  @apply flex flex-col-reverse items-center justify-center relative sm:flex-row;
+  .page-numbers-container {
+    @apply flex space-x-1 transition-opacity justify-center p-3;
     &.disabled {
-      @apply cursor-not-allowed text-neutral-400;
+      @apply pointer-events-none opacity-50;
     }
-    &.active {
-      @apply z-10 bg-neutral-100;
-    }
-    &.dots {
-      @apply font-sans text-neutral-400 hover:bg-white;
-    }
-    &.arrow {
-      @apply flex items-center;
 
-      .chevron-icon {
-        @apply h-4 w-4;
+    .pagination-page-button {
+      @apply rounded-md bg-white px-1.5 py-1 font-mono text-sm font-medium text-neutral-700 no-underline sm:px-2;
+      &:not(.disabled):not(.active):not(.dots) {
+        @apply hover:bg-neutral-50;
+      }
+      &.disabled {
+        @apply cursor-not-allowed text-neutral-400;
+      }
+      &.active {
+        @apply z-10 bg-neutral-100;
+      }
+      &.dots {
+        @apply font-sans text-neutral-400 hover:bg-white;
+      }
+      &.arrow {
+        @apply flex items-center;
+
+        .chevron-icon {
+          @apply h-4 w-4;
+        }
+      }
+    }
+  }
+  .page-size-container {
+    @apply relative left-0 flex items-center justify-center pb-2 sm:absolute sm:pb-0 sm:left-6;
+    .page-size-text {
+      @apply text-gray-500 pl-2;
+    }
+    .page-size-dropdown {
+      @apply w-16;
+      .toggle-button {
+        @apply py-0 px-2 leading-8 h-8;
       }
     }
   }

--- a/packages/app/src/components/common/Pagination.vue
+++ b/packages/app/src/components/common/Pagination.vue
@@ -1,7 +1,13 @@
 <template>
   <div class="pagination-container">
     <div class="page-size-container">
-      <Dropdown class="page-size-dropdown" v-model="computedPageSize" :options="pageSizeOptions" :show-above="true" />
+      <Dropdown
+        class="page-size-dropdown"
+        v-model="computedPageSize"
+        :options="pageSizeOptions"
+        :show-above="true"
+        :pending="disabled"
+      />
       <span class="page-size-text">{{ t("pagination.records") }}</span>
     </div>
 

--- a/packages/app/src/components/transactions/Table.vue
+++ b/packages/app/src/components/transactions/Table.vue
@@ -265,7 +265,8 @@ const toDate = new Date();
 watch(
   [activePage, () => route.query.pageSize, searchParams],
   ([page, pageSize]) => {
-    load(page, toDate, parseInt(pageSize as string));
+    const currentPageSize = pageSize ? parseInt(pageSize as string) : 10;
+    load(page, toDate, currentPageSize);
   },
   { immediate: true }
 );

--- a/packages/app/src/components/transactions/Table.vue
+++ b/packages/app/src/components/transactions/Table.vue
@@ -171,15 +171,13 @@
       </TableBodyColumn>
     </template>
     <template v-if="pagination && total && total > pageSize && transactions?.length" #footer>
-      <div class="pagination">
-        <Pagination
-          v-model:active-page="activePage"
-          :use-query="useQueryPagination"
-          :total-items="total!"
-          :page-size="pageSize"
-          :disabled="isLoading"
-        />
-      </div>
+      <Pagination
+        v-model:active-page="activePage"
+        :use-query="useQueryPagination"
+        :total-items="total!"
+        :page-size="pageSize"
+        :disabled="isLoading"
+      />
     </template>
     <template #loading>
       <tr class="loader-row" v-for="row in pageSize" :key="row">
@@ -265,9 +263,9 @@ const activePage = ref(props.useQueryPagination ? parseInt(route.query.page as s
 const toDate = new Date();
 
 watch(
-  [activePage, searchParams],
-  ([page]) => {
-    load(page, toDate);
+  [activePage, () => route.query.pageSize, searchParams],
+  ([page, pageSize]) => {
+    load(page, toDate, parseInt(pageSize as string));
   },
   { immediate: true }
 );
@@ -460,10 +458,6 @@ function getDirection(item: TransactionListItem): Direction {
   }
   .badge-container.type-label {
     @apply pr-2 normal-case	normal-case;
-  }
-
-  .pagination {
-    @apply flex justify-center p-3;
   }
 
   .table-body {

--- a/packages/app/src/composables/common/useFetchCollection.ts
+++ b/packages/app/src/composables/common/useFetchCollection.ts
@@ -12,7 +12,7 @@ export type UseFetchCollection<T> = {
   page: ComputedRef<null | number>;
   pageSize: ComputedRef<number>;
 
-  load: (nextPage: number, toDate?: Date) => Promise<void>;
+  load: (nextPage: number, toDate?: Date, pageSize?: number) => Promise<void>;
 };
 
 export function useFetchCollection<T, TApiResponse = T>(
@@ -29,15 +29,18 @@ export function useFetchCollection<T, TApiResponse = T>(
   const page = ref<null | number>(null);
   const total = ref<null | number>(null);
 
-  async function load(nextPage: number, toDate?: Date) {
+  async function load(nextPage: number, toDate?: Date, updatedPageSize?: number) {
     page.value = nextPage;
+    if (updatedPageSize) {
+      pageSize.value = updatedPageSize;
+    }
 
     pending.value = true;
     failed.value = false;
 
     try {
       const url = typeof resource === "function" ? resource() : resource;
-      url.searchParams.set("pageSize", pageSize.value.toString());
+      url.searchParams.set("limit", pageSize.value.toString());
       url.searchParams.set("page", nextPage.toString());
 
       if (toDate && +new Date(toDate) > 0) {

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -730,5 +730,8 @@
     "systemAlert": {
         "indexerDelayed": "Transaction indexing is {indexerDelayInHours} hours behind. Transactions are being processed normally and will gradually show up. You can also use other <a href=\"https://zksync.io/explore/\" style=\"color: inherit\">explorers</a> meanwhile.",
         "indexerDelayedDueToHeavyLoad": "The network is under a heavy load at the moment and transaction indexing on the explorer is {indexerDelayInHours} hours behind. Transactions are being processed normally and will gradually show up. You can also use other <a href=\"https://zksync.io/explore/\" style=\"color: inherit\">explorers</a> meanwhile."
+    },
+    "pagination": {
+        "records": "Records"
     }
 }

--- a/packages/app/src/locales/uk.json
+++ b/packages/app/src/locales/uk.json
@@ -456,5 +456,8 @@
     "systemAlert": {
         "indexerDelayed": "Індексація транзакцій відстає на {indexerDelayInHours} годин. Транзакції будуть поступово оброблені та відображені. Ви також можете скористатися іншими <a href=\"https://zksync.io/explore/\" style=\"color: inherit\">блок експлорерами</a> наразі.",
         "indexerDelayedDueToHeavyLoad": "Мережа наразі перебуває під великим навантаженням, індексація транзакцій відстає на {indexerDelayInHours} годин. Транзакції будуть поступово оброблені та відображені. Ви також можете скористатися іншими <a href=\"https://zksync.io/explore/\" style=\"color: inherit\">блок експлорерами</a> наразі."
+    },
+    "pagination" : {
+        "records": "записи"
     }
 }

--- a/packages/app/src/views/BatchesView.vue
+++ b/packages/app/src/views/BatchesView.vue
@@ -11,16 +11,14 @@
       </span>
       <BatchesTable v-else :loading="pending" :loading-rows="pageSize" :batches="data ?? []">
         <template v-if="total && total > pageSize" #footer>
-          <div class="pagination-container">
-            <Pagination :active-page="page!" :total-items="total!" :page-size="pageSize" :disabled="pending" />
-          </div>
+          <Pagination :active-page="page!" :total-items="total!" :page-size="pageSize" :disabled="pending" />
         </template>
       </BatchesTable>
     </div>
   </div>
 </template>
 <script setup lang="ts">
-import { computed, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute } from "vue-router";
 
@@ -50,10 +48,11 @@ const breadcrumbItems = computed((): BreadcrumbItem[] => [
 ]);
 
 watch(
-  () => route.query.page,
-  (page) => {
+  [() => route.query.page, () => route.query.pageSize],
+  ([page, pageSize]) => {
     const currentPage = page ? parseInt(page as string) : 1;
-    load(currentPage, currentPage === 1 ? new Date() : undefined);
+    const currentPageSize = pageSize ? parseInt(pageSize as string) : 10;
+    load(currentPage, currentPage === 1 ? new Date() : undefined, currentPageSize);
   },
   { immediate: true }
 );
@@ -72,8 +71,5 @@ watch(
   .table-body-col {
     @apply min-w-[120px];
   }
-}
-.pagination-container {
-  @apply flex justify-center p-3;
 }
 </style>

--- a/packages/app/tests/components/Account.spec.ts
+++ b/packages/app/tests/components/Account.spec.ts
@@ -17,10 +17,13 @@ const router = {
     value: {},
   },
 };
+const routeQueryMock = vi.fn(() => ({}));
 
 vi.mock("vue-router", () => ({
   useRouter: () => router,
-  useRoute: () => vi.fn(),
+  useRoute: () => ({
+    query: routeQueryMock(),
+  }),
 }));
 
 describe("Account:", () => {

--- a/packages/app/tests/components/common/Pagination.spec.ts
+++ b/packages/app/tests/components/common/Pagination.spec.ts
@@ -1,9 +1,13 @@
+import { createI18n } from "vue-i18n";
+
 import { describe, expect, it, vi } from "vitest";
 
 import { fireEvent } from "@testing-library/vue";
 import { mount, RouterLinkStub } from "@vue/test-utils";
 
 import Pagination from "@/components/common/Pagination.vue";
+
+import enUS from "@/locales/en.json";
 
 vi.mock("vue-router", () => ({
   useRouter: () => vi.fn(),
@@ -13,6 +17,14 @@ vi.mock("vue-router", () => ({
 }));
 
 describe("Pagination:", () => {
+  const i18n = createI18n({
+    locale: "en",
+    allowComposition: true,
+    messages: {
+      en: enUS,
+    },
+  });
+
   it("renders default state properly", () => {
     const wrapper = mount(Pagination, {
       props: {
@@ -23,12 +35,13 @@ describe("Pagination:", () => {
         stubs: {
           RouterLink: RouterLinkStub,
         },
+        plugins: [i18n],
       },
     });
     const pageLinks = wrapper.findAllComponents(RouterLinkStub).filter((e) => e.classes().includes("page"));
 
     expect(pageLinks.length).toBe(5);
-    expect(pageLinks[0].props().to.query).toEqual({});
+    expect(pageLinks[0].props().to.query).toEqual({ pageSize: "10" });
     for (let a = 2; a < 5; a++) {
       expect(pageLinks[a - 1].props().to.query.page).toBe(a);
     }
@@ -46,9 +59,10 @@ describe("Pagination:", () => {
         stubs: {
           RouterLink: RouterLinkStub,
         },
+        plugins: [i18n],
       },
     });
-    expect(wrapper.classes("disabled")).toBe(true);
+    expect(wrapper.find(".page-numbers-container").classes("disabled")).toBe(true);
   });
 
   describe("Dots:", () => {
@@ -62,6 +76,7 @@ describe("Pagination:", () => {
           stubs: {
             RouterLink: RouterLinkStub,
           },
+          plugins: [i18n],
         },
       });
       expect(wrapper.findAll(".dots").length).toBe(1);
@@ -77,6 +92,7 @@ describe("Pagination:", () => {
           stubs: {
             RouterLink: RouterLinkStub,
           },
+          plugins: [i18n],
         },
       });
       expect(wrapper.findAll(".dots").length).toBe(1);
@@ -92,6 +108,7 @@ describe("Pagination:", () => {
           stubs: {
             RouterLink: RouterLinkStub,
           },
+          plugins: [i18n],
         },
       });
       expect(wrapper.findAll(".dots").length).toBe(2);
@@ -109,6 +126,7 @@ describe("Pagination:", () => {
         stubs: {
           RouterLink: RouterLinkStub,
         },
+        plugins: [i18n],
       },
     });
 
@@ -116,7 +134,7 @@ describe("Pagination:", () => {
     expect(wrapper.emitted("update:activePage")).toEqual([[5], [5], [5], [6]]);
   });
   describe("Back & Next buttons:", () => {
-    it("back button doesn't have a query and is disabled if first page is active", () => {
+    it("back button only has pageSize query and is disabled if first page is active", () => {
       const wrapper = mount(Pagination, {
         props: {
           activePage: 1,
@@ -126,10 +144,11 @@ describe("Pagination:", () => {
           stubs: {
             RouterLink: RouterLinkStub,
           },
+          plugins: [i18n],
         },
       });
       const pageLinks = wrapper.findAllComponents(RouterLinkStub).filter((e) => e.classes().includes("arrow"));
-      expect(pageLinks[0].props().to.query).toEqual({});
+      expect(pageLinks[0].props().to.query).toEqual({ pageSize: "10" });
       expect(pageLinks[0].classes().includes("disabled")).toEqual(true);
     });
     it("next button is disabled if last page is active", () => {
@@ -142,6 +161,7 @@ describe("Pagination:", () => {
           stubs: {
             RouterLink: RouterLinkStub,
           },
+          plugins: [i18n],
         },
       });
       const pageLinks = wrapper.findAllComponents(RouterLinkStub).filter((e) => e.classes().includes("arrow"));
@@ -158,6 +178,7 @@ describe("Pagination:", () => {
           stubs: {
             RouterLink: RouterLinkStub,
           },
+          plugins: [i18n],
         },
       });
       const pageLinks = wrapper.findAllComponents(RouterLinkStub).filter((e) => e.classes().includes("arrow"));
@@ -177,6 +198,7 @@ describe("Pagination:", () => {
         stubs: {
           RouterLink: RouterLinkStub,
         },
+        plugins: [i18n],
       },
     });
     const pageLinks = wrapper.findAllComponents(RouterLinkStub);

--- a/packages/app/tests/components/transactions/Table.spec.ts
+++ b/packages/app/tests/components/transactions/Table.spec.ts
@@ -18,8 +18,16 @@ import type { TransactionListItem } from "@/composables/useTransactions";
 
 import $testId from "@/plugins/testId";
 
+const router = {
+  push: vi.fn(),
+};
+
+const routeQueryMock = vi.fn(() => ({}));
 vi.mock("vue-router", () => ({
-  useRoute: vi.fn(() => ({ query: {} })),
+  useRoute: () => ({
+    query: routeQueryMock(),
+  }),
+  useRouter: () => router,
 }));
 vi.mock("@/composables/useTokenLibrary", () => {
   return {
@@ -278,12 +286,12 @@ describe("Transfers:", () => {
       });
 
       it("renders pagination", async () => {
-        expect(renderResult!.container.querySelector(".pagination")).not.toBeNull();
+        expect(renderResult!.container.querySelector(".pagination-container")).not.toBeNull();
       });
 
       it("does not render pagination if pagination prop is false", async () => {
         await renderResult?.rerender({ pagination: false });
-        expect(renderResult!.container.querySelector(".pagination")).toBeNull();
+        expect(renderResult!.container.querySelector(".pagination-container")).toBeNull();
       });
     });
 

--- a/packages/app/tests/components/transfers/Table.spec.ts
+++ b/packages/app/tests/components/transfers/Table.spec.ts
@@ -16,7 +16,12 @@ import elements from "tests/e2e/testId.json";
 
 import $testId from "@/plugins/testId";
 
+const router = {
+  push: vi.fn(),
+};
+
 vi.mock("vue-router", () => ({
+  useRouter: () => router,
   useRoute: vi.fn(),
 }));
 vi.mock("@/composables/useTokenLibrary", () => {

--- a/packages/app/tests/composables/common/useFetchCollection.spec.ts
+++ b/packages/app/tests/composables/common/useFetchCollection.spec.ts
@@ -111,7 +111,7 @@ describe("useFetchCollection:", () => {
       await fc.load(1, new Date("2023-05-01T10:00:00.000Z"));
 
       expect($fetch).toHaveBeenCalledWith(
-        "https://block-explorer-api.testnets.zksync.dev/?pageSize=10&page=1&toDate=2023-05-01T10%3A00%3A00.000Z"
+        "https://block-explorer-api.testnets.zksync.dev/?limit=10&page=1&toDate=2023-05-01T10%3A00%3A00.000Z"
       );
     });
   });

--- a/packages/app/tests/composables/useTransactions.spec.ts
+++ b/packages/app/tests/composables/useTransactions.spec.ts
@@ -90,7 +90,7 @@ describe("useTransactions:", () => {
     const composable = useTransactions(searchParams);
     await composable.load(1);
     expect(fetchMock.mock.calls[0][0]).toBe(
-      "https://block-explorer-api.testnets.zksync.dev/transactions?blockNumber=0&l1BatchNumber=0&pageSize=10&page=1"
+      "https://block-explorer-api.testnets.zksync.dev/transactions?blockNumber=0&l1BatchNumber=0&limit=10&page=1"
     );
   });
 

--- a/packages/app/tests/e2e/src/pages/base.page.ts
+++ b/packages/app/tests/e2e/src/pages/base.page.ts
@@ -20,6 +20,10 @@ export class BasePage {
     return "//*[@aria-label='Pagination']";
   }
 
+  get pageSizeDropdown() {
+    return "//div[contains(@class, 'page-size-container')]";
+  }
+
   async getColumnByText(text: string) {
     element = `//th[text()="${text}"]`;
     result = await this.world.page?.locator(element).first();

--- a/packages/app/tests/e2e/src/steps/blockexplorer.steps.ts
+++ b/packages/app/tests/e2e/src/steps/blockexplorer.steps.ts
@@ -319,6 +319,11 @@ Then("Pagination form should be visible", async function (this: ICustomWorld) {
   result = await this.page?.locator(element);
 
   await expect(result).toBeVisible(config.increasedTimeout);
+
+  element = basePage.pageSizeDropdown;
+  result = await this.page?.locator(element);
+
+  await expect(result).toBeVisible(config.increasedTimeout);
 });
 
 Then("Column with {string} name is visible", async function (this: ICustomWorld, columnName: string) {

--- a/packages/app/tests/views/BatchView.spec.ts
+++ b/packages/app/tests/views/BatchView.spec.ts
@@ -17,6 +17,7 @@ const router = {
     value: {},
   },
 };
+const routeQueryMock = vi.fn(() => ({}));
 
 vi.mock("@/composables/useSearch", () => {
   return {
@@ -28,7 +29,9 @@ vi.mock("@/composables/useSearch", () => {
 
 vi.mock("vue-router", () => ({
   useRouter: () => router,
-  useRoute: () => vi.fn(),
+  useRoute: () => ({
+    query: routeQueryMock(),
+  }),
   createWebHistory: () => vi.fn(),
   createRouter: () => vi.fn(),
 }));

--- a/packages/app/tests/views/BlockView.spec.ts
+++ b/packages/app/tests/views/BlockView.spec.ts
@@ -17,6 +17,7 @@ const router = {
     value: {},
   },
 };
+const routeQueryMock = vi.fn(() => ({}));
 
 vi.mock("@/composables/useSearch", () => {
   return {
@@ -28,7 +29,9 @@ vi.mock("@/composables/useSearch", () => {
 
 vi.mock("vue-router", () => ({
   useRouter: () => router,
-  useRoute: () => vi.fn(),
+  useRoute: () => ({
+    query: routeQueryMock(),
+  }),
   createWebHistory: () => vi.fn(),
   createRouter: () => vi.fn(),
 }));

--- a/packages/app/tests/views/HomeView.spec.ts
+++ b/packages/app/tests/views/HomeView.spec.ts
@@ -26,6 +26,7 @@ const getBatchesMockCollection = (length: number) =>
     status: "sealed",
     timestamp: "2022-04-13T13:09:31.000Z",
   }));
+const routeQueryMock = vi.fn(() => ({}));
 
 vi.mock("ohmyfetch", () => {
   return {
@@ -35,7 +36,9 @@ vi.mock("ohmyfetch", () => {
 
 vi.mock("vue-router", () => ({
   useRouter: () => vi.fn(),
-  useRoute: () => vi.fn(),
+  useRoute: () => ({
+    query: routeQueryMock(),
+  }),
   createWebHistory: () => vi.fn(),
   createRouter: () => vi.fn(),
 }));


### PR DESCRIPTION
# What ❔

Add page size dropdown to show `10`, `20`, `50`, or `100` records in paginated tables

## Why ❔

Allows users to see more data on a single page.

Closes #215 

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.

## Evidence

https://github.com/user-attachments/assets/77d0aefe-f4ba-4f22-b765-5b3e8872e1a7


