### PR TITLE
fix: pagination display with page sizes

### DIFF
--- a/packages/app/src/components/event/ContractEvents.vue
+++ b/packages/app/src/components/event/ContractEvents.vue
@@ -159,7 +159,7 @@ watch(
     @apply block;
   }
   .pagination {
-    @apply flex justify-center p-3;
+    @apply p-3;
   }
   .only-mobile {
     @apply flex md:hidden;

--- a/packages/app/src/components/transactions/infoTable/Logs.vue
+++ b/packages/app/src/components/transactions/infoTable/Logs.vue
@@ -190,7 +190,7 @@ function scrollPageToTop() {
   }
 
   .pagination {
-    @apply flex justify-center p-3;
+    @apply p-3;
   }
   .loading-row {
     .table-body-col {

--- a/packages/app/src/components/transfers/Table.vue
+++ b/packages/app/src/components/transfers/Table.vue
@@ -219,7 +219,7 @@ watch(
   }
 
   .pagination {
-    @apply flex justify-center p-3;
+    @apply p-3;
   }
 
   .transfer-type {


### PR DESCRIPTION
# What ❔

Fix the display of page size dropdown with pagination component

## Why ❔

They were overlapping wherever previously the styling of the pagination component is occurring outside of `Pagination.vue`

BEFORE:
![image](https://github.com/user-attachments/assets/79be7041-e0ee-4816-96e2-5150b1a370c0)


AFTER:
![image](https://github.com/user-attachments/assets/035526b0-9b22-48d0-83c7-f1c37a45c32f)


## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
