### PR TITLE
fix: add era stage proof network to dev and staging

### DIFF
--- a/packages/app/src/configs/dev.config.json
+++ b/packages/app/src/configs/dev.config.json
@@ -18,6 +18,32 @@
     },
     {
       "groupId": "era",
+      "apiUrl": "https://block-explorer-api.era-stage-proofs.zksync.dev",
+      "verificationApiUrl": "https://dev-api-explorer.era-stage-proofs.zksync.dev",
+      "hostnames": [
+        "https://stage-proofs.staging-scan-v2.zksync.dev"
+      ],
+      "icon": "/images/icons/zksync-arrows.svg",
+      "l1ExplorerUrl": "https://sepolia.etherscan.io/",
+      "settlementChains": [{
+        "explorerUrl": "https://sepolia.etherscan.io",
+        "name": "Ethereum",
+        "chainId": 11155111
+      }, {
+        "explorerUrl": "https://explorer.era-gateway-stage.zksync.dev",
+        "name": "Stage Gateway",
+        "chainId": 123
+      }],
+      "l2ChainId": 499,
+      "l2NetworkName": "ZKsync Era Stage Proofs",
+      "maintenance": false,
+      "name": "stage-proofs",
+      "published": true,
+      "rpcUrl": "https://dev-api.era-stage-proofs.zksync.dev",
+      "baseTokenAddress": "0x000000000000000000000000000000000000800a"
+    },
+    {
+      "groupId": "era",
       "apiUrl": "https://block-explorer-api.sepolia.zksync.dev",
       "verificationApiUrl": "https://explorer.sepolia.era.zksync.dev",
       "bridgeUrl": "https://portal.zksync.io/bridge/?network=sepolia",

--- a/packages/app/src/configs/staging.config.json
+++ b/packages/app/src/configs/staging.config.json
@@ -2,6 +2,32 @@
   "networks": [
     {
       "groupId": "era",
+      "apiUrl": "https://block-explorer-api.era-stage-proofs.zksync.dev",
+      "verificationApiUrl": "https://dev-api-explorer.era-stage-proofs.zksync.dev",
+      "hostnames": [
+        "https://stage-proofs.staging-scan-v2.zksync.dev"
+      ],
+      "icon": "/images/icons/zksync-arrows.svg",
+      "l1ExplorerUrl": "https://sepolia.etherscan.io/",
+      "settlementChains": [{
+        "explorerUrl": "https://sepolia.etherscan.io",
+        "name": "Ethereum",
+        "chainId": 11155111
+      }, {
+        "explorerUrl": "https://explorer.era-gateway-stage.zksync.dev",
+        "name": "Stage Gateway",
+        "chainId": 123
+      }],
+      "l2ChainId": 499,
+      "l2NetworkName": "ZKsync Era Stage Proofs",
+      "maintenance": false,
+      "name": "stage-proofs",
+      "published": true,
+      "rpcUrl": "https://dev-api.era-stage-proofs.zksync.dev",
+      "baseTokenAddress": "0x000000000000000000000000000000000000800a"
+    },
+    {
+      "groupId": "era",
       "apiUrl": "https://block-explorer-api.sepolia.zksync.dev",
       "verificationApiUrl": "https://explorer.sepolia.era.zksync.dev",
       "bridgeUrl": "https://portal.zksync.io/bridge/?network=sepolia",


### PR DESCRIPTION
# What ❔

Add ZKsync Era Stage Proofs network to the dev and staging configs.

## Why ❔

So it's available for the test purpose.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
