### PR TITLE
fix: improve performance of transaction queries

### DIFF
--- a/packages/api/src/common/utils.spec.ts
+++ b/packages/api/src/common/utils.spec.ts
@@ -13,7 +13,6 @@ import {
   parseIntToHex,
   parseReqPathname,
   isAddressEqual,
-  padAddressToTransactionLogTopic,
   computeFromToMinMax,
 } from "./utils";
 import { IPaginationOptions } from "./types";
@@ -542,52 +541,6 @@ describe("utils", () => {
       expect(isAddressEqual(validAddress, undefined as any)).toBe(false);
       expect(isAddressEqual(null as any, null as any)).toBe(false);
       expect(isAddressEqual(undefined as any, undefined as any)).toBe(false);
-    });
-  });
-
-  describe("padAddressToTransactionLogTopic", () => {
-    it("pads a 20-byte address to 32 bytes", () => {
-      const address = "0x1234567890123456789012345678901234567890";
-      const result = padAddressToTransactionLogTopic(address);
-      expect(result).toBe("0x0000000000000000000000001234567890123456789012345678901234567890");
-      expect(result.length).toBe(66); // 0x + 64 hex chars = 32 bytes
-    });
-
-    it("pads a lowercase address correctly", () => {
-      const address = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
-      const result = padAddressToTransactionLogTopic(address);
-      expect(result).toBe("0x000000000000000000000000abcdefabcdefabcdefabcdefabcdefabcdefabcd");
-      expect(result.length).toBe(66);
-    });
-
-    it("pads an uppercase address correctly", () => {
-      const address = "0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD";
-      const result = padAddressToTransactionLogTopic(address);
-      // zeroPadValue returns lowercase
-      expect(result).toBe("0x000000000000000000000000abcdefabcdefabcdefabcdefabcdefabcdefabcd");
-      expect(result.length).toBe(66);
-    });
-
-    it("pads a mixed case address correctly", () => {
-      const address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
-      const result = padAddressToTransactionLogTopic(address);
-      expect(result).toBe("0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
-      expect(result.length).toBe(66);
-    });
-
-    it("pads an address with all zeros", () => {
-      const address = "0x0000000000000000000000000000000000000000";
-      const result = padAddressToTransactionLogTopic(address);
-      expect(result).toBe("0x0000000000000000000000000000000000000000000000000000000000000000");
-      expect(result.length).toBe(66);
-    });
-
-    it("pads an address with all Fs", () => {
-      const address = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
-      const result = padAddressToTransactionLogTopic(address);
-      // zeroPadValue returns lowercase
-      expect(result).toBe("0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff");
-      expect(result.length).toBe(66);
     });
   });
 

--- a/packages/api/src/common/utils.ts
+++ b/packages/api/src/common/utils.ts
@@ -5,7 +5,7 @@ import { NumerableEntity } from "./entities/numerable.entity";
 import { hexTransformer } from "./transformers/hex.transformer";
 import { IPaginationOptions } from "./types";
 import { Request } from "express";
-import { getAddress, zeroPadValue } from "ethers";
+import { getAddress } from "ethers";
 
 const MIN_OFFSET_TO_USE_NUMBER_FILTER = 1000;
 
@@ -143,13 +143,6 @@ export const isAddressEqual = (address1: string, address2: string): boolean => {
     return false;
   }
 };
