### PR TITLE
fix: settlement layer icon when txs are processed by different layers

### DIFF
--- a/packages/api/src/batch/batch.dto.ts
+++ b/packages/api/src/batch/batch.dto.ts
@@ -54,4 +54,22 @@ export class BatchDto {
     examples: [1, null],
   })
   public readonly commitChainId?: number;
+
+  @ApiProperty({
+    type: Number,
+    nullable: true,
+    description: "Prove transaction chain id",
+    example: 1,
+    examples: [1, null],
+  })
+  public readonly proveChainId?: number;
+
+  @ApiProperty({
+    type: Number,
+    nullable: true,
+    description: "Execute transaction chain id",
+    example: 1,
+    examples: [1, null],
+  })
+  public readonly executeChainId?: number;
 }

--- a/packages/api/src/batch/batch.entity.ts
+++ b/packages/api/src/batch/batch.entity.ts
@@ -33,6 +33,12 @@ export class Batch extends BaseEntity {
   @Column({ type: "int", nullable: true })
   public readonly commitChainId?: number;
 
+  @Column({ type: "int", nullable: true })
+  public readonly proveChainId?: number;
+
+  @Column({ type: "int", nullable: true })
+  public readonly executeChainId?: number;
+
   public get size() {
     return this.l1TxCount + this.l2TxCount;
   }

--- a/packages/api/src/batch/batchDetails.dto.ts
+++ b/packages/api/src/batch/batchDetails.dto.ts
@@ -19,30 +19,12 @@ export class BatchDetailsDto extends BatchDto {
   public readonly proveTxHash?: string;
 
   @ApiProperty({
-    type: Number,
-    nullable: true,
-    description: "Prove transaction chain id",
-    example: 1,
-    examples: [1, null],
-  })
-  public readonly proveChainId?: number;
-
-  @ApiProperty({
     type: String,
     description: "Execute transaction hash",
     example: "0x85f97229ef1e489d4a5c2f8c15eb275ee7a6adcdae57d02597221d202b0f421b",
     examples: ["0x85f97229ef1e489d4a5c2f8c15eb275ee7a6adcdae57d02597221d202b0f421b", null],
   })
   public readonly executeTxHash?: string;
-
-  @ApiProperty({
-    type: Number,
-    nullable: true,
-    description: "Execute transaction chain id",
-    example: 1,
-    examples: [1, null],
-  })
-  public readonly executeChainId?: number;
 
   @ApiProperty({
     type: Date,

--- a/packages/api/src/batch/batchDetails.entity.ts
+++ b/packages/api/src/batch/batchDetails.entity.ts
@@ -18,14 +18,8 @@ export class BatchDetails extends Batch {
   @Column({ type: "timestamp", nullable: true })
   public readonly provenAt?: Date;
 
-  @Column({ type: "int", nullable: true })
-  public readonly proveChainId?: number;
-
   @Column({ type: "bytea", nullable: true, transformer: hexTransformer })
   public readonly executeTxHash?: string;
-
-  @Column({ type: "int", nullable: true })
-  public readonly executeChainId?: number;
 
   @Column({ type: "varchar", length: 128 })
   public readonly l1GasPrice: string;

--- a/packages/api/test/batch.e2e-spec.ts
+++ b/packages/api/test/batch.e2e-spec.ts
@@ -212,6 +212,8 @@ describe("BatchController (e2e)", () => {
                 status: "sealed",
                 timestamp: "2022-11-10T14:44:36.000Z",
                 commitChainId: null,
+                proveChainId: null,
+                executeChainId: null,
               },
               {
                 executedAt: null,
@@ -223,6 +225,8 @@ describe("BatchController (e2e)", () => {
                 status: "sealed",
                 timestamp: "2022-11-10T14:44:35.000Z",
                 commitChainId: null,
+                proveChainId: null,
+                executeChainId: null,
               },
             ],
             links: {
@@ -258,6 +262,8 @@ describe("BatchController (e2e)", () => {
               status: BatchStatus.Sealed,
               executedAt: null,
               commitChainId: null,
+              proveChainId: null,
+              executeChainId: null,
             },
             {
               number: 35,
@@ -269,6 +275,8 @@ describe("BatchController (e2e)", () => {
               status: BatchStatus.Sealed,
               executedAt: null,
               commitChainId: null,
+              proveChainId: null,
+              executeChainId: null,
             },
           ])
         );

--- a/packages/app/src/components/batches/Table.vue
+++ b/packages/app/src/components/batches/Table.vue
@@ -97,7 +97,11 @@ function getBadgeIconByStatus(batch: BatchListItem) {
   if (batch.status === "sealed") {
     return ZkSyncIcon;
   }
-  return isGatewaySettlementChain(batch.commitChainId) ? GatewayIcon : EthereumIcon;
+  debugger;
+  // Check chain IDs beginning with the most recent status and moving backward, in case transactions are processed
+  // by different settlement layers, for instance: https://explorer.zksync.io/batch/501263
+  // No need to check commitChainId here, as a batch that only has commitChainId is sealed and the ZKsync icon is shown.
+  return isGatewaySettlementChain(batch.executeChainId || batch.proveChainId) ? GatewayIcon : EthereumIcon;
 }
 </script>
 

--- a/packages/app/src/components/batches/Table.vue
+++ b/packages/app/src/components/batches/Table.vue
@@ -97,7 +97,6 @@ function getBadgeIconByStatus(batch: BatchListItem) {
   if (batch.status === "sealed") {
     return ZkSyncIcon;
   }
-  debugger;
   // Check chain IDs beginning with the most recent status and moving backward, in case transactions are processed
   // by different settlement layers, for instance: https://explorer.zksync.io/batch/501263
   // No need to check commitChainId here, as a batch that only has commitChainId is sealed and the ZKsync icon is shown.

--- a/packages/app/src/components/transactions/Table.vue
+++ b/packages/app/src/components/transactions/Table.vue
@@ -363,7 +363,10 @@ const transactions = computed<TransactionListItemMapped[] | undefined>(() => {
       statusColor: transaction.status === "failed" ? "danger" : "dark-success",
       statusIcon: ["failed", "included"].includes(transaction.status)
         ? ZkSyncIcon
-        : isGatewaySettlementChain(transaction.commitChainId)
+        : // Check chain IDs beginning with the most recent status and moving backward, in case transactions are processed
+        // by different settlement layers, for instance:
+        // https://explorer.zksync.io/tx/0x78a0baa79aa4ebdf719176427205865be6b42938d31fa88205c61bfb8f8494c2
+        isGatewaySettlementChain(transaction.executeChainId || transaction.proveChainId || transaction.commitChainId)
         ? GatewayIcon
         : EthereumIcon,
       isContractDeploymentTx,

--- a/packages/app/src/composables/common/Api.d.ts
+++ b/packages/app/src/composables/common/Api.d.ts
@@ -38,6 +38,8 @@ declare namespace Api {
       l2TxCount: number;
       size: number;
       commitChainId: number | null;
+      proveChainId: number | null;
+      executeChainId: number | null;
     };
 
     type BatchDetails = {

--- a/packages/app/src/configs/dev.config.json
+++ b/packages/app/src/configs/dev.config.json
@@ -43,23 +43,6 @@
     },
     {
       "groupId": "era",
-      "apiUrl": "https://block-explorer-api.stage.zksync.dev",
-      "verificationApiUrl": "https://z2-dev-api-explorer.zksync.dev",
-      "hostnames": [
-        "https://goerli-beta.staging-scan-v2.zksync.dev"
-      ],
-      "icon": "/images/icons/zksync-arrows.svg",
-      "l1ExplorerUrl": "https://goerli.etherscan.io",
-      "l2ChainId": 270,
-      "l2NetworkName": "Goerli (Stage2)",
-      "maintenance": false,
-      "name": "goerli-beta",
-      "published": true,
-      "rpcUrl": "https://z2-dev-api.zksync.dev",
-      "baseTokenAddress": "0x000000000000000000000000000000000000800a"
-    },
-    {
-      "groupId": "era",
       "apiUrl": "https://block-explorer-api.mainnet.zksync.io",
       "verificationApiUrl": "https://zksync2-mainnet-explorer.zksync.io",
       "bridgeUrl": "https://portal.zksync.io/bridge/?network=mainnet",

--- a/packages/app/src/configs/staging.config.json
+++ b/packages/app/src/configs/staging.config.json
@@ -29,23 +29,6 @@
     },
     {
       "groupId": "era",
-      "apiUrl": "https://block-explorer-api.stage.zksync.dev",
-      "verificationApiUrl": "https://z2-dev-api-explorer.zksync.dev",
-      "hostnames": [
-        "https://goerli-beta.staging-scan-v2.zksync.dev"
-      ],
-      "icon": "/images/icons/zksync-arrows.svg",
-      "l1ExplorerUrl": "https://goerli.etherscan.io",
-      "l2ChainId": 270,
-      "l2NetworkName": "Goerli (Stage2)",
-      "maintenance": false,
-      "name": "goerli-beta",
-      "published": true,
-      "rpcUrl": "https://z2-dev-api.zksync.dev",
-      "baseTokenAddress": "0x000000000000000000000000000000000000800a"
-    },
-    {
-      "groupId": "era",
       "apiUrl": "https://block-explorer-api.mainnet.zksync.io",
       "verificationApiUrl": "https://zksync2-mainnet-explorer.zksync.io",
       "bridgeUrl": "https://portal.zksync.io/bridge/?network=mainnet",

--- a/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
+++ b/packages/app/tests/e2e/features/artifacts/artifactsSet1.feature
@@ -60,7 +60,6 @@ Feature: Main Page
   Examples:
       | Value                       | Dropdown |
       | ZKsync Era Sepolia Testnet  | network  |
-      | Goerli (Stage2)             | network  |
 
   @id254:II @productionEnv
   Scenario Outline: Check dropdown "<Dropdown>" for "<Value>" and verify

--- a/packages/app/tests/e2e/features/redirection/redirectionSet3.feature
+++ b/packages/app/tests/e2e/features/redirection/redirectionSet3.feature
@@ -62,7 +62,6 @@ Feature: Redirection
 
     Examples: 
      | Initial page                                             | Network                   | url                                                                      |
-     | /address/0x000000000000000000000000000000000000800A      | Goerli (Stage2)           | /address/0x000000000000000000000000000000000000800A/?network=goerli-beta | 
      | /address/0x000000000000000000000000000000000000800A      | ZKsync Era Mainnet        | /address/0x000000000000000000000000000000000000800A/?network=mainnet     |
      | /address/0x000000000000000000000000000000000000800A      | ZKsync Era Sepolia Testnet | /address/0x000000000000000000000000000000000000800A/?network=sepolia    |  
 


### PR DESCRIPTION
# What ❔

Currently, the settlement layer icon for batches and transactions is determined solely based on the `commitChainId` field. As a result, an incorrect settlement layer icon may be shown if the commit, prove and execute transactions are processed by different chains. For example:
https://explorer.zksync.io/batch/501263, where the commit and execute transactions are processed by Ethereum and ZKsync GW, respectively.

<img width="1249" height="60" alt="image" src="https://github.com/user-attachments/assets/b59caa16-7c2f-41fb-b86b-a4e1066f3029" />
<img width="1262" height="726" alt="image" src="https://github.com/user-attachments/assets/30a460e7-5f6f-46ee-ba73-83f40cd400de" /> 

To fix this:
1. The API has been updated to return `proveChainId` and `executeChainId` for batch list items.
2. When displaying the settlement layer icon, the appropriate chain ID is used, not just `commitChainId`.

After the fix:
<img width="1251" height="61" alt="image" src="https://github.com/user-attachments/assets/599247a5-79ec-48ac-934d-6b984d7ef209" />
<img width="1254" height="517" alt="image" src="https://github.com/user-attachments/assets/3b43d97e-0b57-4147-ac21-2d6d7ff26a49" />

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

To show a proper settlement layer icon.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
