### PR TITLE
fix: fix indexing of evm equiv chains

### DIFF
--- a/packages/data-fetcher/src/token/token.service.ts
+++ b/packages/data-fetcher/src/token/token.service.ts
@@ -74,6 +74,7 @@ export class TokenService {
 
     const bridgeLog =
       transactionReceipt &&
+      transactionReceipt.to &&
       transactionReceipt.to.toLowerCase() === this.blockchainService.bridgeAddresses.l2Erc20DefaultBridge &&
       transactionReceipt.logs?.find(
         (log) =>


### PR DESCRIPTION
On evm equiv chains, `to` can be null so we must check for it.
Without this fix, a chain cannot be indexed.