### PR TITLE
fix: improve compilation info view

### DIFF
--- a/packages/app/src/components/contract/CodeBlock.vue
+++ b/packages/app/src/components/contract/CodeBlock.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="code-block-container">
     <div class="code-block-header">
-      <div class="code-block-label">{{ label }}</div>
+      <div :class="['code-block-label', { bold: labelBold }]">{{ label }}</div>
       <div class="code-block-buttons">
         <CopyButton :value="code" />
         <button class="expand-button" @click="expanded = !expanded">
@@ -27,6 +27,10 @@ defineProps({
     type: String,
     required: true,
   },
+  labelBold: {
+    type: Boolean,
+    default: false,
+  },
   code: {
     type: String,
     required: true,
@@ -43,6 +47,10 @@ const expanded = ref(false);
 
     .code-block-label {
       @apply text-left text-sm;
+
+      &.bold {
+        @apply text-sm font-bold text-neutral-700;
+      }
     }
     .code-block-buttons {
       @apply flex items-center gap-1;

--- a/packages/app/src/components/contract/CompilationInfo.vue
+++ b/packages/app/src/components/contract/CompilationInfo.vue
@@ -33,7 +33,7 @@
         {{ t("contractVerification.compilationInfo.evmVersion") }}
       </p>
       <p class="text">
-        {{ verificationRequest.evmVersion }}
+        {{ verificationRequest?.evmVersion }}
       </p>
     </div>
     <div v-else>

--- a/packages/app/src/components/contract/CompilationInfo.vue
+++ b/packages/app/src/components/contract/CompilationInfo.vue
@@ -28,7 +28,15 @@
       <p class="label">{{ t("contractVerification.compilationInfo.compilerVersion") }}</p>
       <p class="text">{{ verificationRequest?.compilerSolcVersion || verificationRequest?.compilerVyperVersion }}</p>
     </div>
-    <div>
+    <div v-if="contract.isEvmLike">
+      <p class="label">
+        {{ t("contractVerification.compilationInfo.evmVersion") }}
+      </p>
+      <p class="text">
+        {{ verificationRequest.evmVersion }}
+      </p>
+    </div>
+    <div v-else>
       <p class="label">
         {{
           verificationRequest?.compilerVyperVersion
@@ -41,8 +49,25 @@
       </p>
     </div>
     <div>
-      <p class="label">{{ t("contractVerification.compilationInfo.optimization") }}</p>
-      <p class="text">{{ optimization }}</p>
+      <p class="label">{{ t("contractVerification.compilationInfo.optimization.title") }}</p>
+      <p class="text" v-if="optimizationInfo.enabled">
+        <span>{{ t("contractVerification.compilationInfo.optimization.enabled") }}</span>
+        <span v-if="optimizationInfo.runs">
+          {{
+            t("contractVerification.compilationInfo.optimization.runsTemplate", {
+              runs: optimizationInfo.runs,
+            })
+          }}
+        </span>
+        <span v-if="optimizationInfo.mode">
+          {{
+            t("contractVerification.compilationInfo.optimization.modeTemplate", {
+              mode: optimizationInfo.mode,
+            })
+          }}
+        </span>
+      </p>
+      <p class="text" v-else>{{ t("contractVerification.compilationInfo.optimization.disabled") }}</p>
     </div>
   </div>
 </template>
@@ -62,6 +87,11 @@ import { shortValue } from "@/utils/formatters";
 
 const { t } = useI18n();
 
+type OptimizationInfo = {
+  enabled: boolean;
+  runs?: number;
+  mode?: string;
+};
 const props = defineProps({
   contract: {
     type: Object as PropType<Contract>,
@@ -70,7 +100,34 @@ const props = defineProps({
   },
 });
 const verificationRequest = computed(() => props.contract.verificationInfo?.request);
-const optimization = computed(() => (props.contract.verificationInfo?.request.optimizationUsed ? "Yes" : "No"));
+const optimizationInfo = computed(() => {
+  let optimizationInfo: OptimizationInfo = {
+    enabled: false,
+  };
+  if (typeof props.contract.verificationInfo?.request?.sourceCode === "string") {
+    const {
+      optimizationUsed: enabled,
+      optimizerRuns: runs,
+      optimizerMode: mode,
+    } = props.contract.verificationInfo.request;
+    optimizationInfo = {
+      enabled,
+      runs,
+      mode,
+    };
+  } else if (
+    typeof props.contract.verificationInfo?.request?.sourceCode?.settings === "object" &&
+    props.contract.verificationInfo?.request?.sourceCode?.settings?.optimizer
+  ) {
+    const { enabled, runs, mode } = props.contract.verificationInfo.request.sourceCode.settings.optimizer;
+    optimizationInfo = {
+      enabled,
+      runs,
+      mode,
+    };
+  }
+  return optimizationInfo;
+});
 const contractName = computed(() => props.contract.verificationInfo?.request.contractName.replace(/.*\.(sol|vy):/, ""));
 // If address of the contract doesn't match address in the request, the contract was verified "automatically".
 const autoVerified = computed(

--- a/packages/app/src/components/contract/ContractBytecode.vue
+++ b/packages/app/src/components/contract/ContractBytecode.vue
@@ -20,6 +20,9 @@
         <div class="info-field-label">{{ t("contract.sourceCode.label") }}</div>
         <CodeBlock v-for="(item, index) in sourceCode" :key="index" :code="item.code" :label="item.label" />
       </div>
+      <div v-if="settings" class="source-code-container">
+        <CodeBlock :code="settings" :label="t('contract.settings.label')" :label-bold="true" />
+      </div>
       <div v-if="sourceCode" class="abi-json-field-container">
         <div class="info-field-label">{{ t("contract.abiInteraction.contractAbi") }}</div>
         <div class="abi-json">
@@ -59,6 +62,13 @@ const props = defineProps({
 
 const { t } = useI18n();
 
+const settings = computed(() => {
+  const sourceCode = props.contract?.verificationInfo?.request?.sourceCode;
+  if (typeof sourceCode === "object" && typeof sourceCode.settings === "object" && sourceCode.settings) {
+    return JSON.stringify(sourceCode.settings, null, 4);
+  }
+  return undefined;
+});
 const sourceCode = computed<undefined | { code: string; label: string }[]>(() => {
   if (!props.contract?.verificationInfo) {
     return undefined;

--- a/packages/app/src/composables/useAddress.ts
+++ b/packages/app/src/composables/useAddress.ts
@@ -50,6 +50,8 @@ type ContractVerificationRequest = {
         settings: {
           optimizer: {
             enabled: boolean;
+            runs?: number;
+            mode?: string;
           };
         };
         sources: {
@@ -60,6 +62,9 @@ type ContractVerificationRequest = {
       }
     | Record<string, string>;
   optimizationUsed: boolean;
+  evmVersion?: string;
+  optimizerRuns?: number;
+  optimizerMode?: string;
 };
 
 export const VERIFICATION_PROBLEM_INCORRECT_METADATA = "incorrectMetadata";

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -372,6 +372,9 @@
             "singleFileContract": "Single file contract",
             "fileLabel": "File {index} of {total}: {fileName}"
         },
+        "settings": {
+            "label": "Settings"
+        },
         "events": {
             "txnHash": "txn hash",
             "method": "method",
@@ -563,7 +566,14 @@
             "compilerVersion": "Compiler Version",
             "zksolcVersion": "Zksolc Version",
             "zkvyperVersion": "Zkvyper Version",
-            "optimization": "Optimization",
+            "evmVersion": "EVM Version",
+            "optimization": {
+                "title": "Optimization",
+                "enabled": "Yes",
+                "disabled": "No",
+                "runsTemplate": ", with {runs} runs",
+                "modeTemplate": ", with mode {mode}"
+            },
             "autoVerified": "The contract wasn't manually verified, but its bytecode matches the bytecode of the following contract:",
             "partialVerification": "Contract is partially verified: the contract metadata hash and/or constructor arguments do not match. Partial verification provides less guarantees about the authenticity of the code.",
             "partialVerificationDetails": "See more details"

--- a/packages/app/tests/components/contract/CodeBlock.spec.ts
+++ b/packages/app/tests/components/contract/CodeBlock.spec.ts
@@ -35,4 +35,19 @@ describe("CodeBlock", () => {
     await wrapper.find(".expand-button").trigger("click");
     expect(wrapper.findComponent(SolidityEditor).props().expanded).toBe(true);
   });
+  it("renders bold label", () => {
+    const wrapper = mount(CodeBlock, {
+      global: {
+        stubs: ["CopyButton"],
+      },
+      props: {
+        label: "Test label",
+        code: "some code",
+        labelBold: true,
+      },
+    });
+    expect(wrapper.find(".code-block-label.bold").text()).toBe("Test label");
+    expect(wrapper.findComponent(SolidityEditor).props().modelValue).toBe("some code");
+    expect(wrapper.findComponent(CopyButton).props().value).toBe("some code");
+  });
 });

--- a/packages/app/tests/components/contract/CompilationInfo.spec.ts
+++ b/packages/app/tests/components/contract/CompilationInfo.spec.ts
@@ -37,6 +37,37 @@ describe("CompilationInfo", () => {
     expect(container.querySelectorAll(".label")[3].textContent).toEqual("Optimization");
     expect(container.querySelectorAll(".text")[3].textContent).toEqual("Yes");
   });
+  it("renders component properly for evm compilation", async () => {
+    const { container } = render(CompilationInfo, {
+      props: {
+        contract: {
+          ...ERC20Contract.info,
+          verificationInfo: {
+            ...ERC20Contract.info.verificationInfo,
+            request: {
+              ...ERC20Contract.info.verificationInfo.request,
+              optimizationUsed: true,
+              optimizerRuns: 200,
+              evmVersion: "london",
+            },
+          },
+          isEvmLike: true,
+        },
+      },
+      global: {
+        plugins: [i18n],
+      },
+    });
+
+    expect(container.querySelectorAll(".label")[0].textContent).toEqual("Contract Name");
+    expect(container.querySelectorAll(".text")[0].textContent).toEqual("DARA2");
+    expect(container.querySelectorAll(".label")[1].textContent).toEqual("Compiler Version");
+    expect(container.querySelectorAll(".text")[1].textContent).toEqual("0.8.16");
+    expect(container.querySelectorAll(".label")[2].textContent).toEqual("EVM Version");
+    expect(container.querySelectorAll(".text")[2].textContent).toEqual("london");
+    expect(container.querySelectorAll(".label")[3].textContent).toEqual("Optimization");
+    expect(container.querySelectorAll(".text")[3].textContent).toEqual("Yes, with 200 runs");
+  });
   it("renders Optimization 'no' if optimizationUsed value is false", async () => {
     const { container } = render(CompilationInfo, {
       props: {
@@ -56,5 +87,69 @@ describe("CompilationInfo", () => {
       },
     });
     expect(container.querySelectorAll(".text")[3].textContent).toEqual("No");
+  });
+  it("renders optimizer runs", async () => {
+    const { container } = render(CompilationInfo, {
+      props: {
+        contract: {
+          ...ERC20Contract.info,
+          verificationInfo: {
+            ...ERC20Contract.info.verificationInfo,
+            request: {
+              ...ERC20Contract.info.verificationInfo.request,
+              optimizationUsed: true,
+              optimizerRuns: 200,
+            },
+          },
+        },
+      },
+      global: {
+        plugins: [i18n],
+      },
+    });
+    expect(container.querySelectorAll(".text")[3].textContent).toEqual("Yes, with 200 runs");
+  });
+  it("renders optimizer mode", async () => {
+    const { container } = render(CompilationInfo, {
+      props: {
+        contract: {
+          ...ERC20Contract.info,
+          verificationInfo: {
+            ...ERC20Contract.info.verificationInfo,
+            request: {
+              ...ERC20Contract.info.verificationInfo.request,
+              optimizationUsed: true,
+              optimizerMode: "3",
+            },
+          },
+        },
+      },
+      global: {
+        plugins: [i18n],
+      },
+    });
+    expect(container.querySelectorAll(".text")[3].textContent).toEqual("Yes, with mode 3");
+  });
+  it("renders both optimizer runs and mode", async () => {
+    const { container } = render(CompilationInfo, {
+      props: {
+        contract: {
+          ...ERC20Contract.info,
+          verificationInfo: {
+            ...ERC20Contract.info.verificationInfo,
+            request: {
+              ...ERC20Contract.info.verificationInfo.request,
+              optimizationUsed: true,
+              optimizerRuns: 200,
+              optimizerMode: "3",
+            },
+          },
+        },
+      },
+      global: {
+        plugins: [i18n],
+      },
+    });
+    expect(container.querySelectorAll(".text")[3].textContent).toEqual("Yes, with 200 runs, with mode 3");
   });
 });

--- a/packages/app/tests/components/contract/ContractBytecode.spec.ts
+++ b/packages/app/tests/components/contract/ContractBytecode.spec.ts
@@ -194,7 +194,7 @@ describe("ContractBytecode", () => {
       },
     });
     const codeBlocks = wrapper.findAllComponents(CodeBlock);
-    expect(codeBlocks.length).toBe(2);
+    expect(codeBlocks.length).toBe(3);
     expect(codeBlocks[0].props().label).toBe("File 1 of 2: ERC20.sol");
     expect(codeBlocks[0].props().code).toBe(
       verifiedContractSources["@openzeppelin/contracts/token/ERC20/ERC20.sol"].content
@@ -202,6 +202,18 @@ describe("ContractBytecode", () => {
     expect(codeBlocks[1].props().label).toBe("File 2 of 2: IERC20.sol");
     expect(codeBlocks[1].props().code).toBe(
       verifiedContractSources["@openzeppelin/contracts/token/ERC20/IERC20.sol"].content
+    );
+    expect(codeBlocks[2].props().label).toBe("Settings");
+    expect(codeBlocks[2].props().code).toBe(
+      JSON.stringify(
+        {
+          optimizer: {
+            enabled: true,
+          },
+        },
+        null,
+        4
+      )
     );
   });
 


### PR DESCRIPTION
# What ❔

Improvements for the compilation info view:
1. Optimization field shows number of optimizer runs and optimizer mode if available (like Etherscan does):
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/c58cca23-03f6-4832-8b2a-9fe8309adb88" />
2. For EVM contracts EVM Version is shown instead of Zksolc version field:
<img width="1265" alt="image" src="https://github.com/user-attachments/assets/abd3cd6f-1fda-436c-8950-7065f72f0c17" />
3. Compilation settings are shown below the source code (like in Etherscan). The field is copyable and expandable (like other source code fields):
<img width="1263" alt="image" src="https://github.com/user-attachments/assets/8997b5dd-63d1-4368-9e62-34c802a966c8" />


## Why ❔

To improve the UX and provide more information for the verified contracts.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.