### PR TITLE
feat: add GW txs chain ids to the batch entity

### DIFF
--- a/packages/worker/src/entities/batch.entity.ts
+++ b/packages/worker/src/entities/batch.entity.ts
@@ -30,6 +30,9 @@ export class Batch extends BaseEntity {
   @Column({ type: "varchar", length: 128 })
   public readonly l2FairGasPrice: number;
 
+  @Column({ type: "int", nullable: true })
+  public readonly commitChainId?: number;
+
   @Column({ type: "bytea", nullable: true, transformer: hexTransformer })
   public readonly commitTxHash?: string;
 
@@ -37,12 +40,18 @@ export class Batch extends BaseEntity {
   @Column({ type: "timestamp", nullable: true })
   public readonly committedAt?: Date;
 
+  @Column({ type: "int", nullable: true })
+  public readonly proveChainId?: number;
+
   @Column({ type: "bytea", nullable: true, transformer: hexTransformer })
   public readonly proveTxHash?: string;
 
   @Index()
   @Column({ type: "timestamp", nullable: true })
   public readonly provenAt?: Date;
+
+  @Column({ type: "int", nullable: true })
+  public readonly executeChainId?: number;
 
   @Column({ type: "bytea", nullable: true, transformer: hexTransformer })
   public readonly executeTxHash?: string;

--- a/packages/worker/src/migrations/1750085471126-AddGWChainsidsToBatchEntity.ts
+++ b/packages/worker/src/migrations/1750085471126-AddGWChainsidsToBatchEntity.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddGWChainsidsToBatchEntity1750085471126 implements MigrationInterface {
+  name = "AddGWChainsidsToBatchEntity1750085471126";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "batches" ADD "commitChainId" integer`);
+    await queryRunner.query(`ALTER TABLE "batches" ADD "proveChainId" integer`);
+    await queryRunner.query(`ALTER TABLE "batches" ADD "executeChainId" integer`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "executeChainId"`);
+    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "proveChainId"`);
+    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "commitChainId"`);
+  }
+}


### PR DESCRIPTION
# What ❔

Add gateway txs chain ids to the batch entity. It's needed for: https://github.com/matter-labs/block-explorer/issues/408

## Why ❔

In order to show correct URLs for the GW txs, we need to know the chain id for the txs. 

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
