### PR TITLE
fix: disable access for contract information when user is not the owner

### DIFF
--- a/packages/api/src/address/address.controller.spec.ts
+++ b/packages/api/src/address/address.controller.spec.ts
@@ -275,7 +275,7 @@ describe("AddressController", () => {
           });
         });
 
-        it("does not include balances if user is not owner (no logs found)", async () => {
+        it("does not include additional information if user is not owner (no logs found)", async () => {
           logServiceMock.findManyByTopics.mockResolvedValueOnce([]);
 
           const result = await controller.getAddress(blockchainAddress, user);
@@ -289,9 +289,12 @@ describe("AddressController", () => {
             offset: 1,
           });
           expect(result.balances).toEqual({});
+          expect(result["bytecode"]).toEqual("");
+          expect(result["creatorAddress"]).toEqual("");
+          expect(result["creatorTxHash"]).toEqual("");
         });
 
-        it("does not include balances if user is not owner (ownerTopic is undefined)", async () => {
+        it("does not include additional information if user is not owner (ownerTopic is undefined)", async () => {
           logServiceMock.findManyByTopics.mockResolvedValueOnce([
             {
               topics: ["0x", "0x"], // topics[2] is undefined
@@ -312,9 +315,12 @@ describe("AddressController", () => {
           const result = await controller.getAddress(blockchainAddress, user);
 
           expect(result.balances).toEqual({});
+          expect(result["bytecode"]).toEqual("");
+          expect(result["creatorAddress"]).toEqual("");
+          expect(result["creatorTxHash"]).toEqual("");
         });
 
-        it("does not include balances if user is not owner (different owner)", async () => {
+        it("does not include additional information if user is not owner (different owner)", async () => {
           logServiceMock.findManyByTopics.mockResolvedValueOnce([
             {
               topics: ["0x", "0x", zeroPadValue(Wallet.createRandom().address, 32)],
@@ -335,9 +341,12 @@ describe("AddressController", () => {
           const result = await controller.getAddress(blockchainAddress, user);
 
           expect(result.balances).toEqual({});
+          expect(result["bytecode"]).toEqual("");
+          expect(result["creatorAddress"]).toEqual("");
+          expect(result["creatorTxHash"]).toEqual("");
         });
 
-        it("includes balances if user is owner", async () => {
+        it("includes additional information if user is owner", async () => {
           logServiceMock.findManyByTopics.mockResolvedValueOnce([
             {
               topics: ["0x", "0x", zeroPadValue(mockUser, 32)],
@@ -359,9 +368,12 @@ describe("AddressController", () => {
 
           expect(balanceServiceMock.getBalances).toHaveBeenCalledWith(blockchainAddress);
           expect(result.balances).toBeDefined();
+          expect(result["bytecode"]).not.toEqual("");
+          expect(result["creatorAddress"]).not.toEqual("");
+          expect(result["creatorTxHash"]).not.toEqual("");
         });
 
-        it("does not include balances if logService throws an error", async () => {
+        it("does not include additional information if logService throws an error", async () => {
           const err = new Error("Database error");
           logServiceMock.findManyByTopics.mockRejectedValueOnce(err);
           const loggerSpy = jest.spyOn(controller["logger"], "error").mockImplementation();
@@ -370,6 +382,9 @@ describe("AddressController", () => {
 
           expect(loggerSpy).toHaveBeenCalledWith("Failed to check if user is owner of contract", err.stack);
           expect(result.balances).toEqual({});
+          expect(result["bytecode"]).toEqual("");
+          expect(result["creatorAddress"]).toEqual("");
+          expect(result["creatorTxHash"]).toEqual("");
 
           loggerSpy.mockRestore();
         });

--- a/packages/api/src/address/address.controller.ts
+++ b/packages/api/src/address/address.controller.ts
@@ -70,6 +70,9 @@ export class AddressController {
       ? AddressType.Contract
       : AddressType.Account;
     let includeBalances = true;
+    let includeBytecode = true;
+    let includeCreatorAddress = true;
+    let includeCreatorTxHash = true;
 
     if (user) {
       // If address is an account and is not own address, forbid access
@@ -77,9 +80,12 @@ export class AddressController {
         throw new ForbiddenException();
       }
 
-      // If address is a contract and user is not owner, don't include balances
+      // If address is a contract and user is not owner, don't include additional information
       if (addressType === AddressType.Contract && !(await this.isUserOwnerOfContract(address, user.address))) {
         includeBalances = false;
+        includeBytecode = false;
+        includeCreatorAddress = false;
+        includeCreatorTxHash = false;
       }
     }
 
@@ -95,10 +101,11 @@ export class AddressController {
         blockNumber: addressBalance.blockNumber || addressRecord.createdInBlockNumber,
         balances: addressBalance.balances,
         createdInBlockNumber: addressRecord.createdInBlockNumber,
-        creatorTxHash: addressRecord.creatorTxHash,
+        creatorTxHash: includeCreatorTxHash ? addressRecord.creatorTxHash : "",
         totalTransactions,
-        creatorAddress: addressRecord.creatorAddress,
+        creatorAddress: includeCreatorAddress ? addressRecord.creatorAddress : "",
         isEvmLike: addressRecord.isEvmLike,
+        bytecode: includeBytecode ? addressRecord.bytecode : "",
       };
     }
 


### PR DESCRIPTION
# What ❔

This PR disables access for contract information in Prividium when the user is not the owner.

Closes https://github.com/matter-labs/zksync-prividium/issues/170

## Why ❔

 Users should not be able to access the contract’s deployed bytecode or its creation transaction.
## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
