### PR TITLE
fix: update log ordering in LogService

### DIFF
--- a/packages/api/src/log/log.service.ts
+++ b/packages/api/src/log/log.service.ts
@@ -141,7 +141,8 @@ export class LogService {
 
     queryBuilder.offset((page - 1) * offset);
     queryBuilder.limit(offset);
-    queryBuilder.orderBy("log.timestamp", "DESC");
+    queryBuilder.orderBy("log.blockNumber", "DESC");
+    queryBuilder.addOrderBy("log.logIndex", "DESC");
     return await queryBuilder.getMany();
   }
 }


### PR DESCRIPTION

# What ❔

Changed the ordering of log entries to sort by block number and log index in descending order for improved query results.

Blockchain events should be ordered by blockNumber and logIndex for deterministic results. Timestamp ordering can vary between nodes and doesn't guarantee a correct event sequence within a block.

## Why ❔

Security Impact

  - Incorrect ownership determination: If multiple ownership transfers occur within the same block, timestamp ordering is
  non-deterministic
  - Unauthorized access: Wrong owner could gain access to contract balances and sensitive data
  - Data leakage: Private contract information could be exposed to non-owners

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
