### PR TITLE
fix: show full solc compiler version

### DIFF
--- a/packages/app/src/composables/useAddress.ts
+++ b/packages/app/src/composables/useAddress.ts
@@ -7,6 +7,7 @@ import useContext from "./useContext";
 
 import { PROXY_CONTRACT_IMPLEMENTATION_ABI } from "@/utils/constants";
 import { numberToHexString } from "@/utils/formatters";
+import { getSolcFullVersion } from "@/utils/solcFullVersions";
 
 const oneBigInt = BigInt(1);
 const EIP1967_PROXY_IMPLEMENTATION_SLOT = numberToHexString(
@@ -104,7 +105,15 @@ export default (context = useContext()) => {
       return null;
     }
     try {
-      return await $fetch(`${context.currentNetwork.value.verificationApiUrl}/contract_verification/info/${address}`);
+      const verificationInfo = await $fetch<ContractVerificationInfo>(
+        `${context.currentNetwork.value.verificationApiUrl}/contract_verification/info/${address}`
+      );
+      if (verificationInfo?.request?.compilerSolcVersion) {
+        verificationInfo.request.compilerSolcVersion = await getSolcFullVersion(
+          verificationInfo.request.compilerSolcVersion
+        );
+      }
+      return verificationInfo;
     } catch (e) {
       if (!(e instanceof FetchError) || e.response?.status !== 404) {
         throw e;

--- a/packages/app/src/utils/solcFullVersions.ts
+++ b/packages/app/src/utils/solcFullVersions.ts
@@ -1,0 +1,132 @@
+import { $fetch } from "ohmyfetch";
+
+// Hardcoded solc full versions to be used as a fallback
+const SOLC_FULL_VERSIONS: Record<string, string> = {
+  "0.4.10": "v0.4.10+commit.f0d539ae",
+  "0.4.11": "v0.4.11+commit.68ef5810",
+  "0.4.12": "v0.4.12+commit.194ff033",
+  "0.4.13": "v0.4.13+commit.0fb4cb1a",
+  "0.4.14": "v0.4.14+commit.c2215d46",
+  "0.4.15": "v0.4.15+commit.8b45bddb",
+  "0.4.16": "v0.4.16+commit.d7661dd9",
+  "0.4.17": "v0.4.17+commit.bdeb9e52",
+  "0.4.18": "v0.4.18+commit.9cf6e910",
+  "0.4.19": "v0.4.19+commit.c4cbbb05",
+  "0.4.20": "v0.4.20+commit.3155dd80",
+  "0.4.21": "v0.4.21+commit.dfe3193c",
+  "0.4.22": "v0.4.22+commit.4cb486ee",
+  "0.4.23": "v0.4.23+commit.124ca40d",
+  "0.4.24": "v0.4.24+commit.e67f0147",
+  "0.4.25": "v0.4.25+commit.59dbf8f1",
+  "0.4.26": "v0.4.26+commit.4563c3fc",
+  "0.5.0": "v0.5.0+commit.1d4f565a",
+  "0.5.1": "v0.5.1+commit.c8a2cb62",
+  "0.5.2": "v0.5.2+commit.1df8f40c",
+  "0.5.3": "v0.5.3+commit.10d17f24",
+  "0.5.4": "v0.5.4+commit.9549d8ff",
+  "0.5.5": "v0.5.5+commit.47a71e8f",
+  "0.5.6": "v0.5.6+commit.b259423e",
+  "0.5.7": "v0.5.7+commit.6da8b019",
+  "0.5.8": "v0.5.8+commit.23d335f2",
+  "0.5.9": "v0.5.9+commit.c68bc34e",
+  "0.5.10": "v0.5.10+commit.5a6ea5b1",
+  "0.5.11": "v0.5.11+commit.22be8592",
+  "0.5.12": "v0.5.12+commit.7709ece9",
+  "0.5.13": "v0.5.13+commit.5b0b510c",
+  "0.5.14": "v0.5.14+commit.01f1aaa4",
+  "0.5.15": "v0.5.15+commit.6a57276f",
+  "0.5.16": "v0.5.16+commit.9c3226ce",
+  "0.5.17": "v0.5.17+commit.d19bba13",
+  "0.6.0": "v0.6.0+commit.26b70077",
+  "0.6.1": "v0.6.1+commit.e6f7d5a4",
+  "0.6.2": "v0.6.2+commit.bacdbe57",
+  "0.6.3": "v0.6.3+commit.8dda9521",
+  "0.6.4": "v0.6.4+commit.1dca32f3",
+  "0.6.5": "v0.6.5+commit.f956cc89",
+  "0.6.6": "v0.6.6+commit.6c089d02",
+  "0.6.7": "v0.6.7+commit.b8d736ae",
+  "0.6.8": "v0.6.8+commit.0bbfe453",
+  "0.6.9": "v0.6.9+commit.3e3065ac",
+  "0.6.10": "v0.6.10+commit.00c0fcaf",
+  "0.6.11": "v0.6.11+commit.5ef660b1",
+  "0.6.12": "v0.6.12+commit.27d51765",
+  "0.7.0": "v0.7.0+commit.9e61f92b",
+  "0.7.1": "v0.7.1+commit.f4a555be",
+  "0.7.2": "v0.7.2+commit.51b20bc0",
+  "0.7.3": "v0.7.3+commit.9bfce1f6",
+  "0.7.4": "v0.7.4+commit.3f05b770",
+  "0.7.5": "v0.7.5+commit.eb77ed08",
+  "0.7.6": "v0.7.6+commit.7338295f",
+  "0.8.0": "v0.8.0+commit.c7dfd78e",
+  "0.8.1": "v0.8.1+commit.df193b15",
+  "0.8.2": "v0.8.2+commit.661d1103",
+  "0.8.3": "v0.8.3+commit.8d00100c",
+  "0.8.4": "v0.8.4+commit.c7e474f2",
+  "0.8.5": "v0.8.5+commit.a4f2e591",
+  "0.8.6": "v0.8.6+commit.11564f7e",
+  "0.8.7": "v0.8.7+commit.e28d00a7",
+  "0.8.8": "v0.8.8+commit.dddeac2f",
+  "0.8.9": "v0.8.9+commit.e5eed63a",
+  "0.8.10": "v0.8.10+commit.fc410830",
+  "0.8.11": "v0.8.11+commit.d7f03943",
+  "0.8.12": "v0.8.12+commit.f00d7308",
+  "0.8.13": "v0.8.13+commit.abaa5c0e",
+  "0.8.14": "v0.8.14+commit.80d49f37",
+  "0.8.15": "v0.8.15+commit.e14f2714",
+  "0.8.16": "v0.8.16+commit.07a7930e",
+  "0.8.17": "v0.8.17+commit.8df45f5f",
+  "0.8.18": "v0.8.18+commit.87f61d96",
+  "0.8.19": "v0.8.19+commit.7dd6d404",
+  "0.8.20": "v0.8.20+commit.a1b79de6",
+  "0.8.21": "v0.8.21+commit.d9974bed",
+  "0.8.22": "v0.8.22+commit.4fc1097e",
+  "0.8.23": "v0.8.23+commit.f704f362",
+  "0.8.24": "v0.8.24+commit.e11b9ed9",
+  "0.8.25": "v0.8.25+commit.b61c2a91",
+  "0.8.26": "v0.8.26+commit.8a97fa7a",
+  "0.8.27": "v0.8.27+commit.40a35a09",
+  "0.8.28": "v0.8.28+commit.7893614a",
+  "0.8.29": "v0.8.29+commit.ab55807c",
+};
+
+type SolcBuild = {
+  prerelease: string;
+  version: string;
+  longVersion: string;
+};
+
+export function getSolcShortVersion(fullVersion: string): string {
+  let shortVersion = fullVersion;
+  if (shortVersion.startsWith("v")) {
+    shortVersion = shortVersion.substring(1);
+  }
+  return shortVersion.split("+")[0];
+}
+
+export async function getSolcFullVersion(version: string): Promise<string> {
+  // return zkVM version as is
+  if (version.startsWith("zkVM")) {
+    return version;
+  }
+  const fullSolcVersion = SOLC_FULL_VERSIONS[version];
+  if (!fullSolcVersion) {
+    await initSolcFullVersions();
+  }
+  return SOLC_FULL_VERSIONS[version] || version;
+}
+
+async function initSolcFullVersions(): Promise<void> {
+  try {
+    const solcBuilds = await $fetch<{ builds: SolcBuild[] }>(
+      "https://raw.githubusercontent.com/ethereum/solc-bin/refs/heads/gh-pages/bin/list.json",
+      { parseResponse: JSON.parse }
+    );
+    solcBuilds?.builds
+      .filter((build) => !build.prerelease)
+      .forEach((build) => {
+        SOLC_FULL_VERSIONS[build.version] = `v${build.longVersion}`;
+      });
+  } catch (error) {
+    console.error("Error fetching solc full versions:", error);
+  }
+}

--- a/packages/app/tests/composables/useAddress.spec.ts
+++ b/packages/app/tests/composables/useAddress.spec.ts
@@ -12,6 +12,9 @@ vi.mock("ohmyfetch", () => {
       if (url.includes("contract_verification")) {
         return {
           artifacts: { abi: "abi" },
+          request: {
+            compilerSolcVersion: "0.8.0",
+          },
         };
       }
       return {
@@ -47,6 +50,12 @@ vi.mock("@/composables/useContext", () => {
         getStorage: (slot: string) => mockGetStorage(slot),
       }),
     }),
+  };
+});
+
+vi.mock("@/utils/solcFullVersions", () => {
+  return {
+    getSolcFullVersion: vi.fn().mockImplementation(async (v) => `full-${v}`),
   };
 });
 
@@ -101,12 +110,18 @@ describe("useAddresses", () => {
         type: "contract",
         verificationInfo: {
           artifacts: { abi: "abi" },
+          request: {
+            compilerSolcVersion: "full-0.8.0",
+          },
         },
         proxyInfo: {
           implementation: {
             address: "0xc31f9d4cbf557b6cf0ad2af66d44c358f7fa7a10",
             verificationInfo: {
               artifacts: { abi: "abi" },
+              request: {
+                compilerSolcVersion: "full-0.8.0",
+              },
             },
           },
         },
@@ -140,12 +155,18 @@ describe("useAddresses", () => {
         type: "contract",
         verificationInfo: {
           artifacts: { abi: "abi" },
+          request: {
+            compilerSolcVersion: "full-0.8.0",
+          },
         },
         proxyInfo: {
           implementation: {
             address: "0xc31f9d4cbf557b6cf0ad2af66d44c358f7fa7a10",
             verificationInfo: {
               artifacts: { abi: "abi" },
+              request: {
+                compilerSolcVersion: "full-0.8.0",
+              },
             },
           },
         },
@@ -170,12 +191,18 @@ describe("useAddresses", () => {
           type: "contract",
           verificationInfo: {
             artifacts: { abi: "abi" },
+            request: {
+              compilerSolcVersion: "full-0.8.0",
+            },
           },
           proxyInfo: {
             implementation: {
               address: "0xc31f9d4cbf557b6cf0ad2af66d44c358f7fa7a12",
               verificationInfo: {
                 artifacts: { abi: "abi" },
+                request: {
+                  compilerSolcVersion: "full-0.8.0",
+                },
               },
             },
           },
@@ -199,12 +226,18 @@ describe("useAddresses", () => {
           type: "contract",
           verificationInfo: {
             artifacts: { abi: "abi" },
+            request: {
+              compilerSolcVersion: "full-0.8.0",
+            },
           },
           proxyInfo: {
             implementation: {
               address: "0xc31f9d4cbf557b6cf0ad2af66d44c358f7fa7a13",
               verificationInfo: {
                 artifacts: { abi: "abi" },
+                request: {
+                  compilerSolcVersion: "full-0.8.0",
+                },
               },
             },
           },
@@ -229,12 +262,18 @@ describe("useAddresses", () => {
           type: "contract",
           verificationInfo: {
             artifacts: { abi: "abi" },
+            request: {
+              compilerSolcVersion: "full-0.8.0",
+            },
           },
           proxyInfo: {
             implementation: {
               address: "0xc31f9d4cbf557b6cf0ad2af66d44c358f7fa7a14",
               verificationInfo: {
                 artifacts: { abi: "abi" },
+                request: {
+                  compilerSolcVersion: "full-0.8.0",
+                },
               },
             },
           },
@@ -258,6 +297,9 @@ describe("useAddresses", () => {
           type: "contract",
           verificationInfo: {
             artifacts: { abi: "abi" },
+            request: {
+              compilerSolcVersion: "full-0.8.0",
+            },
           },
           proxyInfo: null,
         });

--- a/packages/app/tests/composables/useContractVerification.spec.ts
+++ b/packages/app/tests/composables/useContractVerification.spec.ts
@@ -16,6 +16,13 @@ vi.mock("ohmyfetch", () => {
   };
 });
 
+vi.mock("@/utils/solcFullVersions", () => {
+  return {
+    getSolcFullVersion: vi.fn().mockImplementation(async (v) => `full-${v}`),
+    getSolcShortVersion: vi.fn().mockImplementation((v) => v),
+  };
+});
+
 describe("useContractVerification:", () => {
   it("creates useContractVerification composable", () => {
     const result = useContractVerification();
@@ -125,6 +132,20 @@ describe("useContractVerification:", () => {
       await requestCompilerVersions(CompilerEnum.zksolc);
 
       expect(compilerVersions.value.zksolc.versions).toEqual(["v1.1.4", "v1.1.3", "v1.1.2", "v1.1.0"]);
+      mock.mockRestore();
+    });
+    it("sets compiler versions to full compiler versions for solc compiler", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mock = ($fetch as any).mockResolvedValue(["v1.1.4", "v1.1.2", "v1.1.0", "v1.1.3"]);
+      const { compilerVersions, requestCompilerVersions } = useContractVerification();
+      await requestCompilerVersions(CompilerEnum.solc);
+
+      expect(compilerVersions.value.solc.versions).toEqual([
+        "full-v1.1.4",
+        "full-v1.1.3",
+        "full-v1.1.2",
+        "full-v1.1.0",
+      ]);
       mock.mockRestore();
     });
     it("sorts compiler versions starting from the latest version", async () => {

--- a/packages/app/tests/utils/solcFullVersions.spec.ts
+++ b/packages/app/tests/utils/solcFullVersions.spec.ts
@@ -35,6 +35,7 @@ describe("getSolcFullVersion", () => {
   });
 
   it("requests unknown solc version from the API", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mock = ($fetch as any).mockResolvedValueOnce({
       builds: [
         {
@@ -56,6 +57,7 @@ describe("getSolcFullVersion", () => {
   });
 
   it("returns version unchanged if the API call fails", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mock = ($fetch as any).mockRejectedValue(new Error("An error occurred"));
     expect(await getSolcFullVersion("0.9.1")).toBe("0.9.1");
     expect($fetch).toHaveBeenCalledTimes(1);

--- a/packages/app/tests/utils/solcFullVersions.spec.ts
+++ b/packages/app/tests/utils/solcFullVersions.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { $fetch } from "ohmyfetch";
+
+import { getSolcFullVersion, getSolcShortVersion } from "@/utils/solcFullVersions";
+
+vi.mock("ohmyfetch", () => {
+  return {
+    $fetch: vi.fn(() => Promise.resolve()),
+    FetchError: function error() {
+      return;
+    },
+  };
+});
+
+describe("getSolcShortVersion", () => {
+  it("returns short version for the full solc version", () => {
+    expect(getSolcShortVersion("v0.8.14+commit.80d49f37")).toBe("0.8.14");
+  });
+
+  it("returns zkVM version unchanged", () => {
+    expect(getSolcShortVersion("zkVM-0.8.29-1.0.1")).toBe("zkVM-0.8.29-1.0.1");
+  });
+
+  it("returns short version unchanged", () => {
+    expect(getSolcShortVersion("0.8.14")).toBe("0.8.14");
+  });
+});
+
+describe("getSolcFullVersion", () => {
+  it("returns hardcoded solc versions without additional request to the API", async () => {
+    expect(await getSolcFullVersion("0.4.10")).toBe("v0.4.10+commit.f0d539ae");
+    expect(await getSolcFullVersion("0.8.29")).toBe("v0.8.29+commit.ab55807c");
+    expect($fetch).toHaveBeenCalledTimes(0);
+  });
+
+  it("requests unknown solc version from the API", async () => {
+    const mock = ($fetch as any).mockResolvedValueOnce({
+      builds: [
+        {
+          version: "0.9.0",
+          longVersion: "0.9.0+prerelease.abc123",
+          prerelease: "123",
+        },
+        {
+          version: "0.9.0",
+          longVersion: "0.9.0+commit.abc123",
+        },
+      ],
+    });
+    expect(await getSolcFullVersion("0.9.0")).toBe("v0.9.0+commit.abc123");
+    expect(await getSolcFullVersion("0.8.29")).toBe("v0.8.29+commit.ab55807c");
+    expect(await getSolcFullVersion("0.9.0")).toBe("v0.9.0+commit.abc123");
+    expect($fetch).toHaveBeenCalledTimes(1);
+    mock.mockRestore();
+  });
+
+  it("returns version unchanged if the API call fails", async () => {
+    const mock = ($fetch as any).mockRejectedValue(new Error("An error occurred"));
+    expect(await getSolcFullVersion("0.9.1")).toBe("0.9.1");
+    expect($fetch).toHaveBeenCalledTimes(1);
+    mock.mockRestore();
+  });
+});


### PR DESCRIPTION
# What ❔

Show full version for solc compiler. On:
* contract verification page:
<img width="1267" alt="image" src="https://github.com/user-attachments/assets/47cf92f4-b3a7-46d9-ae63-54bfaa353cb8" />
* contract verification info page:
<img width="1264" alt="image" src="https://github.com/user-attachments/assets/a3f64229-133a-462f-b76f-bb467f0c40b2" />

## Why ❔

To provide the same UX as Etherscan.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
