### PR TITLE
fix: app network selection

### DIFF
--- a/packages/app/src/composables/useContext.ts
+++ b/packages/app/src/composables/useContext.ts
@@ -49,8 +49,12 @@ export default (): Context => {
     const defaultNetwork = networks.value[0] ?? DEFAULT_NETWORK;
     if (networkFromQueryParam) {
       network.value = networkFromQueryParam;
+    } else if (
       // If the data from storage wasn't used or is the same
-    } else if (network.value === defaultNetwork.name) {
+      network.value === defaultNetwork.name ||
+      // If the network is not in the list of networks. May happen if the network was removed from the config or renamed.
+      !networks.value.some((e) => e.name === network.value)
+    ) {
       if (networkOnDomain) {
         network.value = networkOnDomain.name;
       } else {


### PR DESCRIPTION
# What ❔

Fix the app to correctly select a network when the previously selected one has been removed or renamed.

## Why ❔

If a network in the config is removed or renamed and this network was previously selected by the user, it breaks the network selection, making it impossible to change the network. This scenario should be handled the same way as if no network had been selected.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
