### PR TITLE
feat: added function selectors to explorer ui function dropdowns

### DIFF
--- a/packages/app/src/components/contract/interaction/FunctionDropdown.vue
+++ b/packages/app/src/components/contract/interaction/FunctionDropdown.vue
@@ -3,6 +3,7 @@
     <button type="button" @click="opened = !opened" class="function-disclosure-btn" :class="{ opened: opened }">
       <span>
         <slot />
+        <span class="function-selector">({{ getFunctionSelector(abiFragment) }})</span>
       </span>
       <ChevronDownIcon class="function-arrow-icon" />
     </button>
@@ -64,6 +65,8 @@ import useContractInteraction from "@/composables/useContractInteraction";
 import type { AbiFragment } from "@/composables/useAddress";
 import type { PropType } from "vue";
 
+import { getFunctionSelector } from "@/utils/contracts";
+
 const props = defineProps({
   type: {
     type: String as PropType<"read" | "write">,
@@ -112,6 +115,9 @@ const submit = async (form: Record<string, string | string[] | boolean | boolean
   }
   .function-arrow-icon {
     @apply h-5 w-5 text-neutral-500;
+  }
+  .function-selector {
+    @apply ml-2 font-mono text-sm text-neutral-500;
   }
 }
 

--- a/packages/app/src/utils/contracts.ts
+++ b/packages/app/src/utils/contracts.ts
@@ -1,0 +1,18 @@
+import { id } from "ethers";
+
+import type { AbiFragment } from "@/composables/useAddress";
+
+/**
+ * Calculates the function selector for a given ABI fragment
+ * @param abiFragment - The ABI fragment containing function information
+ * @returns The 4-byte function selector as a hex string (e.g., "0x12345678")
+ */
+export function getFunctionSelector(abiFragment: AbiFragment): string {
+  // Build the function signature
+  const inputs = abiFragment.inputs.map((input) => input.type).join(",");
+  const signature = `${abiFragment.name}(${inputs})`;
+
+  // Calculate the keccak256 hash and take the first 4 bytes (8 hex chars)
+  const hash = id(signature);
+  return hash.slice(0, 10); // "0x" + 8 hex chars = 10 chars total
+}

--- a/packages/app/tests/utils/contracts.spec.ts
+++ b/packages/app/tests/utils/contracts.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import type { AbiFragment } from "@/composables/useAddress";
+
+import { getFunctionSelector } from "@/utils/contracts";
+
+describe("contracts utils", () => {
+  describe("getFunctionSelector", () => {
+    it("calculates correct selector for transfer function", () => {
+      const transferAbi: AbiFragment = {
+        name: "transfer",
+        type: "function",
+        stateMutability: "nonpayable",
+        inputs: [
+          { name: "_to", type: "address", internalType: "address" },
+          { name: "_value", type: "uint256", internalType: "uint256" },
+        ],
+        outputs: [{ name: "", type: "bool", internalType: "bool" }],
+      };
+
+      const selector = getFunctionSelector(transferAbi);
+      expect(selector).toBe("0xa9059cbb");
+    });
+
+    it("calculates correct selector for approve function", () => {
+      const approveAbi: AbiFragment = {
+        name: "approve",
+        type: "function",
+        stateMutability: "nonpayable",
+        inputs: [
+          { name: "_spender", type: "address", internalType: "address" },
+          { name: "_value", type: "uint256", internalType: "uint256" },
+        ],
+        outputs: [{ name: "", type: "bool", internalType: "bool" }],
+      };
+
+      const selector = getFunctionSelector(approveAbi);
+      expect(selector).toBe("0x095ea7b3");
+    });
+
+    it("calculates correct selector for function with no parameters", () => {
+      const totalSupplyAbi: AbiFragment = {
+        name: "totalSupply",
+        type: "function",
+        stateMutability: "view",
+        inputs: [],
+        outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+      };
+
+      const selector = getFunctionSelector(totalSupplyAbi);
+      expect(selector).toBe("0x18160ddd");
+    });
+
+    it("calculates correct selector for function with tuple types", () => {
+      const tupleAbi: AbiFragment = {
+        name: "multicall",
+        type: "function",
+        stateMutability: "nonpayable",
+        inputs: [
+          {
+            name: "calls",
+            type: "(address,bytes)[]",
+            internalType: "(address,bytes)[]",
+          },
+        ],
+        outputs: [{ name: "results", type: "bytes[]", internalType: "bytes[]" }],
+      };
+
+      const selector = getFunctionSelector(tupleAbi);
+      expect(selector).toBe("0xcaa5c23f");
+    });
+  });
+});


### PR DESCRIPTION
# What ❔

Added function selectors to the functions in the explorer.

From this:
<img width="224" height="269" alt="Screenshot 2025-08-01 at 4 09 52 PM" src="https://github.com/user-attachments/assets/2d90f108-b49f-4c8a-9bed-11a36fd3dac6" />

To this:
<img width="315" height="267" alt="Screenshot 2025-08-01 at 4 07 46 PM" src="https://github.com/user-attachments/assets/d05a8072-2710-4e5d-9229-be802d75b1fd" />

## Why ❔

When I'm looking through hex for doing security stuff, I usually want a quick way to see which function selector of a contract matches what I'm looking at. Otherwise, I have to calculate the selectors myself sometimes. This is a helpful cue for developers and security researchers. 

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
