### PR TITLE
fix: avoid checking prividium env at runtime

### DIFF
--- a/packages/api/src/config/index.spec.ts
+++ b/packages/api/src/config/index.spec.ts
@@ -64,6 +64,7 @@ describe("config", () => {
         feature2Enabled: false,
       }),
       gracefulShutdownTimeoutMs: 0,
+      prividium: {},
     });
   });
 
@@ -136,6 +137,7 @@ describe("config", () => {
           feature2Enabled: false,
         }),
         gracefulShutdownTimeoutMs: 0,
+        prividium: {},
       });
     });
 
@@ -200,6 +202,7 @@ describe("config", () => {
             feature2Enabled: false,
           }),
           gracefulShutdownTimeoutMs: 0,
+          prividium: {},
         });
       });
     });
@@ -263,6 +266,7 @@ describe("config", () => {
             feature2Enabled: false,
           }),
           gracefulShutdownTimeoutMs: 0,
+          prividium: {},
         });
       });
     });

--- a/packages/api/src/config/index.ts
+++ b/packages/api/src/config/index.ts
@@ -2,6 +2,7 @@ import { TypeOrmModuleOptions } from "@nestjs/typeorm";
 import * as featureFlags from "./featureFlags";
 import { BASE_TOKEN_L1_ADDRESS, BASE_TOKEN_L2_ADDRESS } from "../common/constants";
 import { z } from "zod";
+import { prividium } from "./featureFlags";
 
 export type BaseToken = {
   name: string;
@@ -149,23 +150,10 @@ export default () => {
   };
 
   const getPrividiumConfig = () => {
-    if (!featureFlags.prividium) {
-      return null;
-    }
-
-    const schema = z.object({
-      privateRpcUrl: z.string().url(),
-      privateRpcSecret: z.string().min(1),
-    });
-    const result = schema.safeParse({
+    return {
       privateRpcUrl: PRIVIDIUM_PRIVATE_RPC_URL,
       privateRpcSecret: PRIVIDIUM_PRIVATE_RPC_SECRET,
-    });
-    if (!result.success) {
-      throw new Error("Invalid Prividium config");
-    }
-
-    return result.data;
+    };
   };
 
   return {


### PR DESCRIPTION
# What ❔

This PR avoid checking the env var "PRIVIDIUM" after the AppModule was built. This makes e2e testing a lot easier, and in general a more elegant way to build the app module