### PR TITLE
feat: add support for EraVM Extensions

### DIFF
--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -456,6 +456,14 @@
                 },
                 "underline": "If you enabled optimization during compilation, select yes."
             },
+            "enableEraVMExtensionsUsed": {
+                "label": "Enable EraVM Extensions",
+                "options": {
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "underline": "If you enabled EraVM Extensions during compilation, select yes."
+            },
             "solcVersion": {
                 "label": "Solc Version",
                 "placeholder": "Choose version",

--- a/packages/app/src/locales/uk.json
+++ b/packages/app/src/locales/uk.json
@@ -263,6 +263,14 @@
                 },
                 "underline": "Якщо ви ввімкнули оптимізацію під час компіляції, виберіть так."
             },
+            "enableEraVMExtensionsUsed": {
+                "label": "Ввімкнути EraVM Extensions",
+                "options": {
+                    "yes": "Так",
+                    "no": "Ні"
+                },
+                "underline": "Якщо ви ввімкнули EraVM Extensions під час компіляції, виберіть так."
+            },
             "solcVersion": {
                 "label": "Solc версія",
                 "placeholder": "Вибрати версію",

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -38,6 +38,7 @@ export type ContractVerificationData = {
   contractAddress: string;
   contractName: string;
   optimizationUsed: boolean;
+  enableEraVMExtensionsUsed: boolean;
   sourceCode:
     | string
     | {
@@ -48,6 +49,7 @@ export type ContractVerificationData = {
           };
         };
         settings: {
+          enableEraVMExtensions: boolean;
           optimizer: {
             enabled: boolean;
           };

--- a/packages/app/src/views/ContractVerificationView.vue
+++ b/packages/app/src/views/ContractVerificationView.vue
@@ -154,7 +154,33 @@
         </div>
         <template #underline>{{ t("contractVerification.form.optimizationUsed.underline") }}</template>
       </FormItem>
-
+      <FormItem
+        tag="fieldset"
+        :label="t('contractVerification.form.enableEraVMExtensionsUsed.label')"
+        label-tag="legend"
+      >
+        <div class="grid w-max grid-cols-2 items-center gap-4" :data-testid="$testId.enableEraVMExtensionsRadioButtons">
+          <RadioInput
+            id="enableEraVMExtensionsUsed-yes"
+            name="enableEraVMExtensionsUsed"
+            :disabled="isRequestPending"
+            :value="true"
+            v-model="form.enableEraVMExtensionsUsed"
+          >
+            {{ t("contractVerification.form.enableEraVMExtensionsUsed.options.yes") }}
+          </RadioInput>
+          <RadioInput
+            id="enableEraVMExtensionsUsed-no"
+            name="enableEraVMExtensionsUsed"
+            :disabled="isRequestPending"
+            :value="false"
+            v-model="form.enableEraVMExtensionsUsed"
+          >
+            {{ t("contractVerification.form.enableEraVMExtensionsUsed.options.no") }}
+          </RadioInput>
+        </div>
+        <template #underline>{{ t("contractVerification.form.enableEraVMExtensionsUsed.underline") }}</template>
+      </FormItem>
       <h3 class="form-subheading">Contract info</h3>
       <FormItem id="contractName" :label="t('contractVerification.form.contractName.label')">
         <Input
@@ -403,6 +429,7 @@ const defaultValues = computed<
     contractName: "",
     contractPath: "",
     optimizationUsed: true,
+    enableEraVMExtensionsUsed: false,
     zkCompilerVersion: selectedZkCompiler.value.versions[0] || "",
     compilerVersion: selectedCompiler.value.versions[0] || "",
     sourceCode: "",
@@ -545,6 +572,7 @@ async function submitForm() {
     codeFormat: ContractVerificationCodeFormatEnum[selectedCompilationType.value],
     contractAddress: form.value.contractAddress,
     optimizationUsed: form.value.optimizationUsed,
+    enableEraVMExtensionsUsed: form.value.enableEraVMExtensionsUsed,
     zkCompilerVersion: form.value.zkCompilerVersion,
     compilerVersion: form.value.compilerVersion,
     constructorArguments: form.value.constructorArguments,
@@ -576,6 +604,7 @@ async function submitForm() {
           optimizer: {
             enabled: form.value.optimizationUsed,
           },
+          enableEraVMExtensions: form.value.enableEraVMExtensionsUsed,
         },
       },
       ...commonData,

--- a/packages/app/tests/composables/useContractVerification.spec.ts
+++ b/packages/app/tests/composables/useContractVerification.spec.ts
@@ -33,6 +33,7 @@ describe("useContractVerification:", () => {
       contractAddress: "",
       contractName: "",
       optimizationUsed: false,
+      enableEraVMExtensionsUsed: false,
       sourceCode: "",
       zkCompilerVersion: "",
       compilerVersion: "",

--- a/packages/app/tests/e2e/testId.json
+++ b/packages/app/tests/e2e/testId.json
@@ -11,6 +11,7 @@
   "initiatorsAddress": "initiators-address",
   "fromAddress": "from-address",
   "optimizationRadioButtons": "radio-buttons",
+  "enableEraVMExtensionsRadioButtons": "radio-buttons",
   "pageTitle": "page-title",
   "previousInstructionButton": "previous-instruction-navigation-button",
   "showInstructionMetadataButton": "show-instruction-metadata-button",


### PR DESCRIPTION
# What ❔
Add support for the enableEraVMExtension flag (formerly isSystem) in the verification process.

## Why ❔

Ensuring it matches the settings used during compilation.

![image](https://github.com/user-attachments/assets/f43cf4f9-2ee1-4d31-a531-393708201e13)


## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [+] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [+] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