-
-/**
- * Pads an address to 32 bytes by adding zeros to the left.
- * @param address - The address to pad.
- * @returns The padded address.
- */
-export const padAddressToTransactionLogTopic = (address: string) => zeroPadValue(address, 32);
 
 export const computeFromToMinMax = (
   from: string,

--- a/packages/api/src/transaction/transaction.controller.spec.ts
+++ b/packages/api/src/transaction/transaction.controller.spec.ts
@@ -208,14 +208,10 @@ describe("TransactionController", () => {
     describe("when user is provided", () => {
       let user: MockProxy<UserWithRoles>;
       const mockUser = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
-      const transactionLogs = mock<Pagination<Log>>({
-        items: [mock<Log>({ topics: [] })],
-      });
 
       beforeEach(() => {
         user = mock<UserWithRoles>({ address: mockUser, isAdmin: false });
         (serviceMock.findOne as jest.Mock).mockResolvedValue(transaction);
-        (logServiceMock.findAll as jest.Mock).mockResolvedValue(transactionLogs);
       });
 
       afterEach(() => {
@@ -223,22 +219,13 @@ describe("TransactionController", () => {
       });
 
       it("returns the transaction when user can see it", async () => {
-        (serviceMock.isTransactionVisibleByUser as jest.Mock).mockReturnValue(true);
+        (serviceMock.isTransactionVisibleByUser as jest.Mock).mockResolvedValue(true);
         const result = await controller.getTransaction(transactionHash, user);
-        expect(logServiceMock.findAll).toHaveBeenCalledWith(
-          { transactionHash },
-          {
-            page: 1,
-            limit: 10_000,
-          }
-        );
-        expect(serviceMock.isTransactionVisibleByUser).toHaveBeenCalledWith(transaction, transactionLogs.items, user);
+        expect(serviceMock.isTransactionVisibleByUser).toHaveBeenCalledWith(transaction, user);
         expect(result).toBe(transaction);
       });
 
       it("returns the transaction when user is admin", async () => {
-        (serviceMock.isTransactionVisibleByUser as jest.Mock).mockReturnValue(false);
-
         const result = await controller.getTransaction(
           transactionHash,
           mock<UserWithRoles>({
@@ -246,13 +233,12 @@ describe("TransactionController", () => {
             isAdmin: true,
           })
         );
-        expect(logServiceMock.findAll).not.toHaveBeenCalled();
         expect(serviceMock.isTransactionVisibleByUser).not.toHaveBeenCalled();
         expect(result).toBe(transaction);
       });
 
       it("throws NotFoundException when transaction is not visible to user", async () => {
-        (serviceMock.isTransactionVisibleByUser as jest.Mock).mockReturnValue(false);
+        (serviceMock.isTransactionVisibleByUser as jest.Mock).mockResolvedValue(false);
 
         try {
           await controller.getTransaction(transactionHash, user);

--- a/packages/api/src/transaction/transaction.controller.ts
+++ b/packages/api/src/transaction/transaction.controller.ts
@@ -85,14 +85,8 @@ export class TransactionController {
     }
 
     if (user && !user.isAdmin) {
-      const transactionLogs = await this.logService.findAll(
-        { transactionHash },
-        {
-          page: 1,
-          limit: 10_000, // default max limit used in pagination-enabled endpoints
-        }
-      );
-      if (!this.transactionService.isTransactionVisibleByUser(transactionDetail, transactionLogs.items, user)) {
+      const isVisibleByUser = await this.transactionService.isTransactionVisibleByUser(transactionDetail, user);
+      if (!isVisibleByUser) {
         throw new NotFoundException();
       }
       return transactionDetail;

--- a/packages/api/src/transaction/transaction.service.spec.ts
+++ b/packages/api/src/transaction/transaction.service.spec.ts
@@ -12,7 +12,6 @@ import { AddressTransaction } from "./entities/addressTransaction.entity";
 import { VisibleTransaction } from "./entities/visibleTransaction.entity";
 import { AddressVisibleTransaction } from "./entities/addressVisibleTransaction.entity";
 import { Block } from "../block/block.entity";
-import { Log } from "../log/log.entity";
 import { ConfigService } from "@nestjs/config";
 
 jest.mock("../common/utils", () => ({
@@ -232,10 +231,8 @@ describe("TransactionService", () => {
         expect(queryBuilderMock.addSelect).toHaveBeenCalledWith(["block.status"]);
       });
 
-      it("orders transactions by blockNumber, receivedAt and transactionIndex DESC", async () => {
+      it("orders transactions by receivedAt and transactionIndex DESC", async () => {
         await service.findAll(filterTransactionsOptions, pagingOptions);
-        expect(queryBuilderMock.orderBy).toBeCalledTimes(1);
-        expect(queryBuilderMock.orderBy).toHaveBeenCalledWith("transaction.blockNumber", "DESC");
         expect(queryBuilderMock.addOrderBy).toBeCalledTimes(2);
         expect(queryBuilderMock.addOrderBy).toHaveBeenCalledWith("transaction.receivedAt", "DESC");
         expect(queryBuilderMock.addOrderBy).toHaveBeenCalledWith("transaction.transactionIndex", "DESC");
@@ -335,13 +332,8 @@ describe("TransactionService", () => {
         expect(addressTransactionsQueryBuilderMock.addSelect).toHaveBeenCalledWith(["block.status"]);
       });
 
-      it("orders transactions by blockNumber, receivedAt and transactionIndex DESC", async () => {
+      it("orders transactions by receivedAt and transactionIndex DESC", async () => {
         await service.findAll(filterTransactionsOptions, pagingOptions);
-        expect(addressTransactionsQueryBuilderMock.orderBy).toBeCalledTimes(1);
-        expect(addressTransactionsQueryBuilderMock.orderBy).toHaveBeenCalledWith(
-          "addressTransaction.blockNumber",
-          "DESC"
-        );
         expect(addressTransactionsQueryBuilderMock.addOrderBy).toBeCalledTimes(2);
         expect(addressTransactionsQueryBuilderMock.addOrderBy).toHaveBeenCalledWith(
           "addressTransaction.receivedAt",
@@ -397,10 +389,14 @@ describe("TransactionService", () => {
           expect(visibleTransactionsQueryBuilderMock.where).toHaveBeenCalledWith({ visibleBy });
         });
 
-        it("orders by visibleTransaction.blockNumber DESC", async () => {
+        it("orders by visibleTransaction receivedAt and transactionIndex DESC", async () => {
           await service.findAll(filterTransactionsOptions, pagingOptions);
-          expect(visibleTransactionsQueryBuilderMock.orderBy).toHaveBeenCalledWith(
-            "visibleTransaction.blockNumber",
+          expect(visibleTransactionsQueryBuilderMock.addOrderBy).toHaveBeenCalledWith(
+            "visibleTransaction.receivedAt",
+            "DESC"
+          );
+          expect(visibleTransactionsQueryBuilderMock.addOrderBy).toHaveBeenCalledWith(
+            "visibleTransaction.transactionIndex",
             "DESC"
           );
         });
@@ -475,10 +471,14 @@ describe("TransactionService", () => {
           expect(addressVisibleTransactionsQueryBuilderMock.where).toHaveBeenCalledWith({ address, visibleBy });
         });
 
-        it("orders by addressVisibleTransaction.blockNumber DESC", async () => {
+        it("orders by addressVisibleTransaction receivedAt and transactionIndex DESC", async () => {
           await service.findAll(filterTransactionsOptions, pagingOptions);
-          expect(addressVisibleTransactionsQueryBuilderMock.orderBy).toHaveBeenCalledWith(
-            "addressVisibleTransaction.blockNumber",
+          expect(addressVisibleTransactionsQueryBuilderMock.addOrderBy).toHaveBeenCalledWith(
+            "addressVisibleTransaction.receivedAt",
+            "DESC"
+          );
+          expect(addressVisibleTransactionsQueryBuilderMock.addOrderBy).toHaveBeenCalledWith(
+            "addressVisibleTransaction.transactionIndex",
             "DESC"
           );
         });
@@ -514,9 +514,10 @@ describe("TransactionService", () => {
           );
         });
 
-        it("orders by transaction.blockNumber DESC", async () => {
+        it("orders by transaction receivedAt and transactionIndex DESC", async () => {
           await service.findAll(filterTransactionsOptions, pagingOptions);
-          expect(queryBuilderMock.orderBy).toHaveBeenCalledWith("transaction.blockNumber", "DESC");
+          expect(queryBuilderMock.addOrderBy).toHaveBeenCalledWith("transaction.receivedAt", "DESC");
+          expect(queryBuilderMock.addOrderBy).toHaveBeenCalledWith("transaction.transactionIndex", "DESC");
         });
 
         it("returns paginated result", async () => {
@@ -603,7 +604,7 @@ describe("TransactionService", () => {
       expect(addressTransactionsQueryBuilderMock.addSelect).toHaveBeenCalledWith(["block.status"]);
     });
 
-    it("orders transactions by blockNumber, receivedAt and transactionIndex", async () => {
+    it("orders transactions by blockNumber and transactionIndex", async () => {
       await service.findByAddress("address", {
         page: 10,
         offset: 100,
@@ -611,11 +612,7 @@ describe("TransactionService", () => {
       });
       expect(addressTransactionsQueryBuilderMock.orderBy).toBeCalledTimes(1);
       expect(addressTransactionsQueryBuilderMock.orderBy).toHaveBeenCalledWith("addressTransaction.blockNumber", "ASC");
-      expect(addressTransactionsQueryBuilderMock.addOrderBy).toBeCalledTimes(2);
-      expect(addressTransactionsQueryBuilderMock.addOrderBy).toHaveBeenCalledWith(
-        "addressTransaction.receivedAt",
-        "ASC"
-      );
+      expect(addressTransactionsQueryBuilderMock.addOrderBy).toBeCalledTimes(1);
       expect(addressTransactionsQueryBuilderMock.addOrderBy).toHaveBeenCalledWith(
         "addressTransaction.transactionIndex",
         "ASC"
@@ -825,91 +822,57 @@ describe("TransactionService", () => {
   describe("isTransactionVisibleByUser", () => {
     const userAddress = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
     const user = { address: userAddress, token: "token" };
+    const txHash = "0xabcdef1234567890";
 
     describe("when user is the sender", () => {
-      it("returns true", () => {
+      it("returns true", async () => {
         const transaction = {
+          hash: txHash,
           from: userAddress,
           to: "0x0987654321098765432109876543210987654321",
         } as Transaction;
-        const result = service.isTransactionVisibleByUser(transaction, [], user);
+        const result = await service.isTransactionVisibleByUser(transaction, user);
         expect(result).toBe(true);
       });
     });
 
     describe("when user is the receiver", () => {
-      it("returns true", () => {
+      it("returns true", async () => {
         const transaction = {
+          hash: txHash,
           from: "0x1234567890123456789012345678901234567890",
           to: userAddress,
         } as Transaction;
-        const result = service.isTransactionVisibleByUser(transaction, [], user);
+        const result = await service.isTransactionVisibleByUser(transaction, user);
         expect(result).toBe(true);
       });
     });
 
-    describe("when user address is in log topics", () => {
-      const paddedAddress = "0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+    describe("when user has a visible transaction record", () => {
       let transaction: Transaction;
 
       beforeEach(() => {
         transaction = {
+          hash: txHash,
           from: "0x1234567890123456789012345678901234567890",
           to: "0x0987654321098765432109876543210987654321",
         } as Transaction;
       });
 
-      it("returns true when user address is in topic[1]", () => {
-        const logs = [
-          {
-            topics: ["0xtopic0", paddedAddress, "0xtopic2"],
-          } as Log,
-        ];
-        const result = service.isTransactionVisibleByUser(transaction, logs, user);
+      it("returns true when a visible transaction record exists", async () => {
+        (visibleTransactionRepositoryMock.findOne as jest.Mock).mockResolvedValue({ transactionHash: txHash });
+        const result = await service.isTransactionVisibleByUser(transaction, user);
         expect(result).toBe(true);
+        expect(visibleTransactionRepositoryMock.findOne).toHaveBeenCalledWith({
+          where: { transactionHash: txHash, visibleBy: userAddress },
+          select: { transactionHash: true },
+        });
       });
 
-      it("returns true when user address is in topic[2]", () => {
-        const logs = [
-          {
-            topics: ["0xtopic0", "0xtopic1", paddedAddress],
-          } as Log,
-        ];
-        const result = service.isTransactionVisibleByUser(transaction, logs, user);
-        expect(result).toBe(true);
-      });
-
-      it("returns true when user address is in topic[3]", () => {
-        const logs = [
-          {
-            topics: ["0xtopic0", "0xtopic1", "0xtopic2", paddedAddress],
-          } as Log,
-        ];
-        const result = service.isTransactionVisibleByUser(transaction, logs, user);
-        expect(result).toBe(true);
-      });
-
-      it("returns true with case-insensitive address matching", () => {
-        const logs = [
-          {
-            topics: ["0xtopic0", paddedAddress.toUpperCase()],
-          } as Log,
-        ];
-        const result = service.isTransactionVisibleByUser(transaction, logs, user);
-        expect(result).toBe(true);
-      });
-
-      it("returns true when user address is in multiple logs", () => {
-        const logs = [
-          {
-            topics: ["0xtopic0", "0xtopic1"],
-          } as Log,
-          {
-            topics: ["0xtopic0", paddedAddress],
-          } as Log,
-        ];
-        const result = service.isTransactionVisibleByUser(transaction, logs, user);
-        expect(result).toBe(true);
+      it("returns false when no visible transaction record exists", async () => {
+        (visibleTransactionRepositoryMock.findOne as jest.Mock).mockResolvedValue(null);
+        const result = await service.isTransactionVisibleByUser(transaction, user);
+        expect(result).toBe(false);
       });
 
       describe("when disableTxVisibilityByTopics is true", () => {
@@ -917,10 +880,10 @@ describe("TransactionService", () => {
           (configServiceMock.get as jest.Mock).mockReturnValue(true);
         });
 
-        it("returns false even when user address is in log topics", () => {
-          const logs = [{ topics: ["0xtopic0", paddedAddress] } as Log];
-          const result = service.isTransactionVisibleByUser(transaction, logs, user);
+        it("returns false without querying visible transactions", async () => {
+          const result = await service.isTransactionVisibleByUser(transaction, user);
           expect(result).toBe(false);
+          expect(visibleTransactionRepositoryMock.findOne).not.toHaveBeenCalled();
         });
       });
     });
@@ -930,23 +893,15 @@ describe("TransactionService", () => {
 
       beforeEach(() => {
         transaction = {
+          hash: txHash,
           from: "0x1234567890123456789012345678901234567890",
           to: "0x0987654321098765432109876543210987654321",
         } as Transaction;
       });
 
-      it("returns false when user is not sender, receiver, or in logs", () => {
-        const logs = [
-          {
-            topics: ["0xtopic0", "0xothertopic1", "0xothertopic2"],
-          } as Log,
-        ];
-        const result = service.isTransactionVisibleByUser(transaction, logs, user);
-        expect(result).toBe(false);
-      });
-
-      it("returns false when there are no logs", () => {
-        const result = service.isTransactionVisibleByUser(transaction, [], user);
+      it("returns false when no visible transaction record exists", async () => {
+        (visibleTransactionRepositoryMock.findOne as jest.Mock).mockResolvedValue(null);
+        const result = await service.isTransactionVisibleByUser(transaction, user);
         expect(result).toBe(false);
       });
     });

--- a/packages/api/src/transaction/transaction.service.ts
+++ b/packages/api/src/transaction/transaction.service.ts
@@ -3,7 +3,7 @@ import { ConfigService } from "@nestjs/config";
 import { InjectRepository } from "@nestjs/typeorm";
 import { FindOperator, LessThanOrEqual, MoreThanOrEqual, Repository, SelectQueryBuilder } from "typeorm";
 import { Pagination } from "nestjs-typeorm-paginate";
-import { isAddressEqual, padAddressToTransactionLogTopic, paginate, computeFromToMinMax } from "../common/utils";
+import { isAddressEqual, paginate, computeFromToMinMax } from "../common/utils";
 import { CounterCriteria, IPaginationOptions, SortingOrder } from "../common/types";
 import { Transaction } from "./entities/transaction.entity";
 import { AddressTransaction } from "./entities/addressTransaction.entity";
@@ -11,7 +11,6 @@ import { VisibleTransaction } from "./entities/visibleTransaction.entity";
 import { AddressVisibleTransaction } from "./entities/addressVisibleTransaction.entity";
 import { Block, BlockStatus } from "../block/block.entity";
 import { CounterService } from "../counter/counter.service";
-import { Log } from "../log/log.entity";
 import { UserParam } from "../user/user.decorator";
 
 export interface FilterTransactionsOptions {
@@ -164,7 +163,6 @@ export class TransactionService {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private addDefaultOrder(qb: SelectQueryBuilder<any>, alias: string): void {
-    qb.orderBy(`${alias}.blockNumber`, "DESC");
     qb.addOrderBy(`${alias}.receivedAt`, "DESC");
     qb.addOrderBy(`${alias}.transactionIndex`, "DESC");
   }
@@ -207,7 +205,6 @@ export class TransactionService {
     }
     const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
     queryBuilder.orderBy("addressTransaction.blockNumber", order);
-    queryBuilder.addOrderBy("addressTransaction.receivedAt", order);
     queryBuilder.addOrderBy("addressTransaction.transactionIndex", order);
     queryBuilder.offset((page - 1) * offset);
     queryBuilder.limit(offset);
@@ -252,18 +249,23 @@ export class TransactionService {
     return this.counterService.count(Transaction, criteria);
   }
 
-  public isTransactionVisibleByUser(transaction: Transaction, transactionLogs: Log[], user: UserParam): boolean {
+  public async isTransactionVisibleByUser(transaction: Transaction, user: UserParam): Promise<boolean> {
     // A transaction is visible by a user if:
     // - user is the sender
     // - user is the receiver
     // - user is included as part of the logs topics
+    // - user's smart account produced some logs in the transaction
     if (isAddressEqual(transaction.from, user.address) || isAddressEqual(transaction.to, user.address)) {
       return true;
     }
     if (this.configService.get<boolean>("prividium.disableTxVisibilityByTopics")) {
       return false;
     }
-    const topicUserAddress = padAddressToTransactionLogTopic(user.address).toLowerCase();
-    return transactionLogs.some((log) => log.topics.some((topic) => topic.toLowerCase() === topicUserAddress));
+    return (
+      (await this.visibleTransactionRepository.findOne({
+        where: { transactionHash: transaction.hash, visibleBy: user.address },
+        select: { transactionHash: true },
+      })) != null
+    );
   }
 }

--- a/packages/worker/src/entities/addressTransaction.entity.ts
+++ b/packages/worker/src/entities/addressTransaction.entity.ts
@@ -6,7 +6,8 @@ import { hexTransformer } from "../transformers/hex.transformer";
 import { bigIntNumberTransformer } from "../transformers/bigIntNumber.transformer";
 
 @Entity({ name: "addressTransactions" })
-@Index(["address", "blockNumber", "receivedAt", "transactionIndex"])
+@Index(["address", "receivedAt", "transactionIndex"])
+@Index(["address", "blockNumber", "transactionIndex"])
 export class AddressTransaction extends BaseEntity {
   @PrimaryColumn({ generated: true, type: "bigint" })
   public readonly number: number;

--- a/packages/worker/src/entities/addressVisibleTransaction.entity.ts
+++ b/packages/worker/src/entities/addressVisibleTransaction.entity.ts
@@ -6,7 +6,7 @@ import { hexTransformer } from "../transformers/hex.transformer";
 import { bigIntNumberTransformer } from "../transformers/bigIntNumber.transformer";
 
 @Entity({ name: "addressVisibleTransactions" })
-@Index(["address", "visibleBy", "blockNumber", "receivedAt", "transactionIndex"])
+@Index(["address", "visibleBy", "receivedAt", "transactionIndex"])
 export class AddressVisibleTransaction extends BaseEntity {
   @PrimaryColumn({ generated: true, type: "bigint" })
   public readonly number: number;

--- a/packages/worker/src/entities/transaction.entity.ts
+++ b/packages/worker/src/entities/transaction.entity.ts
@@ -9,7 +9,7 @@ import { stringTransformer } from "../transformers/string.transformer";
 @Index(["receivedAt", "transactionIndex"])
 @Index(["blockNumber", "receivedAt", "transactionIndex"])
 @Index(["from", "isL1Originated", "blockNumber", "nonce"])
-@Index(["fromToMin", "fromToMax", "blockNumber", "receivedAt", "transactionIndex"])
+@Index(["fromToMin", "fromToMax", "receivedAt", "transactionIndex"])
 export class Transaction extends CountableEntity {
   @PrimaryColumn({ type: "bytea", transformer: hexTransformer })
   public readonly hash: string;

--- a/packages/worker/src/entities/visibleTransaction.entity.ts
+++ b/packages/worker/src/entities/visibleTransaction.entity.ts
@@ -6,7 +6,8 @@ import { hexTransformer } from "../transformers/hex.transformer";
 import { bigIntNumberTransformer } from "../transformers/bigIntNumber.transformer";
 
 @Entity({ name: "visibleTransactions" })
-@Index(["visibleBy", "blockNumber", "receivedAt", "transactionIndex"])
+@Index(["visibleBy", "receivedAt", "transactionIndex"])
+@Index(["transactionHash", "visibleBy"])
 export class VisibleTransaction extends BaseEntity {
   @PrimaryColumn({ generated: true, type: "bigint" })
   public readonly number: number;
@@ -15,7 +16,6 @@ export class VisibleTransaction extends BaseEntity {
   @JoinColumn({ name: "transactionHash" })
   private readonly _transaction: never;
 
-  @Index()
   @Column({ type: "bytea", transformer: hexTransformer })
   public readonly transactionHash: string;
 

--- a/packages/worker/src/migrations/1775063540019-UpdateTransactionsIndexes.ts
+++ b/packages/worker/src/migrations/1775063540019-UpdateTransactionsIndexes.ts
@@ -1,0 +1,55 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateTransactionsIndexes1775063540019 implements MigrationInterface {
+  name = "UpdateTransactionsIndexes1775063540019";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_9228143efe55cf142e861bc502"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_1f9ba40f27ea5b5179e8c45ac2"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_c954af638c99003126575112ad"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_1635dac1e1b877b7b2f9f65aef"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_f8b841e005e13e12008d9778ed"`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_0d5b5806881e34ed37a37a96a2" ON "transactions" ("fromToMin", "fromToMax", "receivedAt", "transactionIndex") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_5e6e7c912525e72be8f297c643" ON "visibleTransactions" ("transactionHash", "visibleBy") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_0951097d52fcdc05c871418a23" ON "visibleTransactions" ("visibleBy", "receivedAt", "transactionIndex") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_315b7ee8ce9935cb41eb49862c" ON "addressVisibleTransactions" ("address", "visibleBy", "receivedAt", "transactionIndex") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_fd733e62d93b4ad776eb113677" ON "addressTransactions" ("address", "blockNumber", "transactionIndex") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_b4d30b6cac6431409597b0f480" ON "addressTransactions" ("address", "receivedAt", "transactionIndex") `
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_b4d30b6cac6431409597b0f480"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_fd733e62d93b4ad776eb113677"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_315b7ee8ce9935cb41eb49862c"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_0951097d52fcdc05c871418a23"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_5e6e7c912525e72be8f297c643"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_0d5b5806881e34ed37a37a96a2"`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_f8b841e005e13e12008d9778ed" ON "addressTransactions" ("address", "blockNumber", "receivedAt", "transactionIndex") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_1635dac1e1b877b7b2f9f65aef" ON "addressVisibleTransactions" ("address", "visibleBy", "blockNumber", "receivedAt", "transactionIndex") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c954af638c99003126575112ad" ON "visibleTransactions" ("visibleBy", "blockNumber", "receivedAt", "transactionIndex") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_1f9ba40f27ea5b5179e8c45ac2" ON "visibleTransactions" ("transactionHash") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_9228143efe55cf142e861bc502" ON "transactions" ("transactionIndex", "blockNumber", "receivedAt", "fromToMin", "fromToMax") `
+    );
+  }
+}


### PR DESCRIPTION
# What ❔

- Fix transactions queries to not include `blockNumber` ordering and update indexes accordingly. When date range filter is applied the only way to make the query fast is to order by the date field first, so `blockNumber` is removed.
- Improve prividium visibility check for transaction to not load 10k logs and use visibility table instead.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [+] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [+] Tests for the changes have been added / updated.
