### PR TITLE
feat: add lables for bridged and native tokens

### DIFF
--- a/packages/app/src/components/TokenIconLabel.vue
+++ b/packages/app/src/components/TokenIconLabel.vue
@@ -17,12 +17,22 @@
         />
       </div>
     </AddressLink>
-    <div class="token-info" v-if="name && symbol">
-      <div class="token-symbol">
-        {{ symbol }}
-      </div>
-      <div class="token-name">
-        {{ name }}
+    <div class="token-info-container">
+      <div class="token-info" v-if="name && symbol">
+        <div class="token-symbol">
+          {{ symbol }}
+        </div>
+        <div class="token-name">
+          {{ name }}
+        </div>
+        <div class="token-badge">
+          <Badge v-if="bridged" color="primary" class="verified-badge" :tooltip="t('tokensView.table.bridged.tooltip')">
+            {{ t("tokensView.table.bridged.title") }}
+          </Badge>
+          <Badge v-else color="progress" class="verified-badge" :tooltip="t('tokensView.table.native.tooltip')">
+            {{ t("tokensView.table.native.title") }}
+          </Badge>
+        </div>
       </div>
     </div>
   </div>
@@ -34,6 +44,7 @@ import { useI18n } from "vue-i18n";
 import { useImage } from "@vueuse/core";
 
 import AddressLink from "@/components/AddressLink.vue";
+import Badge from "@/components/common/Badge.vue";
 
 import type { Hash } from "@/types";
 
@@ -65,6 +76,10 @@ const props = defineProps({
   name: {
     type: String,
     default: "",
+  },
+  bridged: {
+    type: Boolean,
+    default: false,
   },
 });
 
@@ -115,12 +130,21 @@ const { isReady: isImageLoaded } = useImage({ src: imgSource.value });
       }
     }
   }
+  .token-info-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+  }
   .token-info {
     .token-symbol {
       @apply text-neutral-600;
     }
     .token-name {
       @apply text-xs text-neutral-400;
+    }
+    .token-badge {
+      @apply flex items-center justify-end md:justify-start gap-x-1;
     }
   }
 }

--- a/packages/app/src/components/contract/VerificationButton.vue
+++ b/packages/app/src/components/contract/VerificationButton.vue
@@ -14,13 +14,9 @@ import { useI18n } from "vue-i18n";
 
 import Button from "@/components/common/Button.vue";
 
-import type { Address } from "@/types";
-import type { PropType } from "vue";
-
 defineProps({
   address: {
-    type: Object as PropType<Address>,
-    default: () => ({}),
+    type: String,
     required: true,
   },
 });

--- a/packages/app/src/components/token/TokenListTable.vue
+++ b/packages/app/src/components/token/TokenListTable.vue
@@ -14,6 +14,7 @@
           :address="item.l2Address"
           :name="item.name"
           :icon-url="item.iconURL"
+          :bridged="item.l1Address ? true : false"
         />
       </TableBodyColumn>
       <TableBodyColumn :data-heading="t('tokensView.table.price')">

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -599,6 +599,15 @@
         "table": {
             "tokenName": "Token Name",
             "price": "Price",
+            "tokenAddress": "Token Address",
+            "bridged": {
+                "title": "Bridged",
+                "tooltip": "This token is bridged from L1 to ZKsync Era"
+            },
+            "native": {
+                "title": "L2-native",
+                "tooltip": "This token is native to ZKsync Era"
+            },
             "tokenAddressL2": "L2 Token address",
             "tokenAddressL1": "L1 Token address"
         }

--- a/packages/app/src/locales/uk.json
+++ b/packages/app/src/locales/uk.json
@@ -353,6 +353,15 @@
         "table": {
             "tokenName": "Назва Токена",
             "price": "Ціна",
+            "tokenAddress": "Адреса Токена",
+            "bridged": {
+                "title": "Бридж",
+                "tooltip": "Цей токен перенесений з L1 до ZKsync Era"
+            },
+            "native": {
+                "title": "L2-нативний",
+                "tooltip": "Цей токен є нативним для ZKsync Era"
+            },
             "tokenAddressL2": "L2 Адреса Токена",
             "tokenAddressL1": "L1 Адреса Токена"
         }

--- a/packages/app/tests/components/token/TokenListTable.spec.ts
+++ b/packages/app/tests/components/token/TokenListTable.spec.ts
@@ -43,7 +43,7 @@ describe("TokenListTable:", () => {
       en: enUS,
     },
   });
