### PR TITLE
fix: decode gateway transaction data

### DIFF
--- a/packages/app/src/composables/useTransactionData.ts
+++ b/packages/app/src/composables/useTransactionData.ts
@@ -44,7 +44,12 @@ export function decodeDataWithABI(
     })!;
     return {
       name: decodedData.name,
-      inputs: decodedData.fragment.inputs.flatMap((input) => decodeInputData(input, decodedData.args[input.name])),
+      inputs: decodedData.fragment.inputs.flatMap((input, index) => {
+        // Use index if name is empty (common with some ABIs)
+        const argName = input.name || `arg${index}`;
+        const args = decodedData.args[argName] || decodedData.args[index];
+        return decodeInputData(input, args);
+      }),
     };
   } catch {
     return undefined;

--- a/packages/app/src/composables/useTransactionData.ts
+++ b/packages/app/src/composables/useTransactionData.ts
@@ -44,12 +44,10 @@ export function decodeDataWithABI(
     })!;
     return {
       name: decodedData.name,
-      inputs: decodedData.fragment.inputs.flatMap((input, index) => {
+      inputs: decodedData.fragment.inputs.flatMap((input, index) =>
         // Use index if name is empty (common with some ABIs)
-        const argName = input.name || `arg${index}`;
-        const args = decodedData.args[argName] || decodedData.args[index];
-        return decodeInputData(input, args);
-      }),
+        decodeInputData(input, decodedData.args[input.name || index])
+      ),
     };
   } catch {
     return undefined;


### PR DESCRIPTION
# What ❔

- use index if name is empty in useTransactionData.ts

## Why ❔

- input data for ValidatorTimelock had empty name causing the explorer to not be able to decode input, now input data is decoded
- fixes https://github.com/matter-labs/block-explorer/issues/490

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
