### PR TITLE
fix: fix log address query and missing sending cookies to API

### DIFF
--- a/packages/api/src/log/log.service.spec.ts
+++ b/packages/api/src/log/log.service.spec.ts
@@ -113,8 +113,8 @@ describe("LogService", () => {
       const filterOptions = { address: address1, visibleBy: address2 };
       await service.findAll(filterOptions, pagingOptions);
       expect(queryBuilderMock.innerJoin).toBeCalledWith("log.transaction", "transactions");
-      expect(queryBuilderMock.where).toBeCalledWith(expect.any(Brackets));
-      const brackets = queryBuilderMock.where.mock.calls[1][0] as Brackets;
+      expect(queryBuilderMock.andWhere).toBeCalledWith(expect.any(Brackets));
+      const brackets = queryBuilderMock.andWhere.mock.calls[0][0] as Brackets;
       expect(brackets).toBeInstanceOf(Brackets);
       const qb = mock<WhereExpressionBuilder>();
       brackets.whereFactory(qb);
@@ -122,7 +122,6 @@ describe("LogService", () => {
       expect(qb.orWhere).toHaveBeenCalledWith("log.topics[2] = :visibleByTopic");
       expect(qb.orWhere).toHaveBeenCalledWith("log.topics[3] = :visibleByTopic");
       expect(qb.orWhere).toHaveBeenCalledWith("transactions.from = :visibleBy");
-      expect(qb.orWhere).toHaveBeenCalledWith("transactions.to = :visibleBy");
     });
   });
 

--- a/packages/api/src/log/log.service.ts
+++ b/packages/api/src/log/log.service.ts
@@ -54,13 +54,12 @@ export class LogService {
     if (visibleBy !== undefined) {
       queryBuilder.innerJoin("log.transaction", "transactions");
       const topic = zeroPadValue(visibleBy, 32);
-      queryBuilder.where(
+      queryBuilder.andWhere(
         new Brackets((qb) => {
           qb.where(`log.topics[1] = :visibleByTopic`);
           qb.orWhere("log.topics[2] = :visibleByTopic");
           qb.orWhere("log.topics[3] = :visibleByTopic");
           qb.orWhere("transactions.from = :visibleBy");
-          qb.orWhere("transactions.to = :visibleBy");
         })
       );
       queryBuilder.setParameters({ visibleByTopic: hexTransformer.to(topic), visibleBy: hexTransformer.to(visibleBy) });

--- a/packages/app/src/composables/useContractEvents.ts
+++ b/packages/app/src/composables/useContractEvents.ts
@@ -1,8 +1,9 @@
 import { ref } from "vue";
 
-import { $fetch, FetchError } from "ohmyfetch";
+import { FetchError } from "ohmyfetch";
 
 import useContext from "@/composables/useContext";
+import useFetch from "@/composables/useFetch";
 
 import type { AbiFragment } from "@/composables/useAddress";
 import type { TransactionLogEntry } from "@/composables/useEventLog";
@@ -34,6 +35,7 @@ export default (context = useContext()) => {
   const isRequestFailed = ref(false);
   const collection = ref<TransactionLogEntry[]>([]);
   const total = ref<number>(0);
+  const $fetch = useFetch();
 
   const getCollection = async (params: EventsQueryParams, abi?: AbiFragment[]) => {
     isRequestPending.value = true;

--- a/packages/app/src/composables/useSearch.ts
+++ b/packages/app/src/composables/useSearch.ts
@@ -1,9 +1,11 @@
 import { ref } from "vue";
 import { useRouter } from "vue-router";
 
-import { $fetch, FetchError } from "ohmyfetch";
+import { FetchError } from "ohmyfetch";
 
 import useContext from "./useContext";
+
+import useFetch from "@/composables/useFetch";
 
 import { isAddress, isBlockNumber, isTransactionHash } from "@/utils/validators";
 
@@ -11,6 +13,7 @@ export default (context = useContext()) => {
   const router = useRouter();
   const isRequestPending = ref(false);
   const isRequestFailed = ref(false);
+  const $fetch = useFetch();
 
   const getSearchRoute = (param: string) => {
     try {


### PR DESCRIPTION
# What ❔

This PR fix several small issues found during a round of QA.

## Why ❔

This fixes several bugs:
- The query for logs related to an addres was not scoping per address, causing the user to see all the events related to their account on every contract, instead of only the ones related to that contract.
- Sending cookies to API in a few places where we were not sending them.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ x ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ x ] Tests for the changes have been added / updated.
- [ x ] Documentation comments have been added / updated.
