### PR TITLE
fix: ctor args param compatibility with etherscan

### DIFF
--- a/packages/api/src/api/contract/contract.controller.spec.ts
+++ b/packages/api/src/api/contract/contract.controller.spec.ts
@@ -316,6 +316,64 @@ describe("ContractController", () => {
       });
     });
 
+    it("sends proper payload to the verification endpoint when constructor args field is not specified", async () => {
+      request = {
+        ...request,
+        sourceCode: "// SPDX-License-Identifier: UNLICENSED",
+        codeformat: ContractVerificationCodeFormatEnum.soliditySingleFile,
+        constructorArguements: undefined,
+      } as unknown as VerifyContractRequestDto;
+
+      pipeMock.mockReturnValue(
+        new rxjs.Observable((subscriber) => {
+          subscriber.next({
+            data: 1234,
+          });
+        })
+      );
+
+      await controller.verifySourceContract(request.contractaddress, request);
+      expect(httpServiceMock.post).toBeCalledWith(`http://verification.api/contract_verification`, {
+        codeFormat: "solidity-single-file",
+        compilerSolcVersion: "0.8.17",
+        compilerZksolcVersion: "v1.3.14",
+        constructorArguments: undefined,
+        contractAddress: "0x14174c76E073f8efEf5C1FE0dd0f8c2Ca9F21e62",
+        contractName: "contracts/HelloWorld.sol:HelloWorld",
+        optimizationUsed: true,
+        sourceCode: "// SPDX-License-Identifier: UNLICENSED",
+      });
+    });
+
+    it("sends proper payload to the verification endpoint when constructor args field doesn't have a leading 0x", async () => {
+      request = {
+        ...request,
+        sourceCode: "// SPDX-License-Identifier: UNLICENSED",
+        codeformat: ContractVerificationCodeFormatEnum.soliditySingleFile,
+        constructorArguements: "123",
+      } as unknown as VerifyContractRequestDto;
+
+      pipeMock.mockReturnValue(
+        new rxjs.Observable((subscriber) => {
+          subscriber.next({
+            data: 1234,
+          });
+        })
+      );
+
+      await controller.verifySourceContract(request.contractaddress, request);
+      expect(httpServiceMock.post).toBeCalledWith(`http://verification.api/contract_verification`, {
+        codeFormat: "solidity-single-file",
+        compilerSolcVersion: "0.8.17",
+        compilerZksolcVersion: "v1.3.14",
+        constructorArguments: "0x123",
+        contractAddress: "0x14174c76E073f8efEf5C1FE0dd0f8c2Ca9F21e62",
+        contractName: "contracts/HelloWorld.sol:HelloWorld",
+        optimizationUsed: true,
+        sourceCode: "// SPDX-License-Identifier: UNLICENSED",
+      });
+    });
+
     it("sends proper payload to the verification endpoint for multi file solidity contract", async () => {
       pipeMock.mockReturnValue(
         new rxjs.Observable((subscriber) => {

--- a/packages/api/src/api/contract/contract.controller.ts
+++ b/packages/api/src/api/contract/contract.controller.ts
@@ -144,6 +144,10 @@ export class ContractController {
       }
     }
 
+    if (request.constructorArguements != null && !request.constructorArguements.startsWith("0x")) {
+      request.constructorArguements = `0x${request.constructorArguements}`;
+    }
+
     if (isSolidityContract && request.sourceCode instanceof Object) {
       const libraries: { [key: string]: Record<string, string> } = {};
       for (let i = 1; i <= 10; i++) {


### PR DESCRIPTION
# What ❔

In the verification request, add 0x to the ctor arguments if it's missing.

## Why ❔

To make verification endpoint compatible with Etherscan.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
