### PR TITLE
feat: add holders page

### DIFF
--- a/packages/api/src/balance/balance.service.ts
+++ b/packages/api/src/balance/balance.service.ts
@@ -4,6 +4,9 @@ import { Repository } from "typeorm";
 import { Balance } from "./balance.entity";
 import { Token } from "../token/token.entity";
 import { hexTransformer } from "../common/transformers/hex.transformer";
+import { BalanceForHolderDto } from "./balanceForHolder.dto";
+import { paginate } from "../common/utils";
+import { IPaginationOptions, Pagination } from "nestjs-typeorm-paginate";
 
 export interface TokenBalance {
   balance: string;
@@ -98,5 +101,42 @@ export class BalanceService {
     );
     const balancesRecords = await balancesQuery.getMany();
     return balancesRecords;
+  }
+
+  public async getBalancesForTokenAddress(
+    tokenAddress: string,
+    paginationOptions?: IPaginationOptions
+  ): Promise<Pagination<BalanceForHolderDto>> {
+    const latestBalancesQuery = this.balanceRepository.createQueryBuilder("latest_balances");
+    latestBalancesQuery.select(`"tokenAddress"`);
+    latestBalancesQuery.addSelect(`"address"`);
+    latestBalancesQuery.addSelect(`MAX("blockNumber")`, "blockNumber");
+    latestBalancesQuery.where(`"tokenAddress" = :tokenAddress`);
+    latestBalancesQuery.groupBy(`"tokenAddress"`);
+    latestBalancesQuery.addGroupBy(`"address"`);
+
+    const balancesQuery = this.balanceRepository.createQueryBuilder("balances");
+    balancesQuery.innerJoin(
+      `(${latestBalancesQuery.getQuery()})`,
+      "latest_balances",
+      `balances."tokenAddress" = latest_balances."tokenAddress" AND
+      balances."address" = latest_balances."address" AND
+      balances."blockNumber" = latest_balances."blockNumber"`
+    );
+    balancesQuery.setParameter("tokenAddress", hexTransformer.to(tokenAddress));
+    balancesQuery.leftJoinAndSelect("balances.token", "token");
+    balancesQuery.orderBy(`CAST(balances.balance AS NUMERIC)`, "DESC");
+
+    const balancesForToken = await paginate<Balance>(balancesQuery, paginationOptions);
+
+    return {
+      ...balancesForToken,
+      items: balancesForToken.items.map((item) => {
+        return {
+          balance: item.balance,
+          address: item.address,
+        };
+      }),
+    };
   }
 }

--- a/packages/api/src/balance/balanceForHolder.dto.ts
+++ b/packages/api/src/balance/balanceForHolder.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class BalanceForHolderDto {
+  @ApiProperty({ type: String, description: "Token balance", example: "0xd754F" })
+  public readonly balance: string;
+
+  @ApiProperty({
+    type: String,
+    description: "Holder address",
+    example: "0x868e3b4391ff95C1cd99C6F9B5332b4EC2b8A63A",
+  })
+  public readonly address: string;
+}

--- a/packages/api/src/token/token.controller.spec.ts
+++ b/packages/api/src/token/token.controller.spec.ts
@@ -174,5 +174,21 @@ describe("TokenController", () => {
         expect(result).toBe(tokenHolders);
       });
     });
+
+    describe("when token does not exist", () => {
+      beforeEach(() => {
+        (serviceMock.exists as jest.Mock).mockResolvedValueOnce(false);
+      });
+
+      it("throws NotFoundException", async () => {
+        expect.assertions(1);
+
+        try {
+          await controller.getTokenHolders(tokenAddress, pagingOptionsWithLimit);
+        } catch (error) {
+          expect(error).toBeInstanceOf(NotFoundException);
+        }
+      });
+    });
   });
 });

--- a/packages/api/src/token/token.module.ts
+++ b/packages/api/src/token/token.module.ts
@@ -6,8 +6,9 @@ import { Token } from "./token.entity";
 import { Block } from "../block/block.entity";
 import { Transaction } from "../transaction/entities/transaction.entity";
 import { TransferModule } from "../transfer/transfer.module";