-  it("renders properly", async () => {
+  it("renders properly with bridged token", async () => {
     const { getTokenInfo } = useToken();
     const wrapper = mount(TokenListTable, {
       props: {
@@ -75,8 +75,46 @@ describe("TokenListTable:", () => {
     expect(tr0Arr[0].find(".token-symbol").text()).toBe("ETH");
     expect(tr0Arr[0].find(".token-name").text()).toBe("Ether");
     expect(tr0Arr[0].find(".token-icon-label img").attributes("src")).toBe("https://icon.com");
+    expect(tr0Arr[0].find(".verified-badge").text()).toBe("Bridged");
     expect(tr0Arr[1].text()).toBe("$150.00");
     expect(tr0Arr[2].text()).toBe("L20x5A7d6b2F92C7...af3E");
     expect(tr0Arr[3].text()).toBe("L10xEee...EEeE");
+  });
+
+  it("renders properly with native token", async () => {
+    const { getTokenInfo } = useToken();
+    const wrapper = mount(TokenListTable, {
+      props: {
+        tokens: [
+          {
+            decimals: 18,
+            iconURL: "https://icon.com",
+            l2Address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+            name: "Ether",
+            symbol: "ETH",
+          } as Token,
+        ],
+        loading: false,
+      },
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub,
+        },
+        plugins: [i18n, $testId],
+      },
+    });
+    await getTokenInfo("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE");
+    await nextTick();
+    const trArr = wrapper.findAll("tbody tr");
+    expect(trArr.length).toBe(1);
+    const tr0Arr = trArr[0].findAll(".table-body-col");
+    expect(tr0Arr.length).toBe(4);
+    expect(tr0Arr[0].find(".token-symbol").text()).toBe("ETH");
+    expect(tr0Arr[0].find(".token-name").text()).toBe("Ether");
+    expect(tr0Arr[0].find(".token-icon-label img").attributes("src")).toBe("https://icon.com");
+    expect(tr0Arr[0].find(".verified-badge").text()).toBe("L2-native");
+    expect(tr0Arr[1].text()).toBe("$150.00");
+    expect(tr0Arr[2].text()).toBe("L20xEeeeeEeeeEeE...EEeE");
+    expect(tr0Arr[3].text()).toBe("");
   });
 });

--- a/packages/app/tests/e2e/features/artifacts/artifactsSet3.feature
+++ b/packages/app/tests/e2e/features/artifacts/artifactsSet3.feature
@@ -64,7 +64,7 @@ Feature: Main Page
 
   @id249 @testnet @testnetSmokeSuite
   Scenario Outline: Verify table contains "<Column name>" column name on Tokens page
-    Given I go to page "/tokenlist"
+    Given I go to page "/tokens"
     # And Table "Tokens" should have "1" rows
     Then Column with "<Column name>" name is visible
 
@@ -77,7 +77,7 @@ Feature: Main Page
 
   @id249 @mainnet
   Scenario Outline: Verify table contains "<Column name>" column name on Tokens page
-    Given I go to page "/tokenlist"
+    Given I go to page "/tokens"
     # And Table "Tokens" should have "56" rows
     Then Column with "<Column name>" name is visible
 

--- a/packages/app/tests/e2e/features/copying.feature
+++ b/packages/app/tests/e2e/features/copying.feature
@@ -159,7 +159,7 @@ Feature: Copying
 
   @id275 @testnet @testnetSmokeSuite
   Scenario Outline: Check "<Row>" hashes copying for Tokens page
-    Given I go to page "/tokenlist"
+    Given I go to page "/tokens"
     When I click on the copy button with "<Row>" row on "Tokens" page
     And Element with "text" "Copied!" should be "visible"
     Then Clipboard contains "<Text>" value
@@ -170,7 +170,7 @@ Feature: Copying
 
   @id275:I @mainnet
   Scenario Outline: Check "<Row>" hashes copying for Tokens page
-    Given I go to page "/tokenlist"
+    Given I go to page "/tokens"
     When I click on the copy button with "<Row>" row on "Tokens" page
     And Element with "text" "Copied!" should be "visible"
     Then Clipboard contains "<Text>" value

--- a/packages/app/tests/e2e/features/redirection/redirectionSet2.feature
+++ b/packages/app/tests/e2e/features/redirection/redirectionSet2.feature
@@ -135,7 +135,7 @@ Feature: Redirection
   #Tokens page 
   @id250 @testnetSmokeSuite
   Scenario Outline: Verify redirection from Tokens page after "<Artifact type>" click
-    Given I go to page "/tokenlist/"
+    Given I go to page "/tokens/"
     When I click on the first "<Artifact type>" link
     Given Page with part address "<url>" includes ID result
 

--- a/packages/app/tests/e2e/src/pages/tokens.page.ts
+++ b/packages/app/tests/e2e/src/pages/tokens.page.ts
@@ -26,7 +26,7 @@ export class TokensPage extends BasePage {
 
   async clickCopyBtnByRow(rowName: string) {
     const copyBtn = this.copyBtn;
-    element = (await this.getRowByText(rowName)) + "/..//..//..//.." + copyBtn;
+    element = (await this.getRowByText(rowName)) + "/..//..//..//..//.." + copyBtn;
 
     await this.world.page?.locator(element).first().click();
   }


### PR DESCRIPTION
# What ❔

Add labels for bridged and native tokens.

## Why ❔

The same token can exist both on the default bridge and on a specific bridge. To help users differentiate between them, we have added labels.

![image](https://github.com/user-attachments/assets/3722a6cd-f3fc-432f-9071-bf19611c2475)

fixes https://github.com/matter-labs/block-explorer/issues/287


## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [+] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [+] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
