### PR TITLE
fix: handle potential concurrent system contracts insertion

### DIFF
--- a/packages/worker/src/contract/systemContract.service.spec.ts
+++ b/packages/worker/src/contract/systemContract.service.spec.ts
@@ -45,15 +45,15 @@ describe("SystemContractService", () => {
         SystemContractService.getSystemContracts().map((contract) => mock<Address>({ address: contract.address }))
       );
       await systemContractService.addSystemContracts();
-      expect(addressRepositoryMock.add).toBeCalledTimes(0);
+      expect(addressRepositoryMock.upsert).toBeCalledTimes(0);
     });
 
     it("adds all system contracts if none of them exist in the DB", async () => {
       (addressRepositoryMock.find as jest.Mock).mockResolvedValue([]);
       await systemContractService.addSystemContracts();
-      expect(addressRepositoryMock.add).toBeCalledTimes(systemContracts.length);
+      expect(addressRepositoryMock.upsert).toBeCalledTimes(systemContracts.length);
       for (const systemContract of systemContracts) {
-        expect(addressRepositoryMock.add).toBeCalledWith({
+        expect(addressRepositoryMock.upsert).toBeCalledWith({
           address: systemContract.address,
           bytecode: `${systemContract.address}-code`,
         });
@@ -69,10 +69,10 @@ describe("SystemContractService", () => {
         existingContractAddresses.map((existingContractAddress) => mock<Address>({ address: existingContractAddress }))
       );
       await systemContractService.addSystemContracts();
-      expect(addressRepositoryMock.add).toBeCalledTimes(systemContracts.length - existingContractAddresses.length);
+      expect(addressRepositoryMock.upsert).toBeCalledTimes(systemContracts.length - existingContractAddresses.length);
       for (const systemContract of systemContracts) {
         if (!existingContractAddresses.includes(systemContract.address)) {
-          expect(addressRepositoryMock.add).toBeCalledWith({
+          expect(addressRepositoryMock.upsert).toBeCalledWith({
             address: systemContract.address,
             bytecode: `${systemContract.address}-code`,
           });
@@ -93,10 +93,10 @@ describe("SystemContractService", () => {
         return `${address}-code`;
       });
       await systemContractService.addSystemContracts();
-      expect(addressRepositoryMock.add).toBeCalledTimes(systemContracts.length - notDeployedSystemContracts.length);
+      expect(addressRepositoryMock.upsert).toBeCalledTimes(systemContracts.length - notDeployedSystemContracts.length);
       for (const systemContract of systemContracts) {
         if (!notDeployedSystemContracts.includes(systemContract.address)) {
-          expect(addressRepositoryMock.add).toBeCalledWith({
+          expect(addressRepositoryMock.upsert).toBeCalledWith({
             address: systemContract.address,
             bytecode: `${systemContract.address}-code`,
           });

--- a/packages/worker/src/contract/systemContract.service.ts
+++ b/packages/worker/src/contract/systemContract.service.ts
@@ -26,7 +26,7 @@ export class SystemContractService {
         const bytecode = await this.blockchainService.getCode(contract.address);
         // some contract might not exist on the environment yet
         if (bytecode !== "0x") {
-          await this.addressRepository.add({
+          await this.addressRepository.upsert({
             address: contract.address,
             bytecode,
           });


### PR DESCRIPTION
If indexer finds a contract deployment event for a system contract at the same time as system contracts service inserts it - there will be a collision. It can very likely happen especially after these events are added on the blockchain side for initial deployments of system contracts.