+import { BalanceModule } from "src/balance/balance.module";
 @Module({
-  imports: [TypeOrmModule.forFeature([Token, Block, Transaction]), TransferModule],
+  imports: [TypeOrmModule.forFeature([Token, Block, Transaction]), TransferModule, BalanceModule],
   controllers: [TokenController],
   providers: [TokenService],
   exports: [TokenService],

--- a/packages/api/src/token/token.module.ts
+++ b/packages/api/src/token/token.module.ts
@@ -6,7 +6,7 @@ import { Token } from "./token.entity";
 import { Block } from "../block/block.entity";
 import { Transaction } from "../transaction/entities/transaction.entity";
 import { TransferModule } from "../transfer/transfer.module";
-import { BalanceModule } from "src/balance/balance.module";
+import { BalanceModule } from "../balance/balance.module";
 @Module({
   imports: [TypeOrmModule.forFeature([Token, Block, Transaction]), TransferModule, BalanceModule],
   controllers: [TokenController],

--- a/packages/app/src/components/Contract.vue
+++ b/packages/app/src/components/Contract.vue
@@ -74,7 +74,7 @@
         <ContractEvents :contract="contract" />
       </template>
       <template v-if="tokenInfo && !isLoadingTokenInfo" #tab-5-content>
-        <TokenHoldersList :tokenInfo="tokenInfo">
+        <TokenHoldersList v-if="tokenInfo && !isLoadingTokenInfo" :tokenInfo="tokenInfo">
           <template #not-found>
             <TokenHoldersListEmptyState />
           </template>

--- a/packages/app/src/components/Contract.vue
+++ b/packages/app/src/components/Contract.vue
@@ -73,7 +73,7 @@
       <template #tab-4-content>
         <ContractEvents :contract="contract" />
       </template>
-      <template v-if="tokenInfo" #tab-5-content>
+      <template v-if="tokenInfo && !isLoadingTokenInfo" #tab-5-content>
         <TokenHoldersList :tokenInfo="tokenInfo">
           <template #not-found>
             <TokenHoldersListEmptyState />

--- a/packages/app/src/components/token/TokenHoldersList.vue
+++ b/packages/app/src/components/token/TokenHoldersList.vue
@@ -1,0 +1,155 @@
+<template>
+  <Table :data-testid="$testId.tokensHoldersTable" :loading="isLoading" :items="tokenHolders" ref="table">
+    <template v-if="tokenHolders?.length || isLoading" #table-head>
+      <table-head-column>{{ t("tokenHolders.table.address") }}</table-head-column>
+      <table-head-column>{{ t("tokenHolders.table.balance") }}</table-head-column>
+      <table-head-column>{{ t("tokenHolders.table.percentage") }}</table-head-column>
+      <table-head-column>{{ t("tokenHolders.table.value") }}</table-head-column>
+    </template>
+    <template #table-row="{ item }: { item: any }">
+      <TableBodyColumn :data-heading="t('tokenHolders.table.address')">
+        <AddressLink :address="item.address" class="block max-w-sm" :data-testid="$testId.tokenHoldersAddress">
+          {{ shortenFitText(item.address, "left", 210, subtraction) }}
+        </AddressLink>
+        <CopyButton :value="item.address" />
+      </TableBodyColumn>
+      <TableBodyColumn :data-heading="t('tokenHolders.table.balance')">
+        <div :data-testid="$testId.tokenHoldersBalance" class="balance-data-value">
+          {{ formatValue(item.balance, tokenInfo.decimals) }}
+        </div>
+      </TableBodyColumn>
+      <TableBodyColumn :data-testid="$testId.tokenHoldersPercentage" :data-heading="t('tokenHolders.table.percentage')">
+        {{ item.percentage }}
+      </TableBodyColumn>
+      <TableBodyColumn :data-heading="t('tokenHolders.table.value')">
+        <div class="balance-data-price">
+          <div :data-testid="$testId.tokenHoldersValue">
+            {{
+              tokenInfo.usdPrice && item.balance
+                ? formatPricePretty(item.balance, tokenInfo.decimals, tokenInfo.usdPrice.toString())
+                : ""
+            }}
+          </div>
+        </div>
+      </TableBodyColumn>
+    </template>
+    <template v-if="pagination && total && total > pageSize && tokenHolders?.length" #footer>
+      <Pagination
+        v-model:active-page="activePage"
+        :use-query="useQueryPagination"
+        :total-items="total!"
+        :page-size="pageSize"
+        :disabled="isLoading"
+      />
+    </template>
+    <template #loading>
+      <tr class="loading-row" v-for="row in 4" :key="row">
+        <TableBodyColumn class="w-16">
+          <ContentLoader />
+        </TableBodyColumn>
+        <TableBodyColumn>
+          <ContentLoader />
+        </TableBodyColumn>
+        <TableBodyColumn>
+          <ContentLoader />
+        </TableBodyColumn>
+        <TableBodyColumn>
+          <ContentLoader />
+        </TableBodyColumn>
+      </tr>
+    </template>
+    <template #empty>
+      <TableBodyColumn class="holders-not-found">
+        <slot name="not-found">{{ t("transactions.table.notFound") }}</slot>
+      </TableBodyColumn>
+    </template>
+  </Table>
+</template>
+<script lang="ts" setup>
+import { computed, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { useRoute } from "vue-router";
+
+import AddressLink from "@/components/AddressLink.vue";
+import CopyButton from "@/components/common/CopyButton.vue";
+import { shortenFitText } from "@/components/common/HashLabel.vue";
+import Pagination from "@/components/common/Pagination.vue";
+import ContentLoader from "@/components/common/loaders/ContentLoader.vue";
+import Table from "@/components/common/table/Table.vue";
+import TableBodyColumn from "@/components/common/table/TableBodyColumn.vue";
+import TableHeadColumn from "@/components/common/table/TableHeadColumn.vue";
+
+import useTokenHolders from "@/composables/useTokenHolders";
+
+import type { Token } from "@/composables/useToken";
+import type { TokenHolder } from "@/composables/useTokenHolders";
+import type { PropType } from "vue";
+
+import { formatPricePretty, formatValue } from "@/utils/formatters";
+
+const props = defineProps({
+  tokenInfo: {
+    type: Object as PropType<Token>,
+    required: true,
+  },
+  pagination: {
+    type: Boolean,
+    default: true,
+  },
+  useQueryPagination: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const route = useRoute();
+const { data, load, total, pending, pageSize } = useTokenHolders(props.tokenInfo.l2Address);
+const activePage = ref(props.useQueryPagination ? parseInt(route.query.page as string) || 1 : 1);
+const isLoading = computed(() => pending.value);
+const { t } = useI18n();
+const table = ref(null);
+const subtraction = ref(6);
+
+watch(
+  [activePage, () => route.query.pageSize],
+  ([page, pageSize]) => {
+    const currentPageSize = pageSize ? parseInt(pageSize as string) : 10;
+    load(page, undefined, currentPageSize);
+  },
+  { immediate: true }
+);
+
+const tokenHolders = computed<TokenHolder[] | undefined>(() => {
+  return data.value?.map((holder) => {
+    return {
+      ...holder,
+      percentage: props.tokenInfo.liquidity
+        ? `${(parseFloat(holder.balance) / (props.tokenInfo.liquidity / 100)).toFixed(4)} %`
+        : "",
+    };
+  });
+});
+</script>
+
+<style scoped lang="scss">
+.table-body-col {
+  @apply relative flex flex-col items-end justify-end text-right md:table-cell md:w-1/3 md:text-left;
+  &:before {
+    @apply absolute left-4 top-3 whitespace-nowrap pr-5 text-left text-xs uppercase text-neutral-400 content-[attr(data-heading)] md:content-none;
+  }
+  .holder-address-container {
+    @apply flex gap-x-2;
+    .holder-address {
+      @apply block cursor-pointer font-mono text-sm font-medium;
+    }
+  }
+  .loading-row {
+    .content-loader {
+      @apply w-full;
+    }
+  }
+  .holders-not-found {
+    @apply my-0 table-cell items-start justify-start bg-white p-4 text-left text-gray-700;
+  }
+}
+</style>

--- a/packages/app/src/components/token/TokenHoldersListEmptyState.vue
+++ b/packages/app/src/components/token/TokenHoldersListEmptyState.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="holders-empty-state">
+    <EmptyState>
+      <template #title>
+        {{ t("tokenHolders.notFound") }}
+      </template>
+    </EmptyState>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { useI18n } from "vue-i18n";
+
+import EmptyState from "@/components/common/EmptyState.vue";
+
+const { t } = useI18n();
+</script>
+
+<style scoped lang="scss">
+.holders-empty-state {
+  @apply flex py-16 lg:justify-center lg:py-28;
+  .holders-empty-description {
+    @apply max-w-[23rem] whitespace-normal;
+  }
+}
+</style>

--- a/packages/app/src/composables/common/Api.d.ts
+++ b/packages/app/src/composables/common/Api.d.ts
@@ -139,5 +139,10 @@ declare namespace Api {
       totalTransactions: number;
       isEvmLike: boolean;
     };
+
+    type TokenHolder = {
+      address: string;
+      balance: string;
+    };
   }
 }

--- a/packages/app/src/composables/useTokenHolders.ts
+++ b/packages/app/src/composables/useTokenHolders.ts
@@ -1,0 +1,10 @@
+import useFetchCollection from "./common/useFetchCollection";
+import useContext from "./useContext";
+
+export type TokenHolder = Api.Response.TokenHolder;
+
+export default (tokenAddress: string, context = useContext()) => {
+  return useFetchCollection<Api.Response.TokenHolder>(
+    new URL(`/tokens/${tokenAddress}/holders`, context.currentNetwork.value.apiUrl)
+  );
+};

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -598,6 +598,15 @@
             "tokenAddress": "Token Address"
         }
     },
+    "tokenHolders": {
+        "notFound": "Token doesn't have any holders at this moment",
+        "table": {
+            "address": "Address",
+            "balance": "Quantity",
+            "percentage": "Percentage",
+            "value": "Value"
+        }
+    },
     "pageError": {
         "title": "Something went wrong",
         "subtitle": "Unknown request, please try again, or go to the homepage.",
@@ -693,7 +702,8 @@
         "transactions": "Transactions",
         "contract": "Contract",
         "events": "Events",
-        "transfers": "Transfers"
+        "transfers": "Transfers",
+        "holders": "Holders"
     },
     "contractInfoTabs": {
         "contract": "Contract",

--- a/packages/app/src/locales/uk.json
+++ b/packages/app/src/locales/uk.json
@@ -356,6 +356,15 @@
             "tokenAddress": "Адреса Токена"
         }
     },
+    "tokenHolders": {
+        "notFound": "Для даного токена токен-власники відсутні на цей момент",
+        "table": {
+            "address": "Адреса",
+            "balance": "Баланс",
+            "percentage": "Відсоток",
+            "value": "Вартість"
+        }
+    },
     "timeMessages": {
         "justNow": "щойно",
         "past": "тому",
@@ -431,7 +440,10 @@
     },
     "tabs": {
         "transactions": "Транзакції",
-        "contract": "Контракт"
+        "contract": "Контракт",
+        "events": "Події",
+        "transfers": "Трансфери",
+        "holders": "Власники"
     },
     "debuggerTool": {
         "title": "zkEVM Налагоджувач",

--- a/packages/app/tests/components/token/TokenHoldersList.spec.ts
+++ b/packages/app/tests/components/token/TokenHoldersList.spec.ts
@@ -1,0 +1,97 @@
+import { computed } from "vue";
+import { createI18n } from "vue-i18n";
+
+import { afterAll, beforeAll, describe, expect, it, type SpyInstance, vi } from "vitest";
+
+import { render, type RenderResult } from "@testing-library/vue";
+import { RouterLinkStub } from "@vue/test-utils";
+
+import { useContextMock, useTokenHoldersMock } from "../../mocks";
+
+import TokenHolderList from "@/components/token/TokenHoldersList.vue";
+
+import enUS from "@/locales/en.json";
+import elements from "tests/e2e/testId.json";
+
+import $testId from "@/plugins/testId";
+
+const router = {
+  push: vi.fn(),
+};
+const routeQueryMock = vi.fn(() => ({}));
+vi.mock("vue-router", () => ({
+  useRouter: () => router,
+  useRoute: () => ({
+    query: routeQueryMock(),
+  }),
+}));
+
+describe("TokenListTable:", () => {
+  const i18n = createI18n({
+    locale: "en",
+    allowComposition: true,
+    messages: {
+      en: enUS,
+    },
+  });
+
+  let renderResult: RenderResult | null;
+  let mockContext: SpyInstance;
+  let mockHolders: SpyInstance;
+
+  beforeAll(() => {
+    mockHolders = useTokenHoldersMock({
+      data: computed(() => [
+        {
+          address: "0xe1134444211593Cfda9fc9eCc7B43208615556E2",
+          balance: "5000000000000000000",
+        },
+      ]),
+    });
+    mockContext = useContextMock();
+
+    renderResult = render(TokenHolderList, {
+      global: {
+        plugins: [i18n, $testId],
+        stubs: { RouterLink: RouterLinkStub },
+      },
+      props: {
+        tokenInfo: {
+          decimals: 18,
+          iconURL: "https://icon.com",
+          l1Address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+          l2Address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+          liquidity: 22000000000000000000000,
+          name: "Ether",
+          symbol: "ETH",
+          usdPrice: 150,
+        },
+        loading: false,
+        useQueryPagination: false,
+        notFound: false,
+      },
+    });
+  });
+
+  afterAll(() => {
+    mockContext?.mockRestore();
+    mockHolders?.mockRestore();
+    renderResult?.unmount();
+  });
+
+  it("renders transaction hash column", () => {
+    expect(renderResult!.getByTestId(elements.tokenHoldersAddress).textContent).toEqual("0xe11344442115...56E2");
+  });
+
+  it("renders timestamp column", () => {
+    expect(renderResult!.getByTestId(elements.tokenHoldersBalance).textContent).toEqual("5.0");
+  });
+
+  it("renders type column", () => {
+    expect(renderResult!.getByTestId(elements.tokenHoldersPercentage).textContent).toEqual("0.0227 %");
+  });
+
+  it("renders from column", () => {
+    expect(renderResult!.getByTestId(elements.tokenHoldersValue).textContent).toEqual("$750.00");
+  });
+});

--- a/packages/app/tests/composables/useTokenHolders.spec.ts
+++ b/packages/app/tests/composables/useTokenHolders.spec.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, type SpyInstance, vi } from "vitest";
+
+import { $fetch } from "ohmyfetch";
+
+import { useContextMock } from "../mocks";
+
+import useTokenHolders from "@/composables/useTokenHolders";
+
+vi.mock("ohmyfetch", () => {
+  return {
+    $fetch: vi.fn(() =>
+      Promise.resolve({
+        items: [
+          {
+            address: "0xe1134444211593Cfda9fc9eCc7B43208615556E2",
+            balance: "5000000000000000000",
+          },
+        ],
+        meta: {
+          totalItems: 1,
+          page: 1,
+          pageSize: 10,
+          totalPages: 1,
+          itemCount: 1,
+        },
+      })
+    ),
+  };
+});
+const tokenAddress = "0x0faF6df7054946141266420b43783387A78d82A9";
+
+describe("useTokenHolders:", () => {
+  let mockContext: SpyInstance;
+
+  beforeEach(() => {
+    mockContext = useContextMock();
+  });
+
+  afterEach(() => {
+    mockContext?.mockRestore();
+  });
+  /* eslint-disable  @typescript-eslint/no-explicit-any */
+  it("creates useTokenHolders composable", () => {
+    const composable = useTokenHolders(tokenAddress);
+    expect(composable.pending).toBeDefined();
+    expect(composable.failed).toBeDefined();
+    expect(composable.load).toBeDefined();
+    expect(composable.data).toBeDefined();
+  });
+
+  it("gets token holders from API", async () => {
+    const composable = useTokenHolders(tokenAddress);
+    await composable.load(1);
+    const batch = (composable.data.value || [])[0];
+
+    expect(composable.data.value?.length).toBe(1);
+    expect(batch).toEqual({
+      address: "0xe1134444211593Cfda9fc9eCc7B43208615556E2",
+      balance: "5000000000000000000",
+    });
+  });
+
+  it("sets pending to true when request pending", async () => {
+    const composable = useTokenHolders(tokenAddress);
+    const promise = composable.load(1);
+
+    expect(composable.pending.value).toEqual(true);
+    await promise;
+  });
+
+  it("sets pending to false when request completed", async () => {
+    const composable = useTokenHolders(tokenAddress);
+    await composable.load(1);
+
+    expect(composable.pending.value).toEqual(false);
+  });
+
+  it("sets failed to false when request completed", async () => {
+    const composable = useTokenHolders(tokenAddress);
+    await composable.load(1);
+
+    expect(composable.failed.value).toEqual(false);
+  });
+
+  it("sets failed to true when request failed", async () => {
+    const composable = useTokenHolders(tokenAddress);
+    const mock = ($fetch as any).mockRejectedValue(new Error());
+
+    await composable.load(1);
+
+    expect(composable.failed.value).toEqual(true);
+    mock.mockRestore();
+  });
+
+  it("sets batches to null when request failed", async () => {
+    const composable = useTokenHolders(tokenAddress);
+    const mock = ($fetch as any).mockRejectedValue(new Error());
+
+    await composable.load(1);
+
+    expect(composable.data.value).toEqual(null);
+    mock.mockRestore();
+  });
+});

--- a/packages/app/tests/e2e/testId.json
+++ b/packages/app/tests/e2e/testId.json
@@ -27,10 +27,15 @@
   "latestTransactionsTable": "latest-transaction-table",
   "latestBatchesTable": "latest-batches-table",
   "tokensTable": "tokens-table",
+  "tokensHoldersTable": "tokens-holders-table",
   "toAddress": "to-address",
   "transferType": "transfer-type",
   "transferFromOrigin": "transfer-from-origin",
   "transferToOrigin": "transfer-to-origin",
   "transferFromOriginTablet": "transfer-from-origin-tablet",
-  "transferToOriginTablet": "transfer-to-origin-tablet"
+  "transferToOriginTablet": "transfer-to-origin-tablet",
+  "tokenHoldersAddress": "token-holders-address",
+  "tokenHoldersBalance": "token-holders-balance",
+  "tokenHoldersPercentage": "token-holders-percentage",
+  "tokenHoldersValue": "token-holders-value"
 }

--- a/packages/app/tests/mocks.ts
+++ b/packages/app/tests/mocks.ts
@@ -10,6 +10,7 @@ import * as useContext from "@/composables/useContext";
 import * as useContractEvents from "@/composables/useContractEvents";
 import * as useContractInteractionFactory from "@/composables/useContractInteraction";
 import * as useTokenFactory from "@/composables/useToken";
+import * as useTokenHolders from "@/composables/useTokenHolders";
 import * as useTokenLibraryMockFactory from "@/composables/useTokenLibrary";
 import * as useTransaction from "@/composables/useTransaction";
 import * as useTransactions from "@/composables/useTransactions";
@@ -193,4 +194,18 @@ export const useContextMock = (params: any = {}) => {
   });
 
   return mockContextConfig;
+};
+
+export const useTokenHoldersMock = (params: any = {}) => {
+  const mockBlocks = vi.spyOn(useTokenHolders, "default").mockReturnValue({
+    data: ref([]),
+    total: ref(0),
+    load: () => vi.fn(),
+    pending: ref(false),
+    failed: ref(false),
+    page: ref(1),
+    pageSize: ref(10),
+    ...params,
+  });
+  return mockBlocks;
 };


### PR DESCRIPTION
# What ❔

This pull request introduces a new feature that generates a detailed token holder page, where users can view all token holders along with their respective balances. In addition to the balance, the page will display the percentage of the total token supply held by each address and provide the equivalent USD value of their holdings

## Why ❔
To have similar detailed analytics provided on the Etherscan.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [+] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [+] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
