### PR TITLE
fix: apply joins after offset + limit

### DIFF
--- a/packages/api/src/common/types.ts
+++ b/packages/api/src/common/types.ts
@@ -14,6 +14,7 @@ export interface IPaginationOptions<CustomMetaType = IPaginationMeta> extends Ne
   filterOptions?: IPaginationFilterOptions;
   maxLimit?: number;
   canUseNumberFilterAsOffset?: boolean;
+  deferJoins?: boolean;
 }
 
 export type CounterCriteria<T> = Partial<{

--- a/packages/api/src/common/utils.spec.ts
+++ b/packages/api/src/common/utils.spec.ts
@@ -64,7 +64,9 @@ describe("utils", () => {
 
     beforeEach(() => {
       countMainQueryBuilder = mock<SelectQueryBuilder<BaseEntity>>();
-      countSubQueryBuilder = mock<SelectQueryBuilder<BaseEntity>>();
+      countSubQueryBuilder = mock<SelectQueryBuilder<BaseEntity>>({
+        expressionMap: { joinAttributes: [] } as any,
+      });
       queryBuilder = mock<SelectQueryBuilder<BaseEntity>>({
         connection: {
           createQueryBuilder: jest.fn().mockReturnValue(countMainQueryBuilder),
@@ -101,6 +103,12 @@ describe("utils", () => {
     it("sets count sub query select setting to true", async () => {
       await paginate(queryBuilder, options);
       expect(countSubQueryBuilder.select).toHaveBeenCalledWith("true");
+    });
+
+    it("clears count sub query join attributes", async () => {
+      countSubQueryBuilder.expressionMap.joinAttributes.push({} as any);
+      await paginate(queryBuilder, options);
+      expect(countSubQueryBuilder.expressionMap.joinAttributes).toHaveLength(0);
     });
 
     it("resets count sub query skip setting", async () => {

--- a/packages/api/src/common/utils.spec.ts
+++ b/packages/api/src/common/utils.spec.ts
@@ -359,6 +359,77 @@ describe("utils", () => {
         });
       });
     });
+
+    describe("when deferJoins is true", () => {
+      it("creates an outer query via clone and calls getMany on it instead of the original", async () => {
+        const outerQb = mock<SelectQueryBuilder<BaseEntity>>({
+          expressionMap: {
+            wheres: [{ type: "simple" }],
+            joinAttributes: [],
+            orderBys: { "alias.col": "DESC" },
+          } as any,
+          getMany: jest.fn().mockResolvedValue([]),
+        });
+        const innerClone = mock<SelectQueryBuilder<BaseEntity>>({
+          expressionMap: { joinAttributes: [] } as any,
+          getQuery: jest.fn().mockReturnValue("SELECT pk FROM ..."),
+          getParameters: jest.fn().mockReturnValue({ param1: "val1" }),
+        });
+
+        (queryBuilder.clone as jest.Mock)
+          .mockReturnValueOnce(innerClone) // inner subquery
+          .mockReturnValueOnce(outerQb); // outer query
+        (queryBuilder as any).alias = "entity";
+        (queryBuilder as any).expressionMap = {
+          ...queryBuilder.expressionMap,
+          mainAlias: {
+            metadata: {
+              primaryColumns: [{ databaseName: "number" }],
+            },
+          },
+          joinAttributes: [],
+          orderBys: { "entity.col": "DESC" },
+        };
+
+        await paginate(queryBuilder, { ...options, deferJoins: true }, async () => 50);
+
+        // inner clone should have select PK only and joins cleared
+        expect(innerClone.select).toHaveBeenCalledWith("entity.number");
+        // outer clone should have wheres cleared and innerJoin added
+        expect(outerQb.expressionMap.wheres).toEqual([]);
+        expect(outerQb.innerJoin).toHaveBeenCalledWith(
+          "(SELECT pk FROM ...)",
+          "_paginated",
+          `"_paginated"."entity_number" = "entity"."number"`
+        );
+        // getMany called on outer, not original
+        expect(outerQb.getMany).toHaveBeenCalledTimes(1);
+        expect(queryBuilder.getMany).not.toHaveBeenCalled();
+      });
+
+      it("skips deferred joins when canUseNumberFilterAsOffset kicks in", async () => {
+        const clonedForNumberFilter = {
+          limit: jest.fn().mockReturnThis(),
+          getOne: jest.fn().mockResolvedValue({ number: 5000 }),
+        };
+        (queryBuilder.clone as jest.Mock).mockReturnValueOnce(clonedForNumberFilter);
+
+        await paginate(
+          queryBuilder,
+          {
+            ...options,
+            page: 200,
+            deferJoins: true,
+            canUseNumberFilterAsOffset: true,
+          },
+          async () => 10000
+        );
+
+        // Should use number filter path, not deferred joins
+        expect(queryBuilder.andWhere).toHaveBeenCalled();
+        expect(queryBuilder.getMany).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   describe("formatHexAddress", () => {

--- a/packages/api/src/common/utils.spec.ts
+++ b/packages/api/src/common/utils.spec.ts
@@ -394,13 +394,13 @@ describe("utils", () => {
         await paginate(queryBuilder, { ...options, deferJoins: true }, async () => 50);
 
         // inner clone should have select PK only and joins cleared
-        expect(innerClone.select).toHaveBeenCalledWith("entity.number");
+        expect(innerClone.select).toHaveBeenCalledWith("entity.number", "number");
         // outer clone should have wheres cleared and innerJoin added
         expect(outerQb.expressionMap.wheres).toEqual([]);
         expect(outerQb.innerJoin).toHaveBeenCalledWith(
           "(SELECT pk FROM ...)",
           "_paginated",
-          `"_paginated"."entity_number" = "entity"."number"`
+          `"_paginated"."number" = "entity"."number"`
         );
         // getMany called on outer, not original
         expect(outerQb.getMany).toHaveBeenCalledTimes(1);

--- a/packages/api/src/common/utils.ts
+++ b/packages/api/src/common/utils.ts
@@ -27,6 +27,10 @@ async function countQueryWithLimit<T, CustomMetaType = IPaginationMeta>(
   const totalQueryBuilder = queryBuilder.clone();
 
   totalQueryBuilder.select("true");
+  // Remove any joins to improve performance
+  if (totalQueryBuilder.expressionMap?.joinAttributes) {
+    totalQueryBuilder.expressionMap.joinAttributes.length = 0;
+  }
   totalQueryBuilder.skip(undefined);
   totalQueryBuilder.limit(options.maxLimit);
   totalQueryBuilder.offset(undefined);

--- a/packages/api/src/common/utils.ts
+++ b/packages/api/src/common/utils.ts
@@ -29,7 +29,7 @@ async function countQueryWithLimit<T, CustomMetaType = IPaginationMeta>(
   totalQueryBuilder.select("true");
   // Remove any joins to improve performance
   if (totalQueryBuilder.expressionMap?.joinAttributes) {
-    totalQueryBuilder.expressionMap.joinAttributes.length = 0;
+    totalQueryBuilder.expressionMap.joinAttributes = [];
   }
   totalQueryBuilder.skip(undefined);
   totalQueryBuilder.limit(options.maxLimit);
@@ -72,18 +72,15 @@ async function paginateQueryBuilder<T, CustomMetaType = IPaginationMeta>(
   }
 
   let itemsQuery = queryBuilder;
+  const pkColumn = queryBuilder.expressionMap.mainAlias?.metadata?.primaryColumns[0]?.databaseName;
   // When using number filter as offset leave the query as it is as deferred joins don't improve performance in this case
-  if (options.deferJoins && !useNumberFilterAsOffset) {
+  if (options.deferJoins && !useNumberFilterAsOffset && pkColumn) {
     const alias = queryBuilder.alias;
-    const metadata = queryBuilder.expressionMap.mainAlias.metadata;
-    const pkColumn = metadata.primaryColumns[0].databaseName;
 
     // Inner subquery: only select PK with filters + limit/offset, no joins
     const innerQb = queryBuilder.clone();
-    innerQb.select(`${alias}.${pkColumn}`);
-    if (innerQb.expressionMap?.joinAttributes) {
-      innerQb.expressionMap.joinAttributes.length = 0;
-    }
+    innerQb.select(`${alias}.${pkColumn}`, pkColumn);
+    innerQb.expressionMap.joinAttributes = [];
 
     // Outer query: clone to keep selects/aliases, reorder so INNER JOIN comes first
     const outerQb = queryBuilder.clone();
@@ -91,11 +88,7 @@ async function paginateQueryBuilder<T, CustomMetaType = IPaginationMeta>(
     outerQb.offset(undefined);
     outerQb.limit(undefined);
     const originalJoins = outerQb.expressionMap.joinAttributes.splice(0);
-    outerQb.innerJoin(
-      `(${innerQb.getQuery()})`,
-      "_paginated",
-      `"_paginated"."${alias}_${pkColumn}" = "${alias}"."${pkColumn}"`
-    );
+    outerQb.innerJoin(`(${innerQb.getQuery()})`, "_paginated", `"_paginated"."${pkColumn}" = "${alias}"."${pkColumn}"`);
     outerQb.expressionMap.joinAttributes.push(...originalJoins);
 
     itemsQuery = outerQb;

--- a/packages/api/src/common/utils.ts
+++ b/packages/api/src/common/utils.ts
@@ -57,7 +57,8 @@ async function paginateQueryBuilder<T, CustomMetaType = IPaginationMeta>(
 
   queryBuilder.limit(limit);
 
-  if (options.canUseNumberFilterAsOffset && offset >= MIN_OFFSET_TO_USE_NUMBER_FILTER) {
+  const useNumberFilterAsOffset = options.canUseNumberFilterAsOffset && offset >= MIN_OFFSET_TO_USE_NUMBER_FILTER;
+  if (useNumberFilterAsOffset) {
     const topItem = (await queryBuilder.clone().limit(1).getOne()) as NumerableEntity;
     const topItemNumber = topItem?.number ?? -1;
 
@@ -70,8 +71,38 @@ async function paginateQueryBuilder<T, CustomMetaType = IPaginationMeta>(
     queryBuilder.offset(offset);
   }
 
+  let itemsQuery = queryBuilder;
+  // When using number filter as offset leave the query as it is as deferred joins don't improve performance in this case
+  if (options.deferJoins && !useNumberFilterAsOffset) {
+    const alias = queryBuilder.alias;
+    const metadata = queryBuilder.expressionMap.mainAlias.metadata;
+    const pkColumn = metadata.primaryColumns[0].databaseName;
+
+    // Inner subquery: only select PK with filters + limit/offset, no joins
+    const innerQb = queryBuilder.clone();
+    innerQb.select(`${alias}.${pkColumn}`);
+    if (innerQb.expressionMap?.joinAttributes) {
+      innerQb.expressionMap.joinAttributes.length = 0;
+    }
+
+    // Outer query: clone to keep selects/aliases, reorder so INNER JOIN comes first
+    const outerQb = queryBuilder.clone();
+    outerQb.expressionMap.wheres = [];
+    outerQb.offset(undefined);
+    outerQb.limit(undefined);
+    const originalJoins = outerQb.expressionMap.joinAttributes.splice(0);
+    outerQb.innerJoin(
+      `(${innerQb.getQuery()})`,
+      "_paginated",
+      `"_paginated"."${alias}_${pkColumn}" = "${alias}"."${pkColumn}"`
+    );
+    outerQb.expressionMap.joinAttributes.push(...originalJoins);
+
+    itemsQuery = outerQb;
+  }
+
   const [items, total] = await Promise.all([
-    queryBuilder.getMany(),
+    itemsQuery.getMany(),
     countQuery ? countQuery() : countQueryWithLimit(queryBuilder, options),
   ]);
 

--- a/packages/api/src/log/log.service.spec.ts
+++ b/packages/api/src/log/log.service.spec.ts
@@ -157,6 +157,11 @@ describe("LogService", () => {
         expect(visibleLogQueryBuilderMock.addOrderBy).toHaveBeenCalledWith("visibleLog.logIndex", "ASC");
       });
 
+      it("calls paginate with deferJoins", async () => {
+        await service.findAll({ address: address1, visibleBy: address2 }, pagingOptions);
+        expect(utils.paginate).toHaveBeenCalledWith(visibleLogQueryBuilderMock, { ...pagingOptions, deferJoins: true });
+      });
+
       it("returns unwrapped log items", async () => {
         const log = mock<Log>();
         const paginationResult = mock<Pagination<VisibleLog, IPaginationMeta>>({
@@ -190,122 +195,120 @@ describe("LogService", () => {
 
   describe("findMany", () => {
     const someAddress = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
-    let queryBuilderMock;
+    let innerQueryBuilderMock;
+    let outerQueryBuilderMock;
 
     beforeEach(() => {
-      queryBuilderMock = mock<SelectQueryBuilder<Log>>();
-      repositoryMock.createQueryBuilder.mockReturnValue(queryBuilderMock);
+      innerQueryBuilderMock = mock<SelectQueryBuilder<Log>>({
+        getQuery: jest.fn().mockReturnValue("inner query"),
+        getParameters: jest.fn().mockReturnValue({}),
+      });
+      outerQueryBuilderMock = mock<SelectQueryBuilder<Log>>({
+        getMany: jest.fn().mockResolvedValue([]),
+      });
+      (repositoryMock.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(innerQueryBuilderMock)
+        .mockReturnValueOnce(outerQueryBuilderMock);
     });
 
-    it("filters by address when address is defined", async () => {
-      await service.findMany({
-        address: someAddress,
-        topics: {},
-      });
-      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith({ address: someAddress });
+    it("creates two query builders for inner and outer queries", async () => {
+      await service.findMany({ topics: {} });
+      expect(repositoryMock.createQueryBuilder).toHaveBeenCalledTimes(2);
+      expect(repositoryMock.createQueryBuilder).toHaveBeenCalledWith("log");
     });
 
-    it("does not filter by address when address is not defined", async () => {
-      await service.findMany({
-        topics: {},
-      });
-      expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith({ address: expect.anything() });
+    it("inner query filters by address when address is defined", async () => {
+      await service.findMany({ address: someAddress, topics: {} });
+      expect(innerQueryBuilderMock.andWhere).toHaveBeenCalledWith({ address: someAddress });
     });
 
-    it("filters by fromBlock when address is defined", async () => {
-      await service.findMany({
-        fromBlock: 10,
-        topics: {},
-      });
-      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith({ blockNumber: MoreThanOrEqual(10) });
+    it("inner query does not filter by address when address is not defined", async () => {
+      await service.findMany({ topics: {} });
+      expect(innerQueryBuilderMock.andWhere).not.toHaveBeenCalledWith({ address: expect.anything() });
     });
 
-    it("filters by toBlock when address is defined", async () => {
-      await service.findMany({
-        toBlock: 10,
-        topics: {},
-      });
-      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith({ blockNumber: LessThanOrEqual(10) });
+    it("inner query filters by fromBlock", async () => {
+      await service.findMany({ fromBlock: 10, topics: {} });
+      expect(innerQueryBuilderMock.andWhere).toHaveBeenCalledWith({ blockNumber: MoreThanOrEqual(10) });
     });
 
-    it("does not restrict by block when no block conditions are sent", async () => {
-      await service.findMany({
-        topics: {},
-      });
-      expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith({ blockNumber: expect.anything() });
+    it("inner query filters by toBlock", async () => {
+      await service.findMany({ toBlock: 10, topics: {} });
+      expect(innerQueryBuilderMock.andWhere).toHaveBeenCalledWith({ blockNumber: LessThanOrEqual(10) });
+    });
+
+    it("inner query does not restrict by block when no block conditions are sent", async () => {
+      await service.findMany({ topics: {} });
+      expect(innerQueryBuilderMock.andWhere).not.toHaveBeenCalledWith({ blockNumber: expect.anything() });
     });
 
     function hexToBuf(hex: string): Buffer {
       return Buffer.from(hex.replace("0x", ""), "hex");
     }
 
-    it("filters by first topic when topic0 is defined", async () => {
+    it("inner query filters by first topic when topic0 is defined", async () => {
       const topic = "0xabab";
-      await service.findMany({
-        topics: {
-          topic0: topic,
-        },
-      });
-      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith("log.topics[1] = :topic0", {
+      await service.findMany({ topics: { topic0: topic } });
+      expect(innerQueryBuilderMock.andWhere).toHaveBeenCalledWith("log.topics[1] = :topic0", {
         topic0: hexToBuf(topic),
       });
-      expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith(/log.topics\[2\]/, expect.anything());
-      expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith(/log.topics\[3\]/, expect.anything());
-      expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith(/log.topics\[4\]/, expect.anything());
     });
 
-    it("filters by second topic when topic1 is defined", async () => {
+    it("inner query filters by second topic when topic1 is defined", async () => {
       const topic = "0xabab";
-      await service.findMany({
-        topics: {
-          topic1: topic,
-        },
-      });
-      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith("log.topics[2] = :topic1", {
+      await service.findMany({ topics: { topic1: topic } });
+      expect(innerQueryBuilderMock.andWhere).toHaveBeenCalledWith("log.topics[2] = :topic1", {
         topic1: hexToBuf(topic),
       });
-      expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith(/log.topics\[0\]/, expect.anything());
-      expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith(/log.topics\[3\]/, expect.anything());
-      expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith(/log.topics\[4\]/, expect.anything());
     });
 
-    it("filters by third topic when topic2 is defined", async () => {
+    it("inner query filters by third topic when topic2 is defined", async () => {
       const topic = "0xabab";
-      await service.findMany({
-        topics: {
-          topic2: topic,
-        },
-      });
-      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith("log.topics[3] = :topic2", {
+      await service.findMany({ topics: { topic2: topic } });
+      expect(innerQueryBuilderMock.andWhere).toHaveBeenCalledWith("log.topics[3] = :topic2", {
         topic2: hexToBuf(topic),
       });
-      expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith(/log.topics\[0\]/, expect.anything());
-      expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith(/log.topics\[1\]/, expect.anything());
-      expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith(/log.topics\[4\]/, expect.anything());
     });
 
-    it("filters by fourth topic when topic3 is defined", async () => {
+    it("inner query filters by fourth topic when topic3 is defined", async () => {
       const topic = "0xabab";
-      await service.findMany({
-        topics: {
-          topic3: topic,
-        },
-      });
-      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith("log.topics[4] = :topic3", {
+      await service.findMany({ topics: { topic3: topic } });
+      expect(innerQueryBuilderMock.andWhere).toHaveBeenCalledWith("log.topics[4] = :topic3", {
         topic3: hexToBuf(topic),
       });
-      expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith(/log.topics\[1\]/, expect.anything());
-      expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith(/log.topics\[2\]/, expect.anything());
-      expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith(/log.topics\[3\]/, expect.anything());
     });
 
-    it("applies order when provided", async () => {
-      await service.findMany({
-        order: "ASC",
-        topics: {},
-      });
-      expect(queryBuilderMock.orderBy).toHaveBeenCalledWith("log.blockNumber", "ASC");
-      expect(queryBuilderMock.addOrderBy).toHaveBeenCalledWith("log.logIndex", "ASC");
+    it("inner query sets offset and limit", async () => {
+      await service.findMany({ topics: {}, page: 3, offset: 20 });
+      expect(innerQueryBuilderMock.offset).toHaveBeenCalledWith(40);
+      expect(innerQueryBuilderMock.limit).toHaveBeenCalledWith(20);
+    });
+
+    it("outer query joins transaction and receipt", async () => {
+      await service.findMany({ topics: {} });
+      expect(outerQueryBuilderMock.leftJoin).toHaveBeenCalledWith("log.transaction", "transaction");
+      expect(outerQueryBuilderMock.leftJoin).toHaveBeenCalledWith(
+        "transaction.transactionReceipt",
+        "transactionReceipt"
+      );
+      expect(outerQueryBuilderMock.addSelect).toHaveBeenCalledWith([
+        "transaction.gasPrice",
+        "transactionReceipt.gasUsed",
+      ]);
+    });
+
+    it("applies order to both inner and outer queries", async () => {
+      await service.findMany({ order: "ASC", topics: {} });
+      expect(innerQueryBuilderMock.orderBy).toHaveBeenCalledWith("log.blockNumber", "ASC");
+      expect(innerQueryBuilderMock.addOrderBy).toHaveBeenCalledWith("log.logIndex", "ASC");
+      expect(outerQueryBuilderMock.orderBy).toHaveBeenCalledWith("log.blockNumber", "ASC");
+      expect(outerQueryBuilderMock.addOrderBy).toHaveBeenCalledWith("log.logIndex", "ASC");
+    });
+
+    it("executes outer query and returns results", async () => {
+      const result = await service.findMany({ topics: {} });
+      expect(outerQueryBuilderMock.getMany).toBeCalledTimes(1);
+      expect(result).toEqual([]);
     });
   });
 });

--- a/packages/api/src/log/log.service.ts
+++ b/packages/api/src/log/log.service.ts
@@ -54,7 +54,7 @@ export class LogService {
       qb.where({ visibleBy, ...basicFilters });
       qb.orderBy("visibleLog.timestamp", "DESC");
       qb.addOrderBy("visibleLog.logIndex", "ASC");
-      const result = await paginate<VisibleLog>(qb, paginationOptions);
+      const result = await paginate<VisibleLog>(qb, { ...paginationOptions, deferJoins: true });
       return { ...result, items: result.items.map((vl) => vl.log) };
     }
 
@@ -79,39 +79,40 @@ export class LogService {
     offset = 10,
     order = "DESC",
   }: FilterLogsByAddressAndTopicsOptions): Promise<Log[]> {
+    const innerQb = this.logRepository.createQueryBuilder("log");
+    innerQb.select("log.number");
+    if (address !== undefined) {
+      innerQb.andWhere({ address });
+    }
+    if (fromBlock !== undefined) {
+      innerQb.andWhere({ blockNumber: MoreThanOrEqual(fromBlock) });
+    }
+    if (toBlock !== undefined) {
+      innerQb.andWhere({ blockNumber: LessThanOrEqual(toBlock) });
+    }
+    if (topics.topic0 !== undefined) {
+      innerQb.andWhere("log.topics[1] = :topic0", { topic0: hexTransformer.to(topics.topic0) });
+    }
+    if (topics.topic1 !== undefined) {
+      innerQb.andWhere("log.topics[2] = :topic1", { topic1: hexTransformer.to(topics.topic1) });
+    }
+    if (topics.topic2 !== undefined) {
+      innerQb.andWhere("log.topics[3] = :topic2", { topic2: hexTransformer.to(topics.topic2) });
+    }
+    if (topics.topic3 !== undefined) {
+      innerQb.andWhere("log.topics[4] = :topic3", { topic3: hexTransformer.to(topics.topic3) });
+    }
+    innerQb.orderBy("log.blockNumber", order);
+    innerQb.addOrderBy("log.logIndex", order);
+    innerQb.offset((page - 1) * offset);
+    innerQb.limit(offset);
+
     const queryBuilder = this.logRepository.createQueryBuilder("log");
+    queryBuilder.innerJoin(`(${innerQb.getQuery()})`, "_paginated", `"_paginated"."log_number" = "log"."number"`);
+    queryBuilder.setParameters(innerQb.getParameters());
     queryBuilder.leftJoin("log.transaction", "transaction");
     queryBuilder.leftJoin("transaction.transactionReceipt", "transactionReceipt");
     queryBuilder.addSelect(["transaction.gasPrice", "transactionReceipt.gasUsed"]);
-
-    if (address !== undefined) {
-      queryBuilder.andWhere({ address });
-    }
-    if (fromBlock !== undefined) {
-      queryBuilder.andWhere({
-        blockNumber: MoreThanOrEqual(fromBlock),
-      });
-    }
-    if (toBlock !== undefined) {
-      queryBuilder.andWhere({
-        blockNumber: LessThanOrEqual(toBlock),
-      });
-    }
-    if (topics.topic0 !== undefined) {
-      queryBuilder.andWhere("log.topics[1] = :topic0", { topic0: hexTransformer.to(topics.topic0) });
-    }
-    if (topics.topic1 !== undefined) {
-      queryBuilder.andWhere("log.topics[2] = :topic1", { topic1: hexTransformer.to(topics.topic1) });
-    }
-    if (topics.topic2 !== undefined) {
-      queryBuilder.andWhere("log.topics[3] = :topic2", { topic2: hexTransformer.to(topics.topic2) });
-    }
-    if (topics.topic3 !== undefined) {
-      queryBuilder.andWhere("log.topics[4] = :topic3", { topic3: hexTransformer.to(topics.topic3) });
-    }
-
-    queryBuilder.offset((page - 1) * offset);
-    queryBuilder.limit(offset);
     queryBuilder.orderBy("log.blockNumber", order);
     queryBuilder.addOrderBy("log.logIndex", order);
     return await queryBuilder.getMany();

--- a/packages/api/src/log/log.service.ts
+++ b/packages/api/src/log/log.service.ts
@@ -80,7 +80,7 @@ export class LogService {
     order = "DESC",
   }: FilterLogsByAddressAndTopicsOptions): Promise<Log[]> {
     const innerQb = this.logRepository.createQueryBuilder("log");
-    innerQb.select("log.number");
+    innerQb.select("log.number", "number");
     if (address !== undefined) {
       innerQb.andWhere({ address });
     }
@@ -108,7 +108,7 @@ export class LogService {
     innerQb.limit(offset);
 
     const queryBuilder = this.logRepository.createQueryBuilder("log");
-    queryBuilder.innerJoin(`(${innerQb.getQuery()})`, "_paginated", `"_paginated"."log_number" = "log"."number"`);
+    queryBuilder.innerJoin(`(${innerQb.getQuery()})`, "_paginated", `"_paginated"."number" = "log"."number"`);
     queryBuilder.setParameters(innerQb.getParameters());
     queryBuilder.leftJoin("log.transaction", "transaction");
     queryBuilder.leftJoin("transaction.transactionReceipt", "transactionReceipt");

--- a/packages/api/src/transaction/transaction.service.spec.ts
+++ b/packages/api/src/transaction/transaction.service.spec.ts
@@ -556,7 +556,7 @@ describe("TransactionService", () => {
 
     it("inner query selects only PK", async () => {
       await service.findByAddress("address");
-      expect(innerQueryBuilderMock.select).toHaveBeenCalledWith("addressTransaction.number");
+      expect(innerQueryBuilderMock.select).toHaveBeenCalledWith("addressTransaction.number", "number");
     });
 
     it("inner query filters by address", async () => {
@@ -592,7 +592,7 @@ describe("TransactionService", () => {
       expect(outerQueryBuilderMock.innerJoin).toHaveBeenCalledWith(
         "(inner query)",
         "_paginated",
-        `"_paginated"."addressTransaction_number" = "addressTransaction"."number"`
+        `"_paginated"."number" = "addressTransaction"."number"`
       );
       expect(outerQueryBuilderMock.setParameters).toHaveBeenCalledWith({});
     });

--- a/packages/api/src/transaction/transaction.service.spec.ts
+++ b/packages/api/src/transaction/transaction.service.spec.ts
@@ -241,7 +241,7 @@ describe("TransactionService", () => {
       it("returns paginated result", async () => {
         const result = await service.findAll(filterTransactionsOptions, pagingOptions);
         expect(utils.paginate).toBeCalledTimes(1);
-        expect(utils.paginate).toBeCalledWith(queryBuilderMock, pagingOptions);
+        expect(utils.paginate).toBeCalledWith(queryBuilderMock, { ...pagingOptions, deferJoins: true });
         expect(result).toBe(paginationResult);
       });
     });
@@ -348,7 +348,10 @@ describe("TransactionService", () => {
       it("returns paginated result", async () => {
         const result = await service.findAll(filterTransactionsOptions, pagingOptions);
         expect(utils.paginate).toBeCalledTimes(1);
-        expect(utils.paginate).toBeCalledWith(addressTransactionsQueryBuilderMock, pagingOptions);
+        expect(utils.paginate).toBeCalledWith(addressTransactionsQueryBuilderMock, {
+          ...pagingOptions,
+          deferJoins: true,
+        });
         expect(result).toEqual({ ...paginationResult, items: paginationResult.items.map((i) => i.transaction) });
       });
     });
@@ -529,110 +532,99 @@ describe("TransactionService", () => {
   });
 
   describe("findByAddress", () => {
-    let addressTransactionsQueryBuilderMock;
+    let innerQueryBuilderMock;
+    let outerQueryBuilderMock;
 
     beforeEach(() => {
-      addressTransactionsQueryBuilderMock = mock<typeorm.SelectQueryBuilder<AddressTransaction>>({
+      innerQueryBuilderMock = mock<typeorm.SelectQueryBuilder<AddressTransaction>>({
+        getQuery: jest.fn().mockReturnValue("inner query"),
+        getParameters: jest.fn().mockReturnValue({}),
+      });
+      outerQueryBuilderMock = mock<typeorm.SelectQueryBuilder<AddressTransaction>>({
         getMany: jest.fn().mockResolvedValue([]),
       });
-      (addressTransactionRepositoryMock.createQueryBuilder as jest.Mock).mockReturnValue(
-        addressTransactionsQueryBuilderMock
-      );
+      (addressTransactionRepositoryMock.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(innerQueryBuilderMock)
+        .mockReturnValueOnce(outerQueryBuilderMock);
     });
 
-    it("creates query builder with proper params", async () => {
+    it("creates two query builders for inner and outer queries", async () => {
       await service.findByAddress("address");
-      expect(addressTransactionRepositoryMock.createQueryBuilder).toHaveBeenCalledTimes(1);
+      expect(addressTransactionRepositoryMock.createQueryBuilder).toHaveBeenCalledTimes(2);
       expect(addressTransactionRepositoryMock.createQueryBuilder).toHaveBeenCalledWith("addressTransaction");
     });
 
-    it("selects address transactions number", async () => {
+    it("inner query selects only PK", async () => {
       await service.findByAddress("address");
-      expect(addressTransactionsQueryBuilderMock.select).toBeCalledTimes(1);
-      expect(addressTransactionsQueryBuilderMock.select).toHaveBeenCalledWith("addressTransaction.number");
+      expect(innerQueryBuilderMock.select).toHaveBeenCalledWith("addressTransaction.number");
     });
 
-    it("joins transaction records", async () => {
+    it("inner query filters by address", async () => {
       await service.findByAddress("address");
-      expect(addressTransactionsQueryBuilderMock.leftJoinAndSelect).toBeCalledTimes(1);
-      expect(addressTransactionsQueryBuilderMock.leftJoinAndSelect).toHaveBeenCalledWith(
+      expect(innerQueryBuilderMock.where).toHaveBeenCalledWith({ address: "address" });
+    });
+
+    it("inner query applies block filters", async () => {
+      await service.findByAddress("address", { startBlock: 100, endBlock: 200 });
+      expect(innerQueryBuilderMock.andWhere).toBeCalledWith({
+        blockNumber: typeorm.MoreThanOrEqual(100),
+      });
+      expect(innerQueryBuilderMock.andWhere).toBeCalledWith({
+        blockNumber: typeorm.LessThanOrEqual(200),
+      });
+    });
+
+    it("inner query sets offset and limit", async () => {
+      await service.findByAddress("address", { page: 10, offset: 100 });
+      expect(innerQueryBuilderMock.offset).toHaveBeenCalledWith(900);
+      expect(innerQueryBuilderMock.limit).toHaveBeenCalledWith(100);
+    });
+
+    it("inner query orders by blockNumber and transactionIndex", async () => {
+      await service.findByAddress("address", { sort: SortingOrder.Asc });
+      expect(innerQueryBuilderMock.orderBy).toHaveBeenCalledWith("addressTransaction.blockNumber", "ASC");
+      expect(innerQueryBuilderMock.addOrderBy).toHaveBeenCalledWith("addressTransaction.transactionIndex", "ASC");
+    });
+
+    it("outer query joins via inner subquery", async () => {
+      await service.findByAddress("address");
+      expect(outerQueryBuilderMock.select).toHaveBeenCalledWith("addressTransaction.number");
+      expect(outerQueryBuilderMock.innerJoin).toHaveBeenCalledWith(
+        "(inner query)",
+        "_paginated",
+        `"_paginated"."addressTransaction_number" = "addressTransaction"."number"`
+      );
+      expect(outerQueryBuilderMock.setParameters).toHaveBeenCalledWith({});
+    });
+
+    it("outer query joins transaction details", async () => {
+      await service.findByAddress("address");
+      expect(outerQueryBuilderMock.leftJoinAndSelect).toHaveBeenCalledWith(
         "addressTransaction.transaction",
         "transaction"
       );
-    });
-
-    it("joins transactionReceipt records", async () => {
-      await service.findByAddress("address");
-      expect(addressTransactionsQueryBuilderMock.leftJoin).toHaveBeenCalledWith(
+      expect(outerQueryBuilderMock.leftJoin).toHaveBeenCalledWith(
         "transaction.transactionReceipt",
         "transactionReceipt"
       );
-      expect(addressTransactionsQueryBuilderMock.addSelect).toBeCalledWith([
+      expect(outerQueryBuilderMock.addSelect).toBeCalledWith([
         "transactionReceipt.gasUsed",
         "transactionReceipt.cumulativeGasUsed",
         "transactionReceipt.contractAddress",
       ]);
+      expect(outerQueryBuilderMock.leftJoin).toHaveBeenCalledWith("transaction.block", "block");
+      expect(outerQueryBuilderMock.addSelect).toHaveBeenCalledWith(["block.status"]);
     });
 
-    it("joins block records", async () => {
-      await service.findByAddress("address");
-      expect(addressTransactionsQueryBuilderMock.leftJoinAndSelect).toBeCalledTimes(1);
-      expect(addressTransactionsQueryBuilderMock.leftJoin).toHaveBeenCalledWith("transaction.block", "block");
-    });
-
-    it("filters transactions by the specified address", async () => {
-      await service.findByAddress("address");
-      expect(addressTransactionsQueryBuilderMock.where).toHaveBeenCalledWith({ address: "address" });
-    });
-
-    it("filters transactions by the specified options when block filters are defined", async () => {
-      const filterOptions = {
-        startBlock: 100,
-        endBlock: 200,
-      };
-      await service.findByAddress("address", filterOptions);
-      expect(addressTransactionsQueryBuilderMock.andWhere).toBeCalledWith({
-        blockNumber: typeorm.MoreThanOrEqual(filterOptions.startBlock),
-      });
-      expect(addressTransactionsQueryBuilderMock.andWhere).toBeCalledWith({
-        blockNumber: typeorm.LessThanOrEqual(filterOptions.endBlock),
-      });
-    });
-
-    it("selects only needed block fields", async () => {
-      await service.findByAddress("address");
-      expect(addressTransactionsQueryBuilderMock.addSelect).toHaveBeenCalledWith(["block.status"]);
-    });
-
-    it("orders transactions by blockNumber and transactionIndex", async () => {
-      await service.findByAddress("address", {
-        page: 10,
-        offset: 100,
-        sort: SortingOrder.Asc,
-      });
-      expect(addressTransactionsQueryBuilderMock.orderBy).toBeCalledTimes(1);
-      expect(addressTransactionsQueryBuilderMock.orderBy).toHaveBeenCalledWith("addressTransaction.blockNumber", "ASC");
-      expect(addressTransactionsQueryBuilderMock.addOrderBy).toBeCalledTimes(1);
-      expect(addressTransactionsQueryBuilderMock.addOrderBy).toHaveBeenCalledWith(
-        "addressTransaction.transactionIndex",
-        "ASC"
-      );
-    });
-
-    it("sets offset and limit", async () => {
-      await service.findByAddress("address", {
-        page: 10,
-        offset: 100,
-      });
-      expect(addressTransactionsQueryBuilderMock.offset).toBeCalledTimes(1);
-      expect(addressTransactionsQueryBuilderMock.offset).toHaveBeenCalledWith(900);
-      expect(addressTransactionsQueryBuilderMock.limit).toBeCalledTimes(1);
-      expect(addressTransactionsQueryBuilderMock.limit).toHaveBeenCalledWith(100);
+    it("outer query orders by blockNumber and transactionIndex", async () => {
+      await service.findByAddress("address", { sort: SortingOrder.Asc });
+      expect(outerQueryBuilderMock.orderBy).toHaveBeenCalledWith("addressTransaction.blockNumber", "ASC");
+      expect(outerQueryBuilderMock.addOrderBy).toHaveBeenCalledWith("addressTransaction.transactionIndex", "ASC");
     });
 
     it("returns list of transactions", async () => {
       const result = await service.findByAddress("address");
-      expect(addressTransactionsQueryBuilderMock.getMany).toBeCalledTimes(1);
+      expect(outerQueryBuilderMock.getMany).toBeCalledTimes(1);
       expect(result).toEqual([]);
     });
   });

--- a/packages/api/src/transaction/transaction.service.ts
+++ b/packages/api/src/transaction/transaction.service.ts
@@ -189,7 +189,7 @@ export class TransactionService {
 
     // Inner query: paginate on the index-only table
     const innerQb = this.addressTransactionRepository.createQueryBuilder("addressTransaction");
-    innerQb.select("addressTransaction.number");
+    innerQb.select("addressTransaction.number", "number");
     innerQb.where({ address });
     if (startBlock !== undefined) {
       innerQb.andWhere({ blockNumber: MoreThanOrEqual(startBlock) });
@@ -208,7 +208,7 @@ export class TransactionService {
     queryBuilder.innerJoin(
       `(${innerQb.getQuery()})`,
       "_paginated",
-      `"_paginated"."addressTransaction_number" = "addressTransaction"."number"`
+      `"_paginated"."number" = "addressTransaction"."number"`
     );
     queryBuilder.setParameters(innerQb.getParameters());
     queryBuilder.leftJoinAndSelect("addressTransaction.transaction", "transaction");

--- a/packages/api/src/transaction/transaction.service.ts
+++ b/packages/api/src/transaction/transaction.service.ts
@@ -85,7 +85,7 @@ export class TransactionService {
           ...commonFilters,
         });
         this.addDefaultOrder(qb, "transaction");
-        return await paginate<Transaction>(qb, paginationOptions);
+        return await paginate<Transaction>(qb, { ...paginationOptions, deferJoins: true });
       }
 
       // query transactions visible to the user for the address (including topics with user's address)
@@ -99,7 +99,9 @@ export class TransactionService {
         ...commonFilters,
       });
       this.addDefaultOrder(qb, "addressVisibleTransaction");
-      return this.unwrapTransactions(await paginate<AddressVisibleTransaction>(qb, paginationOptions));
+      return this.unwrapTransactions(
+        await paginate<AddressVisibleTransaction>(qb, { ...paginationOptions, deferJoins: true })
+      );
     }
 
     // Case 2: all transactions visible to a user - own transactions + transactions including topics with user's address (prividium)
@@ -119,7 +121,9 @@ export class TransactionService {
         ...commonFilters,
       });
       this.addDefaultOrder(qb, "visibleTransaction");
-      return this.unwrapTransactions(await paginate<VisibleTransaction>(qb, paginationOptions));
+      return this.unwrapTransactions(
+        await paginate<VisibleTransaction>(qb, { ...paginationOptions, deferJoins: true })
+      );
     }
 
     // Case 3: viewing transactions for an arbitrary address (non prividium) or own transactions (prividium)
@@ -132,7 +136,7 @@ export class TransactionService {
     this.addTransactionJoins(qb);
     qb.where(commonFilters);
     this.addDefaultOrder(qb, "transaction");
-    return await paginate<Transaction>(qb, paginationOptions);
+    return await paginate<Transaction>(qb, { ...paginationOptions, deferJoins: true });
   }
 
   private async queryAddressTransactions(
@@ -150,7 +154,7 @@ export class TransactionService {
       ...(filterOptions.blockNumber !== undefined && { blockNumber: filterOptions.blockNumber }),
     });
     this.addDefaultOrder(qb, "addressTransaction");
-    return this.unwrapTransactions(await paginate<AddressTransaction>(qb, paginationOptions));
+    return this.unwrapTransactions(await paginate<AddressTransaction>(qb, { ...paginationOptions, deferJoins: true }));
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -181,8 +185,32 @@ export class TransactionService {
       sort = SortingOrder.Desc,
     }: FindByAddressFilterTransactionsOptions = {}
   ): Promise<AddressTransaction[]> {
+    const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
+
+    // Inner query: paginate on the index-only table
+    const innerQb = this.addressTransactionRepository.createQueryBuilder("addressTransaction");
+    innerQb.select("addressTransaction.number");
+    innerQb.where({ address });
+    if (startBlock !== undefined) {
+      innerQb.andWhere({ blockNumber: MoreThanOrEqual(startBlock) });
+    }
+    if (endBlock !== undefined) {
+      innerQb.andWhere({ blockNumber: LessThanOrEqual(endBlock) });
+    }
+    innerQb.orderBy("addressTransaction.blockNumber", order);
+    innerQb.addOrderBy("addressTransaction.transactionIndex", order);
+    innerQb.offset((page - 1) * offset);
+    innerQb.limit(offset);
+
+    // Outer query: join transaction details only for the paginated rows
     const queryBuilder = this.addressTransactionRepository.createQueryBuilder("addressTransaction");
     queryBuilder.select("addressTransaction.number");
+    queryBuilder.innerJoin(
+      `(${innerQb.getQuery()})`,
+      "_paginated",
+      `"_paginated"."addressTransaction_number" = "addressTransaction"."number"`
+    );
+    queryBuilder.setParameters(innerQb.getParameters());
     queryBuilder.leftJoinAndSelect("addressTransaction.transaction", "transaction");
     queryBuilder.leftJoin("transaction.transactionReceipt", "transactionReceipt");
     queryBuilder.addSelect([
@@ -192,24 +220,9 @@ export class TransactionService {
     ]);
     queryBuilder.leftJoin("transaction.block", "block");
     queryBuilder.addSelect(["block.status"]);
-    queryBuilder.where({ address });
-    if (startBlock !== undefined) {
-      queryBuilder.andWhere({
-        blockNumber: MoreThanOrEqual(startBlock),
-      });
-    }
-    if (endBlock !== undefined) {
-      queryBuilder.andWhere({
-        blockNumber: LessThanOrEqual(endBlock),
-      });
-    }
-    const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
     queryBuilder.orderBy("addressTransaction.blockNumber", order);
     queryBuilder.addOrderBy("addressTransaction.transactionIndex", order);
-    queryBuilder.offset((page - 1) * offset);
-    queryBuilder.limit(offset);
-    const addressTransactions = await queryBuilder.getMany();
-    return addressTransactions;
+    return await queryBuilder.getMany();
   }
 
   private getAccountNonceQueryBuilder(accountAddress: string, isVerified: boolean): SelectQueryBuilder<Transaction> {

--- a/packages/api/src/transfer/transfer.service.spec.ts
+++ b/packages/api/src/transfer/transfer.service.spec.ts
@@ -127,7 +127,7 @@ describe("TransferService", () => {
         (utils.paginate as jest.Mock).mockResolvedValue(paginationResult);
         const result = await service.findAll(filterOptions, pagingOptions);
         expect(utils.paginate).toBeCalledTimes(1);
-        expect(utils.paginate).toBeCalledWith(queryBuilderMock, pagingOptions);
+        expect(utils.paginate).toBeCalledWith(queryBuilderMock, { ...pagingOptions, deferJoins: true });
         expect(result).toBe(paginationResult);
       });
     });
@@ -193,7 +193,7 @@ describe("TransferService", () => {
         (utils.paginate as jest.Mock).mockResolvedValue(paginationResult);
         const result = await service.findAll(filterOptions, pagingOptions);
         expect(utils.paginate).toBeCalledTimes(1);
-        expect(utils.paginate).toBeCalledWith(addressTransfersQueryBuilderMock, pagingOptions);
+        expect(utils.paginate).toBeCalledWith(addressTransfersQueryBuilderMock, { ...pagingOptions, deferJoins: true });
         expect(result).toStrictEqual({ ...paginationResult, items: transfers });
       });
     });
@@ -257,15 +257,33 @@ describe("TransferService", () => {
   });
 
   describe("findTokenTransfers", () => {
-    let queryBuilderMock;
+    let innerQueryBuilderMock;
+    let outerQueryBuilderMock;
+    let innerAddressTransfersQbMock;
+    let outerAddressTransfersQbMock;
     let filterOptions: FilterTokenTransfersOptions;
-    let addressTransfersQueryBuilderMock;
 
     beforeEach(() => {
-      queryBuilderMock = mock<typeorm.SelectQueryBuilder<Transfer>>();
-      addressTransfersQueryBuilderMock = mock<typeorm.SelectQueryBuilder<AddressTransfer>>();
-      (transferRepositoryMock.createQueryBuilder as jest.Mock).mockReturnValue(queryBuilderMock);
-      (addressTransferRepositoryMock.createQueryBuilder as jest.Mock).mockReturnValue(addressTransfersQueryBuilderMock);
+      innerQueryBuilderMock = mock<typeorm.SelectQueryBuilder<Transfer>>({
+        getQuery: jest.fn().mockReturnValue("inner query"),
+        getParameters: jest.fn().mockReturnValue({}),
+      });
+      outerQueryBuilderMock = mock<typeorm.SelectQueryBuilder<Transfer>>({
+        getMany: jest.fn().mockResolvedValue([]),
+      });
+      innerAddressTransfersQbMock = mock<typeorm.SelectQueryBuilder<AddressTransfer>>({
+        getQuery: jest.fn().mockReturnValue("inner query"),
+        getParameters: jest.fn().mockReturnValue({}),
+      });
+      outerAddressTransfersQbMock = mock<typeorm.SelectQueryBuilder<AddressTransfer>>({
+        getMany: jest.fn().mockResolvedValue([]),
+      });
+      (transferRepositoryMock.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(innerQueryBuilderMock)
+        .mockReturnValueOnce(outerQueryBuilderMock);
+      (addressTransferRepositoryMock.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(innerAddressTransfersQbMock)
+        .mockReturnValueOnce(outerAddressTransfersQbMock);
     });
 
     describe("when address filter options is not specified", () => {
@@ -281,121 +299,66 @@ describe("TransferService", () => {
         );
       });
 
-      it("creates query builder with proper params", async () => {
+      it("creates two query builders for inner and outer queries", async () => {
         await service.findTokenTransfers(filterOptions);
-        expect(transferRepositoryMock.createQueryBuilder).toHaveBeenCalledTimes(1);
+        expect(transferRepositoryMock.createQueryBuilder).toHaveBeenCalledTimes(2);
         expect(transferRepositoryMock.createQueryBuilder).toHaveBeenCalledWith("transfer");
       });
 
-      describe("when token type is ERC20", () => {
-        it("adds tokenAddress filter", async () => {
-          await service.findTokenTransfers(filterOptions);
-          expect(queryBuilderMock.where).toBeCalledTimes(1);
-          expect(queryBuilderMock.where).toHaveBeenCalledWith({
-            tokenAddress: filterOptions.tokenAddress,
-          });
-        });
-      });
-
-      describe("when token type is ERC721", () => {
-        it("adds tokenAddress filter", async () => {
-          await service.findTokenTransfers({
-            ...filterOptions,
-            tokenType: TokenType.ERC721,
-          });
-          expect(queryBuilderMock.where).toBeCalledTimes(1);
-          expect(queryBuilderMock.where).toHaveBeenCalledWith({
-            tokenAddress: "tokenAddress",
-          });
-        });
-      });
-
-      it("joins token records to the transfers", async () => {
+      it("inner query filters by tokenAddress", async () => {
         await service.findTokenTransfers(filterOptions);
-        expect(queryBuilderMock.leftJoinAndSelect).toBeCalledTimes(1);
-        expect(queryBuilderMock.leftJoinAndSelect).toHaveBeenCalledWith("transfer.token", "token");
+        expect(innerQueryBuilderMock.select).toHaveBeenCalledWith("transfer.number");
+        expect(innerQueryBuilderMock.where).toHaveBeenCalledWith({ tokenAddress: "tokenAddress" });
       });
 
-      it("joins transactions and transaction receipts records to the transfers", async () => {
-        await service.findTokenTransfers(filterOptions);
-        expect(queryBuilderMock.leftJoin).toHaveBeenCalledTimes(2);
-        expect(queryBuilderMock.addSelect).toHaveBeenCalledTimes(2);
-        expect(queryBuilderMock.leftJoin).toHaveBeenCalledWith("transfer.transaction", "transaction");
-        expect(queryBuilderMock.addSelect).toHaveBeenCalledWith([
-          "transaction.nonce",
-          "transaction.blockHash",
-          "transaction.transactionIndex",
-          "transaction.gasLimit",
-          "transaction.gasPrice",
-          "transaction.data",
-          "transaction.fee",
-          "transaction.type",
-        ]);
-        expect(queryBuilderMock.leftJoin).toHaveBeenCalledWith("transaction.transactionReceipt", "transactionReceipt");
-        expect(queryBuilderMock.addSelect).toHaveBeenCalledWith([
-          "transactionReceipt.gasUsed",
-          "transactionReceipt.cumulativeGasUsed",
-        ]);
-      });
-
-      it("adds start block filter when startBlock is specified", async () => {
-        await service.findTokenTransfers({
-          ...filterOptions,
-          startBlock: 10,
-        });
-        expect(queryBuilderMock.andWhere).toBeCalledTimes(1);
-        expect(queryBuilderMock.andWhere).toHaveBeenCalledWith({
+      it("inner query adds start block filter when startBlock is specified", async () => {
+        await service.findTokenTransfers({ ...filterOptions, startBlock: 10 });
+        expect(innerQueryBuilderMock.andWhere).toHaveBeenCalledWith({
           blockNumber: typeorm.MoreThanOrEqual(10),
         });
       });
 
-      it("adds end block filter when endBlock is specified", async () => {
-        await service.findTokenTransfers({
-          ...filterOptions,
-          endBlock: 10,
-        });
-        expect(queryBuilderMock.andWhere).toBeCalledTimes(1);
-        expect(queryBuilderMock.andWhere).toHaveBeenCalledWith({
+      it("inner query adds end block filter when endBlock is specified", async () => {
+        await service.findTokenTransfers({ ...filterOptions, endBlock: 10 });
+        expect(innerQueryBuilderMock.andWhere).toHaveBeenCalledWith({
           blockNumber: typeorm.LessThanOrEqual(10),
         });
       });
 
+      it("inner query sets offset and limit", async () => {
+        await service.findTokenTransfers({ ...filterOptions, page: 2, offset: 100 });
+        expect(innerQueryBuilderMock.offset).toHaveBeenCalledWith(100);
+        expect(innerQueryBuilderMock.limit).toHaveBeenCalledWith(100);
+      });
+
       it("sorts by descending order by default", async () => {
         await service.findTokenTransfers(filterOptions);
-        expect(queryBuilderMock.orderBy).toBeCalledTimes(1);
-        expect(queryBuilderMock.orderBy).toHaveBeenCalledWith("transfer.blockNumber", "DESC");
-        expect(queryBuilderMock.addOrderBy).toBeCalledTimes(1);
-        expect(queryBuilderMock.addOrderBy).toHaveBeenCalledWith("transfer.logIndex", "DESC");
+        expect(innerQueryBuilderMock.orderBy).toHaveBeenCalledWith("transfer.blockNumber", "DESC");
+        expect(innerQueryBuilderMock.addOrderBy).toHaveBeenCalledWith("transfer.logIndex", "DESC");
+        expect(outerQueryBuilderMock.orderBy).toHaveBeenCalledWith("transfer.blockNumber", "DESC");
+        expect(outerQueryBuilderMock.addOrderBy).toHaveBeenCalledWith("transfer.logIndex", "DESC");
       });
 
       it("sorts by ascending order if specified", async () => {
-        await service.findTokenTransfers({
-          ...filterOptions,
-          sort: SortingOrder.Asc,
-        });
-        expect(queryBuilderMock.orderBy).toBeCalledTimes(1);
-        expect(queryBuilderMock.orderBy).toHaveBeenCalledWith("transfer.blockNumber", "ASC");
-        expect(queryBuilderMock.addOrderBy).toBeCalledTimes(1);
-        expect(queryBuilderMock.addOrderBy).toHaveBeenCalledWith("transfer.logIndex", "ASC");
+        await service.findTokenTransfers({ ...filterOptions, sort: SortingOrder.Asc });
+        expect(innerQueryBuilderMock.orderBy).toHaveBeenCalledWith("transfer.blockNumber", "ASC");
+        expect(outerQueryBuilderMock.orderBy).toHaveBeenCalledWith("transfer.blockNumber", "ASC");
       });
 
-      it("sets offset and limit", async () => {
-        await service.findTokenTransfers({
-          ...filterOptions,
-          page: 2,
-          offset: 100,
-        });
-        expect(queryBuilderMock.offset).toBeCalledTimes(1);
-        expect(queryBuilderMock.offset).toHaveBeenCalledWith(100);
-        expect(queryBuilderMock.limit).toBeCalledTimes(1);
-        expect(queryBuilderMock.limit).toHaveBeenCalledWith(100);
+      it("outer query joins token, transaction and receipt", async () => {
+        await service.findTokenTransfers(filterOptions);
+        expect(outerQueryBuilderMock.leftJoinAndSelect).toHaveBeenCalledWith("transfer.token", "token");
+        expect(outerQueryBuilderMock.leftJoin).toHaveBeenCalledWith("transfer.transaction", "transaction");
+        expect(outerQueryBuilderMock.leftJoin).toHaveBeenCalledWith(
+          "transaction.transactionReceipt",
+          "transactionReceipt"
+        );
       });
 
-      it("executes query and returns transfers list", async () => {
-        jest.spyOn(queryBuilderMock, "getMany").mockResolvedValue([]);
+      it("executes outer query and returns transfers list", async () => {
         const result = await service.findTokenTransfers(filterOptions);
         expect(result).toEqual([]);
-        expect(queryBuilderMock.getMany).toBeCalledTimes(1);
+        expect(outerQueryBuilderMock.getMany).toBeCalledTimes(1);
       });
     });
 
@@ -404,180 +367,131 @@ describe("TransferService", () => {
         filterOptions = {
           address: "address",
         };
-        jest.spyOn(addressTransfersQueryBuilderMock, "getMany").mockResolvedValue([
-          {
-            transfer: { blockNumber: 10 },
-          },
-        ]);
+        jest.spyOn(outerAddressTransfersQbMock, "getMany").mockResolvedValue([{ transfer: { blockNumber: 10 } }]);
       });
 
-      it("creates query builder with proper params", async () => {
+      it("creates two query builders for inner and outer queries", async () => {
         await service.findTokenTransfers(filterOptions);
-        expect(addressTransferRepositoryMock.createQueryBuilder).toHaveBeenCalledTimes(1);
+        expect(addressTransferRepositoryMock.createQueryBuilder).toHaveBeenCalledTimes(2);
         expect(addressTransferRepositoryMock.createQueryBuilder).toHaveBeenCalledWith("addressTransfer");
       });
 
       describe("when token type is ERC20", () => {
-        it("adds address and ERC20 filter", async () => {
+        it("inner query adds address and ERC20 filter", async () => {
           await service.findTokenTransfers(filterOptions);
-          expect(addressTransfersQueryBuilderMock.where).toBeCalledTimes(1);
-          expect(addressTransfersQueryBuilderMock.where).toHaveBeenCalledWith({
-            address: filterOptions.address,
-          });
-          expect(addressTransfersQueryBuilderMock.andWhere).toBeCalledTimes(1);
-          expect(addressTransfersQueryBuilderMock.andWhere).toHaveBeenCalledWith(
+          expect(innerAddressTransfersQbMock.where).toHaveBeenCalledWith({ address: "address" });
+          expect(innerAddressTransfersQbMock.andWhere).toHaveBeenCalledWith(
             `"addressTransfer"."tokenType" = :tokenType`,
-            {
-              tokenType: TokenType.ERC20,
-            }
+            { tokenType: TokenType.ERC20 }
           );
         });
       });
 
       describe("when token type is ERC721", () => {
-        it("adds ERC721 filter", async () => {
-          await service.findTokenTransfers({
-            ...filterOptions,
-            tokenType: TokenType.ERC721,
-          });
-          expect(addressTransfersQueryBuilderMock.where).toBeCalledTimes(1);
-          expect(addressTransfersQueryBuilderMock.where).toHaveBeenCalledWith({
-            address: filterOptions.address,
-          });
-          expect(addressTransfersQueryBuilderMock.andWhere).toBeCalledTimes(1);
-          expect(addressTransfersQueryBuilderMock.andWhere).toHaveBeenCalledWith(
+        it("inner query adds ERC721 filter", async () => {
+          await service.findTokenTransfers({ ...filterOptions, tokenType: TokenType.ERC721 });
+          expect(innerAddressTransfersQbMock.andWhere).toHaveBeenCalledWith(
             `"addressTransfer"."tokenType" = :tokenType`,
-            {
-              tokenType: TokenType.ERC721,
-            }
+            { tokenType: TokenType.ERC721 }
           );
         });
       });
 
       describe("when token address is specified", () => {
-        it("adds token address filter", async () => {
+        it("inner query adds token address filter", async () => {
           await service.findTokenTransfers({
             ...filterOptions,
             tokenAddress: "0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35E",
           });
-          expect(addressTransfersQueryBuilderMock.andWhere).toBeCalledTimes(1);
-          expect(addressTransfersQueryBuilderMock.andWhere).toHaveBeenCalledWith(
+          expect(innerAddressTransfersQbMock.andWhere).toHaveBeenCalledWith(
             `"addressTransfer"."tokenAddress" = :tokenAddress`,
-            {
-              tokenAddress: normalizeAddressTransformer.to("0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35E"),
-            }
+            { tokenAddress: normalizeAddressTransformer.to("0xc7e0220d02d549c4846A6EC31D89C3B670Ebe35E") }
           );
         });
       });
 
-      it("joins transfers and tokens records to the address transfers", async () => {
-        await service.findTokenTransfers(filterOptions);
-        expect(addressTransfersQueryBuilderMock.leftJoinAndSelect).toBeCalledTimes(2);
-        expect(addressTransfersQueryBuilderMock.leftJoinAndSelect).toHaveBeenCalledWith(
-          "addressTransfer.transfer",
-          "transfer"
-        );
-        expect(addressTransfersQueryBuilderMock.leftJoinAndSelect).toHaveBeenCalledWith("transfer.token", "token");
+      it("inner query sets offset and limit", async () => {
+        await service.findTokenTransfers({ ...filterOptions, page: 2, offset: 100 });
+        expect(innerAddressTransfersQbMock.offset).toHaveBeenCalledWith(100);
+        expect(innerAddressTransfersQbMock.limit).toHaveBeenCalledWith(100);
       });
 
-      it("joins transactions and transaction receipts records to the transfers", async () => {
-        await service.findTokenTransfers(filterOptions);
-        expect(addressTransfersQueryBuilderMock.leftJoin).toBeCalledTimes(2);
-        expect(addressTransfersQueryBuilderMock.addSelect).toBeCalledTimes(2);
-        expect(addressTransfersQueryBuilderMock.leftJoin).toHaveBeenCalledWith("transfer.transaction", "transaction");
-        expect(addressTransfersQueryBuilderMock.addSelect).toHaveBeenCalledWith([
-          "transaction.nonce",
-          "transaction.blockHash",
-          "transaction.transactionIndex",
-          "transaction.gasLimit",
-          "transaction.gasPrice",
-          "transaction.data",
-          "transaction.fee",
-          "transaction.type",
-        ]);
-        expect(addressTransfersQueryBuilderMock.leftJoin).toHaveBeenCalledWith(
-          "transaction.transactionReceipt",
-          "transactionReceipt"
-        );
-        expect(addressTransfersQueryBuilderMock.addSelect).toHaveBeenCalledWith([
-          "transactionReceipt.gasUsed",
-          "transactionReceipt.cumulativeGasUsed",
-        ]);
-      });
-
-      it("adds start block filter when startBlock is specified", async () => {
-        await service.findTokenTransfers({
-          ...filterOptions,
-          startBlock: 10,
-        });
-        expect(addressTransfersQueryBuilderMock.andWhere).toHaveBeenCalledWith({
+      it("inner query adds start block filter when startBlock is specified", async () => {
+        await service.findTokenTransfers({ ...filterOptions, startBlock: 10 });
+        expect(innerAddressTransfersQbMock.andWhere).toHaveBeenCalledWith({
           blockNumber: typeorm.MoreThanOrEqual(10),
         });
       });
 
-      it("adds end block filter when endBlock is specified", async () => {
-        await service.findTokenTransfers({
-          ...filterOptions,
-          endBlock: 10,
-        });
-        expect(addressTransfersQueryBuilderMock.andWhere).toHaveBeenCalledWith({
+      it("inner query adds end block filter when endBlock is specified", async () => {
+        await service.findTokenTransfers({ ...filterOptions, endBlock: 10 });
+        expect(innerAddressTransfersQbMock.andWhere).toHaveBeenCalledWith({
           blockNumber: typeorm.LessThanOrEqual(10),
         });
       });
 
+      it("outer query joins transfers, tokens, transaction and receipt", async () => {
+        await service.findTokenTransfers(filterOptions);
+        expect(outerAddressTransfersQbMock.leftJoinAndSelect).toHaveBeenCalledWith(
+          "addressTransfer.transfer",
+          "transfer"
+        );
+        expect(outerAddressTransfersQbMock.leftJoinAndSelect).toHaveBeenCalledWith("transfer.token", "token");
+        expect(outerAddressTransfersQbMock.leftJoin).toHaveBeenCalledWith("transfer.transaction", "transaction");
+        expect(outerAddressTransfersQbMock.leftJoin).toHaveBeenCalledWith(
+          "transaction.transactionReceipt",
+          "transactionReceipt"
+        );
+      });
+
       it("sorts by descending order by default", async () => {
         await service.findTokenTransfers(filterOptions);
-        expect(addressTransfersQueryBuilderMock.orderBy).toBeCalledTimes(1);
-        expect(addressTransfersQueryBuilderMock.orderBy).toHaveBeenCalledWith("addressTransfer.blockNumber", "DESC");
-        expect(addressTransfersQueryBuilderMock.addOrderBy).toBeCalledTimes(1);
-        expect(addressTransfersQueryBuilderMock.addOrderBy).toHaveBeenCalledWith("addressTransfer.logIndex", "DESC");
+        expect(innerAddressTransfersQbMock.orderBy).toHaveBeenCalledWith("addressTransfer.blockNumber", "DESC");
+        expect(outerAddressTransfersQbMock.orderBy).toHaveBeenCalledWith("addressTransfer.blockNumber", "DESC");
       });
 
       it("sorts by ascending order if specified", async () => {
-        await service.findTokenTransfers({
-          ...filterOptions,
-          sort: SortingOrder.Asc,
-        });
-        expect(addressTransfersQueryBuilderMock.orderBy).toBeCalledTimes(1);
-        expect(addressTransfersQueryBuilderMock.orderBy).toHaveBeenCalledWith("addressTransfer.blockNumber", "ASC");
-        expect(addressTransfersQueryBuilderMock.addOrderBy).toBeCalledTimes(1);
-        expect(addressTransfersQueryBuilderMock.addOrderBy).toHaveBeenCalledWith("addressTransfer.logIndex", "ASC");
+        await service.findTokenTransfers({ ...filterOptions, sort: SortingOrder.Asc });
+        expect(innerAddressTransfersQbMock.orderBy).toHaveBeenCalledWith("addressTransfer.blockNumber", "ASC");
+        expect(outerAddressTransfersQbMock.orderBy).toHaveBeenCalledWith("addressTransfer.blockNumber", "ASC");
       });
 
-      it("sets offset and limit", async () => {
-        await service.findTokenTransfers({
-          ...filterOptions,
-          page: 2,
-          offset: 100,
-        });
-        expect(addressTransfersQueryBuilderMock.offset).toBeCalledTimes(1);
-        expect(addressTransfersQueryBuilderMock.offset).toHaveBeenCalledWith(100);
-        expect(addressTransfersQueryBuilderMock.limit).toBeCalledTimes(1);
-        expect(addressTransfersQueryBuilderMock.limit).toHaveBeenCalledWith(100);
-      });
-
-      it("executes query and returns transfers list", async () => {
+      it("executes outer query and returns transfers list", async () => {
         const result = await service.findTokenTransfers(filterOptions);
-        expect(result).toEqual([
-          {
-            blockNumber: 10,
-          },
-        ]);
-        expect(addressTransfersQueryBuilderMock.getMany).toBeCalledTimes(1);
+        expect(result).toEqual([{ blockNumber: 10 }]);
+        expect(outerAddressTransfersQbMock.getMany).toBeCalledTimes(1);
       });
     });
   });
 
   describe("findInternalTransfers", () => {
-    let queryBuilderMock;
+    let innerQueryBuilderMock;
+    let outerQueryBuilderMock;
+    let innerAddressTransfersQbMock;
+    let outerAddressTransfersQbMock;
     let filterOptions: FilterInternalTransfersOptions;
-    let addressTransfersQueryBuilderMock;
 
     beforeEach(() => {
-      queryBuilderMock = mock<typeorm.SelectQueryBuilder<Transfer>>();
-      addressTransfersQueryBuilderMock = mock<typeorm.SelectQueryBuilder<AddressTransfer>>();
-      (transferRepositoryMock.createQueryBuilder as jest.Mock).mockReturnValue(queryBuilderMock);
-      (addressTransferRepositoryMock.createQueryBuilder as jest.Mock).mockReturnValue(addressTransfersQueryBuilderMock);
+      innerQueryBuilderMock = mock<typeorm.SelectQueryBuilder<Transfer>>({
+        getQuery: jest.fn().mockReturnValue("inner query"),
+        getParameters: jest.fn().mockReturnValue({}),
+      });
+      outerQueryBuilderMock = mock<typeorm.SelectQueryBuilder<Transfer>>({
+        getMany: jest.fn().mockResolvedValue([]),
+      });
+      innerAddressTransfersQbMock = mock<typeorm.SelectQueryBuilder<AddressTransfer>>({
+        getQuery: jest.fn().mockReturnValue("inner query"),
+        getParameters: jest.fn().mockReturnValue({}),
+      });
+      outerAddressTransfersQbMock = mock<typeorm.SelectQueryBuilder<AddressTransfer>>({
+        getMany: jest.fn().mockResolvedValue([]),
+      });
+      (transferRepositoryMock.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(innerQueryBuilderMock)
+        .mockReturnValueOnce(outerQueryBuilderMock);
+      (addressTransferRepositoryMock.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(innerAddressTransfersQbMock)
+        .mockReturnValueOnce(outerAddressTransfersQbMock);
     });
 
     describe("when address filter options is not specified", () => {
@@ -585,20 +499,16 @@ describe("TransferService", () => {
         filterOptions = {};
       });
 
-      it("creates query builder with proper params", async () => {
+      it("creates two query builders for inner and outer queries", async () => {
         await service.findInternalTransfers();
-        expect(transferRepositoryMock.createQueryBuilder).toHaveBeenCalledTimes(1);
+        expect(transferRepositoryMock.createQueryBuilder).toHaveBeenCalledTimes(2);
         expect(transferRepositoryMock.createQueryBuilder).toHaveBeenCalledWith("transfer");
       });
 
       describe("when transaction hash filter is specified", () => {
-        it("adds transaction hash filter", async () => {
-          await service.findInternalTransfers({
-            ...filterOptions,
-            transactionHash: "txhash",
-          });
-          expect(queryBuilderMock.where).toBeCalledTimes(1);
-          expect(queryBuilderMock.where).toHaveBeenCalledWith({
+        it("inner query adds transaction hash filter", async () => {
+          await service.findInternalTransfers({ ...filterOptions, transactionHash: "txhash" });
+          expect(innerQueryBuilderMock.where).toHaveBeenCalledWith({
             transactionHash: "txhash",
             isInternal: true,
           });
@@ -606,210 +516,141 @@ describe("TransferService", () => {
       });
 
       describe("when transaction hash filter is not specified", () => {
-        it("does not add transaction hash filter", async () => {
+        it("inner query does not add transaction hash filter", async () => {
           await service.findInternalTransfers(filterOptions);
-          expect(queryBuilderMock.where).toBeCalledTimes(1);
-          expect(queryBuilderMock.where).toHaveBeenCalledWith({
-            isInternal: true,
-          });
+          expect(innerQueryBuilderMock.where).toHaveBeenCalledWith({ isInternal: true });
         });
       });
 
-      it("joins transactions and transaction receipts records to the transfers", async () => {
+      it("outer query joins transactions and transaction receipts", async () => {
         await service.findInternalTransfers(filterOptions);
-        expect(queryBuilderMock.leftJoin).toBeCalledTimes(2);
-        expect(queryBuilderMock.addSelect).toBeCalledTimes(2);
-        expect(queryBuilderMock.leftJoin).toHaveBeenCalledWith("transfer.transaction", "transaction");
-        expect(queryBuilderMock.addSelect).toHaveBeenCalledWith([
+        expect(outerQueryBuilderMock.leftJoin).toHaveBeenCalledWith("transfer.transaction", "transaction");
+        expect(outerQueryBuilderMock.addSelect).toHaveBeenCalledWith([
           "transaction.receiptStatus",
           "transaction.gasLimit",
           "transaction.fee",
           "transaction.type",
         ]);
-        expect(queryBuilderMock.leftJoin).toHaveBeenCalledWith("transaction.transactionReceipt", "transactionReceipt");
-        expect(queryBuilderMock.addSelect).toHaveBeenCalledWith([
+        expect(outerQueryBuilderMock.leftJoin).toHaveBeenCalledWith(
+          "transaction.transactionReceipt",
+          "transactionReceipt"
+        );
+        expect(outerQueryBuilderMock.addSelect).toHaveBeenCalledWith([
           "transactionReceipt.gasUsed",
           "transactionReceipt.contractAddress",
         ]);
       });
 
-      it("adds start block filter when startBlock is specified", async () => {
-        await service.findInternalTransfers({
-          ...filterOptions,
-          startBlock: 10,
-        });
-        expect(queryBuilderMock.andWhere).toBeCalledTimes(1);
-        expect(queryBuilderMock.andWhere).toHaveBeenCalledWith({
+      it("inner query adds start block filter when startBlock is specified", async () => {
+        await service.findInternalTransfers({ ...filterOptions, startBlock: 10 });
+        expect(innerQueryBuilderMock.andWhere).toHaveBeenCalledWith({
           blockNumber: typeorm.MoreThanOrEqual(10),
         });
       });
 
-      it("adds end block filter when endBlock is specified", async () => {
-        await service.findInternalTransfers({
-          ...filterOptions,
-          endBlock: 10,
-        });
-        expect(queryBuilderMock.andWhere).toBeCalledTimes(1);
-        expect(queryBuilderMock.andWhere).toHaveBeenCalledWith({
+      it("inner query adds end block filter when endBlock is specified", async () => {
+        await service.findInternalTransfers({ ...filterOptions, endBlock: 10 });
+        expect(innerQueryBuilderMock.andWhere).toHaveBeenCalledWith({
           blockNumber: typeorm.LessThanOrEqual(10),
         });
       });
 
       it("sorts by descending order by default", async () => {
         await service.findInternalTransfers(filterOptions);
-        expect(queryBuilderMock.orderBy).toBeCalledTimes(1);
-        expect(queryBuilderMock.orderBy).toHaveBeenCalledWith("transfer.blockNumber", "DESC");
-        expect(queryBuilderMock.addOrderBy).toBeCalledTimes(1);
-        expect(queryBuilderMock.addOrderBy).toHaveBeenCalledWith("transfer.logIndex", "DESC");
+        expect(innerQueryBuilderMock.orderBy).toHaveBeenCalledWith("transfer.blockNumber", "DESC");
+        expect(innerQueryBuilderMock.addOrderBy).toHaveBeenCalledWith("transfer.logIndex", "DESC");
+        expect(outerQueryBuilderMock.orderBy).toHaveBeenCalledWith("transfer.blockNumber", "DESC");
+        expect(outerQueryBuilderMock.addOrderBy).toHaveBeenCalledWith("transfer.logIndex", "DESC");
       });
 
       it("sorts by ascending order if specified", async () => {
-        await service.findInternalTransfers({
-          ...filterOptions,
-          sort: SortingOrder.Asc,
-        });
-        expect(queryBuilderMock.orderBy).toBeCalledTimes(1);
-        expect(queryBuilderMock.orderBy).toHaveBeenCalledWith("transfer.blockNumber", "ASC");
-        expect(queryBuilderMock.addOrderBy).toBeCalledTimes(1);
-        expect(queryBuilderMock.addOrderBy).toHaveBeenCalledWith("transfer.logIndex", "ASC");
+        await service.findInternalTransfers({ ...filterOptions, sort: SortingOrder.Asc });
+        expect(innerQueryBuilderMock.orderBy).toHaveBeenCalledWith("transfer.blockNumber", "ASC");
+        expect(outerQueryBuilderMock.orderBy).toHaveBeenCalledWith("transfer.blockNumber", "ASC");
       });
 
-      it("sets offset and limit", async () => {
-        await service.findInternalTransfers({
-          ...filterOptions,
-          page: 2,
-          offset: 100,
-        });
-        expect(queryBuilderMock.offset).toBeCalledTimes(1);
-        expect(queryBuilderMock.offset).toHaveBeenCalledWith(100);
-        expect(queryBuilderMock.limit).toBeCalledTimes(1);
-        expect(queryBuilderMock.limit).toHaveBeenCalledWith(100);
+      it("inner query sets offset and limit", async () => {
+        await service.findInternalTransfers({ ...filterOptions, page: 2, offset: 100 });
+        expect(innerQueryBuilderMock.offset).toHaveBeenCalledWith(100);
+        expect(innerQueryBuilderMock.limit).toHaveBeenCalledWith(100);
       });
 
-      it("executes query and returns transfers list", async () => {
-        jest.spyOn(queryBuilderMock, "getMany").mockResolvedValue([]);
+      it("executes outer query and returns transfers list", async () => {
         const result = await service.findInternalTransfers(filterOptions);
         expect(result).toEqual([]);
-        expect(queryBuilderMock.getMany).toBeCalledTimes(1);
+        expect(outerQueryBuilderMock.getMany).toBeCalledTimes(1);
       });
     });
 
     describe("when address filter option is specified", () => {
       beforeEach(() => {
-        filterOptions = {
-          address: "address",
-        };
-        jest.spyOn(addressTransfersQueryBuilderMock, "getMany").mockResolvedValue([
-          {
-            transfer: { blockNumber: 10 },
-          },
-        ]);
+        filterOptions = { address: "address" };
+        jest.spyOn(outerAddressTransfersQbMock, "getMany").mockResolvedValue([{ transfer: { blockNumber: 10 } }]);
       });
 
-      it("creates query builder with proper params", async () => {
+      it("creates two query builders for inner and outer queries", async () => {
         await service.findInternalTransfers(filterOptions);
-        expect(addressTransferRepositoryMock.createQueryBuilder).toHaveBeenCalledTimes(1);
+        expect(addressTransferRepositoryMock.createQueryBuilder).toHaveBeenCalledTimes(2);
         expect(addressTransferRepositoryMock.createQueryBuilder).toHaveBeenCalledWith("addressTransfer");
       });
 
-      it("adds address filter", async () => {
+      it("inner query adds address filter", async () => {
         await service.findInternalTransfers(filterOptions);
-        expect(addressTransfersQueryBuilderMock.where).toBeCalledTimes(1);
-        expect(addressTransfersQueryBuilderMock.where).toHaveBeenCalledWith({
-          address: filterOptions.address,
+        expect(innerAddressTransfersQbMock.where).toHaveBeenCalledWith({
+          address: "address",
           isInternal: true,
         });
       });
 
-      it("joins transfers records to the address transfers", async () => {
+      it("outer query joins transfers, transaction and receipt", async () => {
         await service.findInternalTransfers(filterOptions);
-        expect(addressTransfersQueryBuilderMock.leftJoinAndSelect).toBeCalledTimes(1);
-        expect(addressTransfersQueryBuilderMock.leftJoinAndSelect).toHaveBeenCalledWith(
+        expect(outerAddressTransfersQbMock.leftJoinAndSelect).toHaveBeenCalledWith(
           "addressTransfer.transfer",
           "transfer"
         );
-      });
-
-      it("joins transactions and transaction receipts records to the transfers", async () => {
-        await service.findInternalTransfers(filterOptions);
-        expect(addressTransfersQueryBuilderMock.leftJoin).toBeCalledTimes(2);
-        expect(addressTransfersQueryBuilderMock.addSelect).toBeCalledTimes(2);
-        expect(addressTransfersQueryBuilderMock.leftJoin).toHaveBeenCalledWith("transfer.transaction", "transaction");
-        expect(addressTransfersQueryBuilderMock.addSelect).toHaveBeenCalledWith([
-          "transaction.receiptStatus",
-          "transaction.gasLimit",
-          "transaction.fee",
-          "transaction.type",
-        ]);
-        expect(addressTransfersQueryBuilderMock.leftJoin).toHaveBeenCalledWith(
+        expect(outerAddressTransfersQbMock.leftJoin).toHaveBeenCalledWith("transfer.transaction", "transaction");
+        expect(outerAddressTransfersQbMock.leftJoin).toHaveBeenCalledWith(
           "transaction.transactionReceipt",
           "transactionReceipt"
         );
-        expect(addressTransfersQueryBuilderMock.addSelect).toHaveBeenCalledWith([
-          "transactionReceipt.gasUsed",
-          "transactionReceipt.contractAddress",
-        ]);
       });
 
-      it("adds start block filter when startBlock is specified", async () => {
-        await service.findInternalTransfers({
-          ...filterOptions,
-          startBlock: 10,
-        });
-        expect(addressTransfersQueryBuilderMock.andWhere).toHaveBeenCalledWith({
+      it("inner query adds start block filter when startBlock is specified", async () => {
+        await service.findInternalTransfers({ ...filterOptions, startBlock: 10 });
+        expect(innerAddressTransfersQbMock.andWhere).toHaveBeenCalledWith({
           blockNumber: typeorm.MoreThanOrEqual(10),
         });
       });
 
-      it("adds end block filter when endBlock is specified", async () => {
-        await service.findInternalTransfers({
-          ...filterOptions,
-          endBlock: 10,
-        });
-        expect(addressTransfersQueryBuilderMock.andWhere).toHaveBeenCalledWith({
+      it("inner query adds end block filter when endBlock is specified", async () => {
+        await service.findInternalTransfers({ ...filterOptions, endBlock: 10 });
+        expect(innerAddressTransfersQbMock.andWhere).toHaveBeenCalledWith({
           blockNumber: typeorm.LessThanOrEqual(10),
         });
       });
 
       it("sorts by descending order by default", async () => {
         await service.findInternalTransfers(filterOptions);
-        expect(addressTransfersQueryBuilderMock.orderBy).toBeCalledTimes(1);
-        expect(addressTransfersQueryBuilderMock.orderBy).toHaveBeenCalledWith("addressTransfer.blockNumber", "DESC");
-        expect(addressTransfersQueryBuilderMock.addOrderBy).toBeCalledTimes(1);
-        expect(addressTransfersQueryBuilderMock.addOrderBy).toHaveBeenCalledWith("addressTransfer.logIndex", "DESC");
+        expect(innerAddressTransfersQbMock.orderBy).toHaveBeenCalledWith("addressTransfer.blockNumber", "DESC");
+        expect(outerAddressTransfersQbMock.orderBy).toHaveBeenCalledWith("addressTransfer.blockNumber", "DESC");
       });
 
       it("sorts by ascending order if specified", async () => {
-        await service.findInternalTransfers({
-          ...filterOptions,
-          sort: SortingOrder.Asc,
-        });
-        expect(addressTransfersQueryBuilderMock.orderBy).toBeCalledTimes(1);
-        expect(addressTransfersQueryBuilderMock.orderBy).toHaveBeenCalledWith("addressTransfer.blockNumber", "ASC");
-        expect(addressTransfersQueryBuilderMock.addOrderBy).toBeCalledTimes(1);
-        expect(addressTransfersQueryBuilderMock.addOrderBy).toHaveBeenCalledWith("addressTransfer.logIndex", "ASC");
+        await service.findInternalTransfers({ ...filterOptions, sort: SortingOrder.Asc });
+        expect(innerAddressTransfersQbMock.orderBy).toHaveBeenCalledWith("addressTransfer.blockNumber", "ASC");
+        expect(outerAddressTransfersQbMock.orderBy).toHaveBeenCalledWith("addressTransfer.blockNumber", "ASC");
       });
 
-      it("sets offset and limit", async () => {
-        await service.findInternalTransfers({
-          ...filterOptions,
-          page: 2,
-          offset: 100,
-        });
-        expect(addressTransfersQueryBuilderMock.offset).toBeCalledTimes(1);
-        expect(addressTransfersQueryBuilderMock.offset).toHaveBeenCalledWith(100);
-        expect(addressTransfersQueryBuilderMock.limit).toBeCalledTimes(1);
-        expect(addressTransfersQueryBuilderMock.limit).toHaveBeenCalledWith(100);
+      it("inner query sets offset and limit", async () => {
+        await service.findInternalTransfers({ ...filterOptions, page: 2, offset: 100 });
+        expect(innerAddressTransfersQbMock.offset).toHaveBeenCalledWith(100);
+        expect(innerAddressTransfersQbMock.limit).toHaveBeenCalledWith(100);
       });
 
-      it("executes query and returns transfers list", async () => {
+      it("executes outer query and returns transfers list", async () => {
         const result = await service.findInternalTransfers(filterOptions);
-        expect(result).toEqual([
-          {
-            blockNumber: 10,
-          },
-        ]);
-        expect(addressTransfersQueryBuilderMock.getMany).toBeCalledTimes(1);
+        expect(result).toEqual([{ blockNumber: 10 }]);
+        expect(outerAddressTransfersQbMock.getMany).toBeCalledTimes(1);
       });
     });
   });

--- a/packages/api/src/transfer/transfer.service.spec.ts
+++ b/packages/api/src/transfer/transfer.service.spec.ts
@@ -307,7 +307,7 @@ describe("TransferService", () => {
 
       it("inner query filters by tokenAddress", async () => {
         await service.findTokenTransfers(filterOptions);
-        expect(innerQueryBuilderMock.select).toHaveBeenCalledWith("transfer.number");
+        expect(innerQueryBuilderMock.select).toHaveBeenCalledWith("transfer.number", "number");
         expect(innerQueryBuilderMock.where).toHaveBeenCalledWith({ tokenAddress: "tokenAddress" });
       });
 

--- a/packages/api/src/transfer/transfer.service.ts
+++ b/packages/api/src/transfer/transfer.service.ts
@@ -112,7 +112,7 @@ export class TransferService {
       const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
 
       const innerQb = this.addressTransferRepository.createQueryBuilder("addressTransfer");
-      innerQb.select("addressTransfer.number");
+      innerQb.select("addressTransfer.number", "number");
       innerQb.where({ address });
       if (tokenAddress) {
         innerQb.andWhere(`"addressTransfer"."tokenAddress" = :tokenAddress`, {
@@ -137,7 +137,7 @@ export class TransferService {
       queryBuilder.innerJoin(
         `(${innerQb.getQuery()})`,
         "_paginated",
-        `"_paginated"."addressTransfer_number" = "addressTransfer"."number"`
+        `"_paginated"."number" = "addressTransfer"."number"`
       );
       queryBuilder.setParameters(innerQb.getParameters());
       queryBuilder.leftJoinAndSelect("addressTransfer.transfer", "transfer");
@@ -166,7 +166,7 @@ export class TransferService {
     const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
 
     const innerQb = this.transferRepository.createQueryBuilder("transfer");
-    innerQb.select("transfer.number");
+    innerQb.select("transfer.number", "number");
     innerQb.where({ tokenAddress });
     if (startBlock !== undefined) {
       innerQb.andWhere({ blockNumber: MoreThanOrEqual(startBlock) });
@@ -180,11 +180,7 @@ export class TransferService {
     innerQb.limit(offset);
 
     const queryBuilder = this.transferRepository.createQueryBuilder("transfer");
-    queryBuilder.innerJoin(
-      `(${innerQb.getQuery()})`,
-      "_paginated",
-      `"_paginated"."transfer_number" = "transfer"."number"`
-    );
+    queryBuilder.innerJoin(`(${innerQb.getQuery()})`, "_paginated", `"_paginated"."number" = "transfer"."number"`);
     queryBuilder.setParameters(innerQb.getParameters());
     queryBuilder.leftJoinAndSelect("transfer.token", "token");
     queryBuilder.leftJoin("transfer.transaction", "transaction");
@@ -218,7 +214,7 @@ export class TransferService {
       const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
 
       const innerQb = this.addressTransferRepository.createQueryBuilder("addressTransfer");
-      innerQb.select("addressTransfer.number");
+      innerQb.select("addressTransfer.number", "number");
       innerQb.where({ address, isInternal: true });
       if (startBlock !== undefined) {
         innerQb.andWhere({ blockNumber: MoreThanOrEqual(startBlock) });
@@ -236,7 +232,7 @@ export class TransferService {
       queryBuilder.innerJoin(
         `(${innerQb.getQuery()})`,
         "_paginated",
-        `"_paginated"."addressTransfer_number" = "addressTransfer"."number"`
+        `"_paginated"."number" = "addressTransfer"."number"`
       );
       queryBuilder.setParameters(innerQb.getParameters());
       queryBuilder.leftJoinAndSelect("addressTransfer.transfer", "transfer");
@@ -257,7 +253,7 @@ export class TransferService {
     const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
 
     const innerQb = this.transferRepository.createQueryBuilder("transfer");
-    innerQb.select("transfer.number");
+    innerQb.select("transfer.number", "number");
     innerQb.where({
       ...(transactionHash && { transactionHash }),
       isInternal: true,
@@ -274,11 +270,7 @@ export class TransferService {
     innerQb.limit(offset);
 
     const queryBuilder = this.transferRepository.createQueryBuilder("transfer");
-    queryBuilder.innerJoin(
-      `(${innerQb.getQuery()})`,
-      "_paginated",
-      `"_paginated"."transfer_number" = "transfer"."number"`
-    );
+    queryBuilder.innerJoin(`(${innerQb.getQuery()})`, "_paginated", `"_paginated"."number" = "transfer"."number"`);
     queryBuilder.setParameters(innerQb.getParameters());
     queryBuilder.leftJoin("transfer.transaction", "transaction");
     queryBuilder.addSelect([

--- a/packages/api/src/transfer/transfer.service.ts
+++ b/packages/api/src/transfer/transfer.service.ts
@@ -66,7 +66,7 @@ export class TransferService {
         queryBuilder.leftJoinAndSelect("transfer.token", "token");
         queryBuilder.orderBy("transfer.timestamp", "DESC");
         queryBuilder.addOrderBy("transfer.logIndex", "ASC");
-        return await paginate<Transfer>(queryBuilder, paginationOptions);
+        return await paginate<Transfer>(queryBuilder, { ...paginationOptions, deferJoins: true });
       }
       if (options.transactionHash) {
         // transactionHash is highly selective — OR over a handful of rows is negligible
@@ -80,7 +80,7 @@ export class TransferService {
         queryBuilder.leftJoinAndSelect("transfer.token", "token");
         queryBuilder.orderBy("transfer.timestamp", "DESC");
         queryBuilder.addOrderBy("transfer.logIndex", "ASC");
-        return await paginate<Transfer>(queryBuilder, paginationOptions);
+        return await paginate<Transfer>(queryBuilder, { ...paginationOptions, deferJoins: true });
       }
       // own transfers: address === visibleBy or no address
       return this.findAddressTransfers({ ...options, address: visibleBy }, paginationOptions);
@@ -95,7 +95,7 @@ export class TransferService {
     queryBuilder.leftJoinAndSelect("transfer.token", "token");
     queryBuilder.orderBy("transfer.timestamp", "DESC");
     queryBuilder.addOrderBy("transfer.logIndex", "ASC");
-    return await paginate<Transfer>(queryBuilder, paginationOptions);
+    return await paginate<Transfer>(queryBuilder, { ...paginationOptions, deferJoins: true });
   }
 
   public async findTokenTransfers({
@@ -109,8 +109,37 @@ export class TransferService {
     sort = SortingOrder.Desc,
   }: FilterTokenTransfersOptions = {}): Promise<Transfer[]> {
     if (address) {
+      const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
+
+      const innerQb = this.addressTransferRepository.createQueryBuilder("addressTransfer");
+      innerQb.select("addressTransfer.number");
+      innerQb.where({ address });
+      if (tokenAddress) {
+        innerQb.andWhere(`"addressTransfer"."tokenAddress" = :tokenAddress`, {
+          tokenAddress: normalizeAddressTransformer.to(tokenAddress),
+        });
+      } else {
+        innerQb.andWhere(`"addressTransfer"."tokenType" = :tokenType`, { tokenType });
+      }
+      if (startBlock !== undefined) {
+        innerQb.andWhere({ blockNumber: MoreThanOrEqual(startBlock) });
+      }
+      if (endBlock !== undefined) {
+        innerQb.andWhere({ blockNumber: LessThanOrEqual(endBlock) });
+      }
+      innerQb.orderBy("addressTransfer.blockNumber", order);
+      innerQb.addOrderBy("addressTransfer.logIndex", order);
+      innerQb.offset((page - 1) * offset);
+      innerQb.limit(offset);
+
       const queryBuilder = this.addressTransferRepository.createQueryBuilder("addressTransfer");
       queryBuilder.select("addressTransfer.number");
+      queryBuilder.innerJoin(
+        `(${innerQb.getQuery()})`,
+        "_paginated",
+        `"_paginated"."addressTransfer_number" = "addressTransfer"."number"`
+      );
+      queryBuilder.setParameters(innerQb.getParameters());
       queryBuilder.leftJoinAndSelect("addressTransfer.transfer", "transfer");
       queryBuilder.leftJoinAndSelect("transfer.token", "token");
       queryBuilder.leftJoin("transfer.transaction", "transaction");
@@ -126,40 +155,37 @@ export class TransferService {
       ]);
       queryBuilder.leftJoin("transaction.transactionReceipt", "transactionReceipt");
       queryBuilder.addSelect(["transactionReceipt.gasUsed", "transactionReceipt.cumulativeGasUsed"]);
-      queryBuilder.where({
-        address,
-      });
-      if (tokenAddress) {
-        queryBuilder.andWhere(`"addressTransfer"."tokenAddress" = :tokenAddress`, {
-          tokenAddress: normalizeAddressTransformer.to(tokenAddress),
-        });
-      } else {
-        queryBuilder.andWhere(`"addressTransfer"."tokenType" = :tokenType`, {
-          tokenType,
-        });
-      }
-      if (startBlock !== undefined) {
-        queryBuilder.andWhere({
-          blockNumber: MoreThanOrEqual(startBlock),
-        });
-      }
-      if (endBlock !== undefined) {
-        queryBuilder.andWhere({
-          blockNumber: LessThanOrEqual(endBlock),
-        });
-      }
-      const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
       queryBuilder.orderBy("addressTransfer.blockNumber", order);
       queryBuilder.addOrderBy("addressTransfer.logIndex", order);
-      queryBuilder.offset((page - 1) * offset);
-      queryBuilder.limit(offset);
       const addressTransfers = await queryBuilder.getMany();
       return addressTransfers.map((item) => item.transfer);
     }
     if (!tokenAddress) {
       throw new BadRequestException("Error! Missing address or contract address");
     }
+    const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
+
+    const innerQb = this.transferRepository.createQueryBuilder("transfer");
+    innerQb.select("transfer.number");
+    innerQb.where({ tokenAddress });
+    if (startBlock !== undefined) {
+      innerQb.andWhere({ blockNumber: MoreThanOrEqual(startBlock) });
+    }
+    if (endBlock !== undefined) {
+      innerQb.andWhere({ blockNumber: LessThanOrEqual(endBlock) });
+    }
+    innerQb.orderBy("transfer.blockNumber", order);
+    innerQb.addOrderBy("transfer.logIndex", order);
+    innerQb.offset((page - 1) * offset);
+    innerQb.limit(offset);
+
     const queryBuilder = this.transferRepository.createQueryBuilder("transfer");
+    queryBuilder.innerJoin(
+      `(${innerQb.getQuery()})`,
+      "_paginated",
+      `"_paginated"."transfer_number" = "transfer"."number"`
+    );
+    queryBuilder.setParameters(innerQb.getParameters());
     queryBuilder.leftJoinAndSelect("transfer.token", "token");
     queryBuilder.leftJoin("transfer.transaction", "transaction");
     queryBuilder.addSelect([
@@ -174,26 +200,9 @@ export class TransferService {
     ]);
     queryBuilder.leftJoin("transaction.transactionReceipt", "transactionReceipt");
     queryBuilder.addSelect(["transactionReceipt.gasUsed", "transactionReceipt.cumulativeGasUsed"]);
-    queryBuilder.where({
-      tokenAddress,
-    });
-    if (startBlock !== undefined) {
-      queryBuilder.andWhere({
-        blockNumber: MoreThanOrEqual(startBlock),
-      });
-    }
-    if (endBlock !== undefined) {
-      queryBuilder.andWhere({
-        blockNumber: LessThanOrEqual(endBlock),
-      });
-    }
-    const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
     queryBuilder.orderBy("transfer.blockNumber", order);
     queryBuilder.addOrderBy("transfer.logIndex", order);
-    queryBuilder.offset((page - 1) * offset);
-    queryBuilder.limit(offset);
-    const transfers = await queryBuilder.getMany();
-    return transfers;
+    return await queryBuilder.getMany();
   }
 
   public async findInternalTransfers({
@@ -206,8 +215,30 @@ export class TransferService {
     sort = SortingOrder.Desc,
   }: FilterInternalTransfersOptions = {}): Promise<Transfer[]> {
     if (address) {
+      const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
+
+      const innerQb = this.addressTransferRepository.createQueryBuilder("addressTransfer");
+      innerQb.select("addressTransfer.number");
+      innerQb.where({ address, isInternal: true });
+      if (startBlock !== undefined) {
+        innerQb.andWhere({ blockNumber: MoreThanOrEqual(startBlock) });
+      }
+      if (endBlock !== undefined) {
+        innerQb.andWhere({ blockNumber: LessThanOrEqual(endBlock) });
+      }
+      innerQb.orderBy("addressTransfer.blockNumber", order);
+      innerQb.addOrderBy("addressTransfer.logIndex", order);
+      innerQb.offset((page - 1) * offset);
+      innerQb.limit(offset);
+
       const queryBuilder = this.addressTransferRepository.createQueryBuilder("addressTransfer");
       queryBuilder.select("addressTransfer.number");
+      queryBuilder.innerJoin(
+        `(${innerQb.getQuery()})`,
+        "_paginated",
+        `"_paginated"."addressTransfer_number" = "addressTransfer"."number"`
+      );
+      queryBuilder.setParameters(innerQb.getParameters());
       queryBuilder.leftJoinAndSelect("addressTransfer.transfer", "transfer");
       queryBuilder.leftJoin("transfer.transaction", "transaction");
       queryBuilder.addSelect([
@@ -218,29 +249,37 @@ export class TransferService {
       ]);
       queryBuilder.leftJoin("transaction.transactionReceipt", "transactionReceipt");
       queryBuilder.addSelect(["transactionReceipt.gasUsed", "transactionReceipt.contractAddress"]);
-      queryBuilder.where({
-        address,
-        isInternal: true,
-      });
-      if (startBlock !== undefined) {
-        queryBuilder.andWhere({
-          blockNumber: MoreThanOrEqual(startBlock),
-        });
-      }
-      if (endBlock !== undefined) {
-        queryBuilder.andWhere({
-          blockNumber: LessThanOrEqual(endBlock),
-        });
-      }
-      const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
       queryBuilder.orderBy("addressTransfer.blockNumber", order);
       queryBuilder.addOrderBy("addressTransfer.logIndex", order);
-      queryBuilder.offset((page - 1) * offset);
-      queryBuilder.limit(offset);
       const addressTransfers = await queryBuilder.getMany();
       return addressTransfers.map((item) => item.transfer);
     }
+    const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
+
+    const innerQb = this.transferRepository.createQueryBuilder("transfer");
+    innerQb.select("transfer.number");
+    innerQb.where({
+      ...(transactionHash && { transactionHash }),
+      isInternal: true,
+    });
+    if (startBlock !== undefined) {
+      innerQb.andWhere({ blockNumber: MoreThanOrEqual(startBlock) });
+    }
+    if (endBlock !== undefined) {
+      innerQb.andWhere({ blockNumber: LessThanOrEqual(endBlock) });
+    }
+    innerQb.orderBy("transfer.blockNumber", order);
+    innerQb.addOrderBy("transfer.logIndex", order);
+    innerQb.offset((page - 1) * offset);
+    innerQb.limit(offset);
+
     const queryBuilder = this.transferRepository.createQueryBuilder("transfer");
+    queryBuilder.innerJoin(
+      `(${innerQb.getQuery()})`,
+      "_paginated",
+      `"_paginated"."transfer_number" = "transfer"."number"`
+    );
+    queryBuilder.setParameters(innerQb.getParameters());
     queryBuilder.leftJoin("transfer.transaction", "transaction");
     queryBuilder.addSelect([
       "transaction.receiptStatus",
@@ -250,29 +289,9 @@ export class TransferService {
     ]);
     queryBuilder.leftJoin("transaction.transactionReceipt", "transactionReceipt");
     queryBuilder.addSelect(["transactionReceipt.gasUsed", "transactionReceipt.contractAddress"]);
-    queryBuilder.where({
-      ...(transactionHash && {
-        transactionHash,
-      }),
-      isInternal: true,
-    });
-    if (startBlock !== undefined) {
-      queryBuilder.andWhere({
-        blockNumber: MoreThanOrEqual(startBlock),
-      });
-    }
-    if (endBlock !== undefined) {
-      queryBuilder.andWhere({
-        blockNumber: LessThanOrEqual(endBlock),
-      });
-    }
-    const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
     queryBuilder.orderBy("transfer.blockNumber", order);
     queryBuilder.addOrderBy("transfer.logIndex", order);
-    queryBuilder.offset((page - 1) * offset);
-    queryBuilder.limit(offset);
-    const transfers = await queryBuilder.getMany();
-    return transfers;
+    return await queryBuilder.getMany();
   }
 
   private async findAddressTransfers(
@@ -286,7 +305,7 @@ export class TransferService {
     queryBuilder.where(where);
     queryBuilder.orderBy("addressTransfer.timestamp", "DESC");
     queryBuilder.addOrderBy("addressTransfer.logIndex", "ASC");
-    const addressTransfers = await paginate<AddressTransfer>(queryBuilder, paginationOptions);
+    const addressTransfers = await paginate<AddressTransfer>(queryBuilder, { ...paginationOptions, deferJoins: true });
     return {
       ...addressTransfers,
       items: addressTransfers.items.map((item) => item.transfer),

--- a/packages/api/src/transfer/transfer.service.ts
+++ b/packages/api/src/transfer/transfer.service.ts
@@ -209,9 +209,9 @@ export class TransferService {
     offset = 10,
     sort = SortingOrder.Desc,
   }: FilterInternalTransfersOptions = {}): Promise<Transfer[]> {
-    if (address) {
-      const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
+    const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
 
+    if (address) {
       const innerQb = this.addressTransferRepository.createQueryBuilder("addressTransfer");
       innerQb.select("addressTransfer.number", "number");
       innerQb.where({ address, isInternal: true });
@@ -249,7 +249,6 @@ export class TransferService {
       const addressTransfers = await queryBuilder.getMany();
       return addressTransfers.map((item) => item.transfer);
     }
-    const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
 
     const innerQb = this.transferRepository.createQueryBuilder("transfer");
     innerQb.select("transfer.number", "number");

--- a/packages/api/src/transfer/transfer.service.ts
+++ b/packages/api/src/transfer/transfer.service.ts
@@ -108,9 +108,9 @@ export class TransferService {
     offset = 10,
     sort = SortingOrder.Desc,
   }: FilterTokenTransfersOptions = {}): Promise<Transfer[]> {
-    if (address) {
-      const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
+    const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
 
+    if (address) {
       const innerQb = this.addressTransferRepository.createQueryBuilder("addressTransfer");
       innerQb.select("addressTransfer.number", "number");
       innerQb.where({ address });
@@ -163,7 +163,6 @@ export class TransferService {
     if (!tokenAddress) {
       throw new BadRequestException("Error! Missing address or contract address");
     }
-    const order = sort === SortingOrder.Asc ? "ASC" : "DESC";
 
     const innerQb = this.transferRepository.createQueryBuilder("transfer");
     innerQb.select("transfer.number", "number");


### PR DESCRIPTION
# What ❔

- Apply joins after limit to avoid additional index scans on joins with big offsets.
- Remove joins from count queries.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [+] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [+] Tests for the changes have been added / updated.
