### PR TITLE
fix: explorer staging config

### DIFF
--- a/packages/app/src/configs/staging.config.json
+++ b/packages/app/src/configs/staging.config.json
@@ -2,32 +2,6 @@
   "networks": [
     {
       "groupId": "era",
-      "apiUrl": "https://block-explorer-api.era-stage-proofs.zksync.dev",
-      "verificationApiUrl": "https://dev-api-explorer.era-stage-proofs.zksync.dev",
-      "hostnames": [
-        "https://stage-proofs.staging-scan-v2.zksync.dev"
-      ],
-      "icon": "/images/icons/zksync-arrows.svg",
-      "l1ExplorerUrl": "https://sepolia.etherscan.io/",
-      "settlementChains": [{
-        "explorerUrl": "https://sepolia.etherscan.io",
-        "name": "Ethereum",
-        "chainId": 11155111
-      }, {
-        "explorerUrl": "https://explorer.era-gateway-stage.zksync.dev",
-        "name": "Stage Gateway",
-        "chainId": 123
-      }],
-      "l2ChainId": 499,
-      "l2NetworkName": "ZKsync Era Stage Proofs",
-      "maintenance": false,
-      "name": "stage-proofs",
-      "published": true,
-      "rpcUrl": "https://dev-api.era-stage-proofs.zksync.dev",
-      "baseTokenAddress": "0x000000000000000000000000000000000000800a"
-    },
-    {
-      "groupId": "era",
       "apiUrl": "https://block-explorer-api.sepolia.zksync.dev",
       "verificationApiUrl": "https://explorer.sepolia.era.zksync.dev",
       "bridgeUrl": "https://portal.zksync.io/bridge/?network=sepolia",
@@ -51,6 +25,32 @@
       "name": "sepolia",
       "published": true,
       "rpcUrl": "https://sepolia.era.zksync.dev",
+      "baseTokenAddress": "0x000000000000000000000000000000000000800a"
+    },
+        {
+      "groupId": "era",
+      "apiUrl": "https://block-explorer-api.era-stage-proofs.zksync.dev",
+      "verificationApiUrl": "https://dev-api-explorer.era-stage-proofs.zksync.dev",
+      "hostnames": [
+        "https://stage-proofs.staging-scan-v2.zksync.dev"
+      ],
+      "icon": "/images/icons/zksync-arrows.svg",
+      "l1ExplorerUrl": "https://sepolia.etherscan.io/",
+      "settlementChains": [{
+        "explorerUrl": "https://sepolia.etherscan.io",
+        "name": "Ethereum",
+        "chainId": 11155111
+      }, {
+        "explorerUrl": "https://explorer.era-gateway-stage.zksync.dev",
+        "name": "Stage Gateway",
+        "chainId": 123
+      }],
+      "l2ChainId": 499,
+      "l2NetworkName": "ZKsync Era Stage Proofs",
+      "maintenance": false,
+      "name": "stage-proofs",
+      "published": true,
+      "rpcUrl": "https://dev-api.era-stage-proofs.zksync.dev",
       "baseTokenAddress": "0x000000000000000000000000000000000000800a"
     },
     {

--- a/packages/app/src/configs/staging.config.json
+++ b/packages/app/src/configs/staging.config.json
@@ -27,7 +27,7 @@
       "rpcUrl": "https://sepolia.era.zksync.dev",
       "baseTokenAddress": "0x000000000000000000000000000000000000800a"
     },
-        {
+    {
       "groupId": "era",
       "apiUrl": "https://block-explorer-api.era-stage-proofs.zksync.dev",
       "verificationApiUrl": "https://dev-api-explorer.era-stage-proofs.zksync.dev",


### PR DESCRIPTION
# What ❔

Fix explorer staging config.

## Why ❔

The default network (sepolia testnet) should go first, otherwise networks switcher is unable to select the proper network.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
