### PR TITLE
fix: change unused arg type from address to uint256 to avoid numeric overflow issue

### DIFF
--- a/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/assetRouter.handler.ts
+++ b/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/assetRouter.handler.ts
@@ -28,7 +28,7 @@ export const assetRouterFinalizeDepositHandler: ExtractTransferHandler = {
     const assetData = parsedLog.args.assetData;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [originalCaller, remoteReceiver, _, amount] = AbiCoder.defaultAbiCoder().decode(
-      ["address", "address", "address", "uint256", "bytes"],
+      ["address", "address", "uint256", "uint256", "bytes"],
       assetData
     );
 


### PR DESCRIPTION
When parsing assetData from DepositFinalizedAssetRouter event one of the encoded address params could be failed to parse as it's value can exceed width (20 bytes). The fix just changes type to uint256 as the param value is never used anyway.