### PR TITLE
feat: update token for upgradable transactions where implementation i…

### DIFF
--- a/packages/data-fetcher/src/app.module.ts
+++ b/packages/data-fetcher/src/app.module.ts
@@ -13,6 +13,7 @@ import { TransferService } from "./transfer/transfer.service";
 import { TokenService } from "./token/token.service";
 import { JsonRpcProviderModule } from "./rpcProvider/jsonRpcProvider.module";
 import { MetricsModule } from "./metrics";
+import { UpgradableService } from "./upgradable/upgradable.service";
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { MetricsModule } from "./metrics";
   providers: [
     BlockchainService,
     AddressService,
+    UpgradableService,
     BalanceService,
     TransferService,
     TokenService,

--- a/packages/data-fetcher/src/upgradable/extractProxyHandlers/default.handler.spec.ts
+++ b/packages/data-fetcher/src/upgradable/extractProxyHandlers/default.handler.spec.ts
@@ -1,0 +1,72 @@
+import { types } from "zksync-ethers";
+import { mock } from "jest-mock-extended";
+import { defaultContractUpgradableHandler } from "./default.handler";
+
+describe("defaultContractUpgradableHandler", () => {
+  let log: types.Log;
+  beforeEach(() => {
+    log = mock<types.Log>({
+      transactionIndex: 1,
+      blockNumber: 3233097,
+      transactionHash: "0x5e018d2a81dbd1ef80ff45171dd241cb10670dcb091e324401ff8f52293841b0",
+      address: "0x1BEB2aBb1678D8a25431d9728A425455f29d12B7",
+      topics: [
+        "0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b",
+        "0x000000000000000000000000a1810a1f32F4DC6c5112b5b837b6975E56b489cc",
+      ],
+      data: "0x",
+      index: 8,
+      blockHash: "0xdfd071dcb9c802f7d11551f4769ca67842041ffb81090c49af7f089c5823f39c",
+      l1BatchNumber: 604161,
+    });
+  });
+
+  describe("matches", () => {
+    it("returns true", () => {
+      const result = defaultContractUpgradableHandler.matches(log);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("extract", () => {
+    let transactionReceipt;
+
+    beforeEach(() => {
+      transactionReceipt = mock<types.TransactionReceipt>({
+        blockNumber: 10,
+        hash: "transactionHash",
+        from: "from",
+      });
+    });
+
+    it("extracts upgraded contract address", () => {
+      const result = defaultContractUpgradableHandler.extract(log, transactionReceipt);
+      expect(result.address).toBe("0x1BEB2aBb1678D8a25431d9728A425455f29d12B7");
+    });
+
+    it("extracts block number for the upgraded contract", () => {
+      const result = defaultContractUpgradableHandler.extract(log, transactionReceipt);
+      expect(result.blockNumber).toBe(transactionReceipt.blockNumber);
+    });
+
+    it("extracts transaction hash for the upgraded contract", () => {
+      const result = defaultContractUpgradableHandler.extract(log, transactionReceipt);
+      expect(result.transactionHash).toBe(transactionReceipt.hash);
+    });
+
+    it("extracts creator address for the upgraded contract", () => {
+      const result = defaultContractUpgradableHandler.extract(log, transactionReceipt);
+      expect(result.creatorAddress).toBe(transactionReceipt.from);
+    });
+
+    it("extracts logIndex for the upgraded contract", () => {
+      const result = defaultContractUpgradableHandler.extract(log, transactionReceipt);
+      expect(result.logIndex).toBe(log.index);
+    });
+
+    it("extracts implementation address for the upgraded contract", () => {
+      const result = defaultContractUpgradableHandler.extract(log, transactionReceipt);
+      expect(result.implementationAddress).toBe("0xa1810a1f32F4DC6c5112b5b837b6975E56b489cc");
+    });
+  });
+});

--- a/packages/data-fetcher/src/upgradable/extractProxyHandlers/default.handler.ts
+++ b/packages/data-fetcher/src/upgradable/extractProxyHandlers/default.handler.ts
@@ -1,0 +1,37 @@
+import { types } from "zksync-ethers";
+import { AbiCoder, keccak256 } from "ethers";
+import { ExtractProxyAddressHandler } from "../interface/extractProxyHandler.interface";
+import { ProxyAddress } from "../interface/proxyAddress.interface";
+
+const abiCoder: AbiCoder = AbiCoder.defaultAbiCoder();
+
+export const encodedUpgradableEvents = [
+  "Upgraded(address)",
+  "BeaconUpgraded(address)",
+  "OwnershipTransferred(address,address)",
+  "AdminChanged(address,address)",
+  "OwnershipTransferred(address,address)",
+];
+
+const decodedUpgradableEvents = encodedUpgradableEvents.map((event) => `${keccak256(Buffer.from(event)).toString()}`);
+
+export const defaultContractUpgradableHandler: ExtractProxyAddressHandler = {
+  matches: (log: types.Log): boolean => {
+    return decodedUpgradableEvents.includes(log.topics[0]);
+  },
+  extract: (log: types.Log, txReceipt: types.TransactionReceipt): ProxyAddress => {
+    if (!log.topics[1]) {
+      return null;
+    }
+
+    const [address] = abiCoder.decode(["address"], log.topics[1]);
+    return {
+      address: log.address,
+      blockNumber: txReceipt.blockNumber,
+      transactionHash: txReceipt.hash,
+      creatorAddress: txReceipt.from,
+      logIndex: log.index,
+      implementationAddress: address,
+    };
+  },
+};

--- a/packages/data-fetcher/src/upgradable/extractProxyHandlers/index.ts
+++ b/packages/data-fetcher/src/upgradable/extractProxyHandlers/index.ts
@@ -1,0 +1,1 @@
+export * from "./default.handler";

--- a/packages/data-fetcher/src/upgradable/interface/extractProxyHandler.interface.ts
+++ b/packages/data-fetcher/src/upgradable/interface/extractProxyHandler.interface.ts
@@ -1,0 +1,7 @@
+import { types } from "zksync-ethers";
+import { ProxyAddress } from "./proxyAddress.interface";
+
+export interface ExtractProxyAddressHandler {
+  matches: (log: types.Log) => boolean;
+  extract: (log: types.Log, txReceipt: types.TransactionReceipt) => ProxyAddress | null;
+}

--- a/packages/data-fetcher/src/upgradable/interface/proxyAddress.interface.ts
+++ b/packages/data-fetcher/src/upgradable/interface/proxyAddress.interface.ts
@@ -1,0 +1,5 @@
+import { ContractAddress } from "../../address/interface/contractAddress.interface";
+
+export type ProxyAddress = ContractAddress & {
+  implementationAddress: string;
+};

--- a/packages/data-fetcher/src/upgradable/upgradable.service.spec.ts
+++ b/packages/data-fetcher/src/upgradable/upgradable.service.spec.ts
@@ -1,0 +1,82 @@
+import { Test } from "@nestjs/testing";
+import { Logger } from "@nestjs/common";
+import { mock } from "jest-mock-extended";
+import { types } from "zksync-ethers";
+
+import { UpgradableService } from "./upgradable.service";
+describe("UpgradableService", () => {
+  let upgradableService: UpgradableService;
+
+  beforeEach(async () => {
+    const app = await Test.createTestingModule({
+      providers: [UpgradableService],
+    }).compile();
+
+    app.useLogger(mock<Logger>());
+
+    upgradableService = app.get<UpgradableService>(UpgradableService);
+  });
+
+  describe("getUpgradableAddresses", () => {
+    const logs = [
+      mock<types.Log>({
+        topics: [
+          "0x290afdae231a3fc0bbae8b1af63698b0a1d79b21ad17df0342dfb952fe74f8e5",
+          "0x000000000000000000000000c7e0220d02d549c4846a6ec31d89c3b670ebe35c",
+          "0x0100014340e955cbf39159da998b3374bee8f3c0b3c75a7a9e3df6b85052379d",
+          "0x000000000000000000000000dc187378edd8ed1585fb47549cc5fe633295d571",
+        ],
+        index: 1,
+      }),
+      mock<types.Log>({
+        topics: [
+          "0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b",
+          "0x0000000000000000000000000db321efaa9e380d0b37b55b530cdaa62728b9a3",
+        ],
+        address: "0xdc187378edD8Ed1585fb47549Cc5fe633295d571",
+        index: 2,
+      }),
+      mock<types.Log>({
+        topics: [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x000000000000000000000000481e48ce19781c3ca573967216dee75fdcf70f54",
+        ],
+        address: "0xD144ca8Aa2E7DFECD56a3CCcBa1cd873c8e5db58",
+        index: 3,
+      }),
+    ];
+
+    const transactionReceipt = mock<types.TransactionReceipt>({
+      blockNumber: 10,
+      hash: "transactionHash",
+      from: "from",
+    });
+
+    it("returns upgradable addresses", async () => {
+      const upgradableAddresses = await upgradableService.getUpgradableAddresses(logs, transactionReceipt);
+      expect(upgradableAddresses).toStrictEqual([
+        {
+          address: "0xdc187378edD8Ed1585fb47549Cc5fe633295d571",
+          implementationAddress: "0x0Db321EFaa9E380d0B37B55B530CDaA62728B9a3",
+          blockNumber: transactionReceipt.blockNumber,
+          transactionHash: transactionReceipt.hash,
+          creatorAddress: transactionReceipt.from,
+          logIndex: logs[1].index,
+        },
+        {
+          address: "0xD144ca8Aa2E7DFECD56a3CCcBa1cd873c8e5db58",
+          implementationAddress: "0x481E48Ce19781c3cA573967216deE75FDcF70F54",
+          blockNumber: transactionReceipt.blockNumber,
+          transactionHash: transactionReceipt.hash,
+          creatorAddress: transactionReceipt.from,
+          logIndex: logs[2].index,
+        },
+      ]);
+    });
+
+    it("returns an empty array if no logs specified", async () => {
+      const result = await upgradableService.getUpgradableAddresses(null, transactionReceipt);
+      expect(result).toStrictEqual([]);
+    });
+  });
+});

--- a/packages/data-fetcher/src/upgradable/upgradable.service.ts
+++ b/packages/data-fetcher/src/upgradable/upgradable.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from "@nestjs/common";
+import { types } from "zksync-ethers";
+import { ExtractProxyAddressHandler } from "./interface/extractProxyHandler.interface";
+import { defaultContractUpgradableHandler } from "./extractProxyHandlers";
+import { ProxyAddress } from "./interface/proxyAddress.interface";
+
+const extractProxyHandlers: ExtractProxyAddressHandler[] = [defaultContractUpgradableHandler];
+
+@Injectable()
+export class UpgradableService {
+  public async getUpgradableAddresses(
+    logs: ReadonlyArray<types.Log>,
+    transactionReceipt: types.TransactionReceipt
+  ): Promise<ProxyAddress[]> {
+    const proxyAddresses: ProxyAddress[] = [];
+    if (!logs) {
+      return proxyAddresses;
+    }
+
+    logs.forEach((log) => {
+      const handlerForLog = extractProxyHandlers.find((handler) => handler.matches(log));
+      if (!handlerForLog) {
+        return;
+      }
+
+      const proxyAddress = handlerForLog.extract(log, transactionReceipt);
+      if (proxyAddress) {
+        proxyAddresses.push(proxyAddress);
+      }
+    });
+
+    return proxyAddresses;
+  }
+}


### PR DESCRIPTION
…s token

# What ❔

This PR updates the token reference in the database for Transparent and UUPS proxies linked to ERC20 token implementations. The upgradable transaction handler detects and replaces outdated tokens with the correct updated version.

## Why ❔

Users can modify the symbol, name, and decimals of tokens deployed as proxies, so these details must be updated in the database to ensure they are displayed correctly in the UI. **Note** that Etherscan does not support this feature, and certain proxy patterns, such as Beacon proxies, are not affected in our case. (since beacon is upgraded but beacon proxy points to him).

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [+ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [+] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
