### PR TITLE
fix: skip decoding last bytes argument from assetData as it is not used

### DIFF
--- a/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/assetRouter.handler.ts
+++ b/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/assetRouter.handler.ts
@@ -28,7 +28,7 @@ export const assetRouterFinalizeDepositHandler: ExtractTransferHandler = {
     const assetData = parsedLog.args.assetData;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [originalCaller, remoteReceiver, _, amount] = AbiCoder.defaultAbiCoder().decode(
-      ["address", "address", "uint256", "uint256", "bytes"],
+      ["address", "address", "uint256", "uint256"],
       assetData
     );
 


### PR DESCRIPTION
When parsing assetData from DepositFinalizedAssetRouter event the last bytes argument may be failed to parse with ethers throwing BUFFER_OVERRUN error. We don't use this argument so skipping parsing it in this PR.