### PR TITLE
feat: fix paging component alignment on blocks view page

### DIFF
--- a/packages/app/src/views/BlocksView.vue
+++ b/packages/app/src/views/BlocksView.vue
@@ -18,9 +18,7 @@
         :blocks="data ?? []"
       >
         <template v-if="page && total && total > pageSize" #footer>
-          <div class="flex justify-center p-3">
-            <Pagination :active-page="page!" :total-items="total!" :page-size="pageSize" :disabled="pending" />
-          </div>
+          <Pagination :active-page="page!" :total-items="total!" :page-size="pageSize" :disabled="pending" />
         </template>
       </TableBlocks>
     </div>


### PR DESCRIPTION
# What ❔

The pagination component had both the dropdown and pagination stacked one under another.
Removing the parent wrapper fixed the alignment.


This PR fixes https://github.com/matter-labs/block-explorer/issues/386