### PR TITLE
docs: add custom base token config docs for worker

### DIFF
--- a/.github/workflows/app-e2e.yml
+++ b/.github/workflows/app-e2e.yml
@@ -120,7 +120,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: allure-results
+          name: ${{ matrix.tags }}-allure-results
           path: packages/app/allure-results
 
       # - name: Upload test results to Allure reporter
@@ -136,7 +136,7 @@ jobs:
         name: Save artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: portal_e2e_${{ github.run_number }}_artifacts
+          name: portal_e2e_${{ github.run_number }}_${{ matrix.tags }}_artifacts
           path: packages/app/tests/e2e/artifacts/*
 
   # publish:

--- a/.github/workflows/app-e2e.yml
+++ b/.github/workflows/app-e2e.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Save artifacts to Git
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: allure-results
           path: packages/app/allure-results
@@ -134,7 +134,7 @@ jobs:
 
       - if: failure()
         name: Save artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: portal_e2e_${{ github.run_number }}_artifacts
           path: packages/app/tests/e2e/artifacts/*

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ npm install
 ### Manually set up env variables
 Make sure you have set up all the necessary env variables. Follow setting up env variables instructions for [Worker](./packages/worker#setting-up-env-variables), [Data Fetcher](./packages/data-fetcher#setting-up-env-variables) and [API](./packages/api#setting-up-env-variables). For the [App](./packages/app) package you might want to edit environment config, see [Environment configs](./packages/app#environment-configs).
 
+### Configure custom base token
+For networks with a custom base token, make sure to configure the base token for both Worker and API services by following the corresponding instructions [here](./packages/worker/README.md#custom-base-token-configuration) and [here](./packages/api/README.md#custom-base-token-configuration).
+
 ### Build env variables based on your [zksync-era](https://github.com/matter-labs/zksync-era) local repo setup
 Make sure you have [zksync-era](https://github.com/matter-labs/zksync-era) repo set up locally. You must have your environment variables files present in the [zksync-era](https://github.com/matter-labs/zksync-era) repo at `/etc/env/*.env` for the build envs script to work.
 

--- a/packages/worker/README.md
+++ b/packages/worker/README.md
@@ -31,6 +31,36 @@ The service doesn't create database automatically, you can create database by ru
 $ npm run db:create
 ```
 
+## Custom base token configuration
+For networks with a custom base token, there are a number of environment variables used to configure custom base token:
+- `BASE_TOKEN_L1_ADDRESS` - example: `0xB44A106F271944fEc1c27cd60b8D6C8792df86d8`. Base token L1 address can be fetched using the RPC call:
+  ```
+  curl http://localhost:3050 \
+  -X POST \
+  -H "Content-Type: application/json" \
+  --data '{"method":"zks_getBaseTokenL1Address","params":[],"id":1,"jsonrpc":"2.0"}'
+  ```
+  or SDK:
+  ```
+  import { Provider } from "zksync-ethers";
+
+  async function main() {
+      const l2provider = new Provider("http://localhost:3050");
+      const baseTokenAddress = await l2provider.getBaseTokenContractAddress();
+      console.log('baseTokenAddress', baseTokenAddress);
+  }
+  main()
+      .then()
+      .catch((error) => {
+          console.error(error);
+          process.exitCode = 1;
+      });
+  ```
+- `BASE_TOKEN_SYMBOL` - base token symbol, e.g.: `ZK`
+- `BASE_TOKEN_NAME` - base token name, e.g.: `ZK`
+- `BASE_TOKEN_DECIMALS` - base token decimals, e.g.: `18`
+- `BASE_TOKEN_ICON_URL` - base token icon url, e.g.: `https://assets.coingecko.com/coins/images/279/large/ethereum.png?1698873266`
+
 ## Running the app
 
 ```bash


### PR DESCRIPTION
# What ❔

Add docs for custom base token configuration for the worker service.

## Why ❔

Base token configuration has been recently added to the worker service and it should be reflected in the docs.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Documentation comments have been added / updated.
