### PR TITLE
fix: preserve deep link across Prividium login redirect

### DIFF
--- a/packages/app/src/composables/useLogin.ts
+++ b/packages/app/src/composables/useLogin.ts
@@ -14,7 +14,7 @@ type LoginState = {
 
 type UseLogin = ToRefs<LoginState> & {
   login: (redirectPath?: string) => Promise<void>;
-  logout: () => Promise<void>;
+  logout: (options?: { redirectToLogin?: boolean }) => Promise<void>;
   initializeLogin: () => Promise<void>;
   handlePrividiumCallback: () => Promise<{ redirect: string | null }>;
   switchWallet: (address: string) => Promise<void>;
@@ -58,7 +58,8 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
       };
     } catch (err) {
       _logger.error("Failed to initialize login:", err);
-      await logout();
+      // Skip the login redirect so the App.vue guard can preserve any ?redirect= query.
+      await logout({ redirectToLogin: false });
     }
   };
 
@@ -127,7 +128,7 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
     }
   };
 
-  const logout = async () => {
+  const logout = async ({ redirectToLogin = true }: { redirectToLogin?: boolean } = {}) => {
     const auth = getPrividiumAuth();
     auth.clearToken();
 
@@ -139,7 +140,9 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
       _logger.error("Logout failed:", error);
     }
     context.user.value = { loggedIn: false };
-    router.push("/login");
+    if (redirectToLogin) {
+      router.push("/login");
+    }
   };
 
   return {

--- a/packages/app/src/composables/useLogin.ts
+++ b/packages/app/src/composables/useLogin.ts
@@ -13,10 +13,10 @@ type LoginState = {
 };
 
 type UseLogin = ToRefs<LoginState> & {
-  login: () => Promise<void>;
+  login: (redirectPath?: string) => Promise<void>;
   logout: () => Promise<void>;
   initializeLogin: () => Promise<void>;
-  handlePrividiumCallback: () => Promise<void>;
+  handlePrividiumCallback: () => Promise<{ redirect: string | null }>;
   switchWallet: (address: string) => Promise<void>;
 };
 
@@ -62,11 +62,11 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
     }
   };
 
-  const login = async () => {
+  const login = async (redirectPath?: string) => {
     try {
       state.isLoginPending = true;
       const auth = getPrividiumAuth();
-      auth.login();
+      auth.login(redirectPath);
     } catch (error) {
       _logger.error("Prividium login failed:", error);
       throw error;
@@ -75,7 +75,7 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
     }
   };
 
-  const handlePrividiumCallback = async () => {
+  const handlePrividiumCallback = async (): Promise<{ redirect: string | null }> => {
     try {
       state.isLoginPending = true;
       const auth = getPrividiumAuth();
@@ -97,6 +97,8 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
           loggedIn: true,
         };
       }
+
+      return { redirect: result?.redirect ?? null };
     } catch (err) {
       _logger.error("Prividium callback failed:", err);
       throw err;

--- a/packages/app/src/lib/prividium-auth/constants.ts
+++ b/packages/app/src/lib/prividium-auth/constants.ts
@@ -1,5 +1,6 @@
 export const PRIVIDIUM_AUTH_CONSTANTS = {
   STATE_KEY: "prividium_auth_state",
+  REDIRECT_KEY: "prividium_auth_redirect",
   TOKEN_KEY: "prividium_jwt",
   SILENT_AUTH_TIMEOUT: 5000,
   DEFAULT_USER_PANEL_URL: "http://localhost:3001",

--- a/packages/app/src/lib/prividium-auth/index.ts
+++ b/packages/app/src/lib/prividium-auth/index.ts
@@ -9,6 +9,7 @@ export interface PrividiumAuthConfig {
 export interface AuthResult {
   token: string;
   state: string;
+  redirect: string | null;
 }
 
 export class PrividiumAuth {
@@ -24,11 +25,21 @@ export class PrividiumAuth {
   }
 
   /**
-   * Initiates the login flow by redirecting to User Panel
+   * Initiates the login flow by redirecting to User Panel.
+   *
+   * @param redirectPath - Optional in-app path to return to after the OAuth round-trip completes.
+   *   Stashed in sessionStorage so `handleCallback()` can surface it after `state` validation.
    */
-  login(): void {
+  login(redirectPath?: string): void {
     this.state = this.generateRandomState();
     sessionStorage.setItem(PRIVIDIUM_AUTH_CONSTANTS.STATE_KEY, this.state);
+
+    if (redirectPath) {
+      sessionStorage.setItem(PRIVIDIUM_AUTH_CONSTANTS.REDIRECT_KEY, redirectPath);
+    } else {
+      // Clear any stale value from a previous attempt so it can't be reunited with this flow's state.
+      sessionStorage.removeItem(PRIVIDIUM_AUTH_CONSTANTS.REDIRECT_KEY);
+    }
 
     const url = new URL(PRIVIDIUM_AUTH_CONSTANTS.AUTH_ENDPOINTS.AUTHORIZE, this.userPanelUrl);
     url.searchParams.set("client_id", this.clientId);
@@ -71,10 +82,14 @@ export class PrividiumAuth {
     this.setToken(token);
     sessionStorage.removeItem(PRIVIDIUM_AUTH_CONSTANTS.STATE_KEY);
 
+    // Retrieve (and clear) the original in-app destination stashed at login() time.
+    const redirect = sessionStorage.getItem(PRIVIDIUM_AUTH_CONSTANTS.REDIRECT_KEY);
+    sessionStorage.removeItem(PRIVIDIUM_AUTH_CONSTANTS.REDIRECT_KEY);
+
     // Clear hash from URL
     window.location.hash = "";
 
-    return { token, state };
+    return { token, state, redirect };
   }
 
   /**

--- a/packages/app/src/lib/prividium-auth/index.ts
+++ b/packages/app/src/lib/prividium-auth/index.ts
@@ -27,8 +27,9 @@ export class PrividiumAuth {
   /**
    * Initiates the login flow by redirecting to User Panel.
    *
-   * @param redirectPath - Optional in-app path to return to after the OAuth round-trip completes.
-   *   Stashed in sessionStorage so `handleCallback()` can surface it after `state` validation.
+   * @param redirectPath - Path to return to after callback completes. Stashed in sessionStorage
+   *   rather than threaded through the OAuth state because user-panel doesn't round-trip
+   *   arbitrary query params — only `state`, which is opaque and must stay random for CSRF.
    */
   login(redirectPath?: string): void {
     this.state = this.generateRandomState();
@@ -37,7 +38,6 @@ export class PrividiumAuth {
     if (redirectPath) {
       sessionStorage.setItem(PRIVIDIUM_AUTH_CONSTANTS.REDIRECT_KEY, redirectPath);
     } else {
-      // Clear any stale value from a previous attempt so it can't be reunited with this flow's state.
       sessionStorage.removeItem(PRIVIDIUM_AUTH_CONSTANTS.REDIRECT_KEY);
     }
 
@@ -82,7 +82,6 @@ export class PrividiumAuth {
     this.setToken(token);
     sessionStorage.removeItem(PRIVIDIUM_AUTH_CONSTANTS.STATE_KEY);
 
-    // Retrieve (and clear) the original in-app destination stashed at login() time.
     const redirect = sessionStorage.getItem(PRIVIDIUM_AUTH_CONSTANTS.REDIRECT_KEY);
     sessionStorage.removeItem(PRIVIDIUM_AUTH_CONSTANTS.REDIRECT_KEY);
 

--- a/packages/app/src/lib/prividium-auth/index.ts
+++ b/packages/app/src/lib/prividium-auth/index.ts
@@ -26,10 +26,6 @@ export class PrividiumAuth {
 
   /**
    * Initiates the login flow by redirecting to User Panel.
-   *
-   * @param redirectPath - Path to return to after callback completes. Stashed in sessionStorage
-   *   rather than threaded through the OAuth state because user-panel doesn't round-trip
-   *   arbitrary query params — only `state`, which is opaque and must stay random for CSRF.
    */
   login(redirectPath?: string): void {
     this.state = this.generateRandomState();

--- a/packages/app/src/views/AuthCallbackView.vue
+++ b/packages/app/src/views/AuthCallbackView.vue
@@ -60,9 +60,8 @@ const redirectToLogin = () => {
 
 onMounted(async () => {
   try {
-    await handlePrividiumCallback();
-    const redirectPath = route.query.redirect;
-    await router.push(isValidRedirectPath(redirectPath) ? redirectPath : "/");
+    const { redirect } = await handlePrividiumCallback();
+    await router.push(isValidRedirectPath(redirect) ? redirect : "/");
   } catch (err: unknown) {
     console.error("Auth callback failed:", err);
 

--- a/packages/app/src/views/LoginView.vue
+++ b/packages/app/src/views/LoginView.vue
@@ -55,7 +55,8 @@ onMounted(() => {
 
 const handleLogin = async () => {
   try {
-    await login();
+    const redirectPath = route.query.redirect;
+    await login(isValidRedirectPath(redirectPath) ? redirectPath : undefined);
   } catch (error: unknown) {
     if (error instanceof FetchError && error.response?.status === 403) {
       router.push({ name: "not-authorized" });

--- a/packages/app/tests/e2e/features/login.feature
+++ b/packages/app/tests/e2e/features/login.feature
@@ -17,3 +17,9 @@ Feature: Prividium Auth Flow
     And I am on the login page
     When I click the login button
     Then I should see the not authorized page
+
+  Scenario: Deep link is preserved across login
+    Given I am an authorized user
+    And I am on the login page with a redirect to "/blocks"
+    When I click the login button
+    Then I should land on "/blocks"

--- a/packages/app/tests/e2e/src/steps/prividium.steps.ts
+++ b/packages/app/tests/e2e/src/steps/prividium.steps.ts
@@ -24,6 +24,13 @@ Given("I am on the login page", async function (this: ICustomWorld) {
   expect(this.page?.url()).toContain(config.BASE_URL + "/login");
 });
 
+Given("I am on the login page with a redirect to {string}", async function (this: ICustomWorld, redirectPath: string) {
+  const loginUrl = `${config.BASE_URL}/login?redirect=${encodeURIComponent(redirectPath)}`;
+  await this.page?.goto(loginUrl);
+  await this.page?.waitForLoadState("networkidle");
+  expect(this.page?.url()).toContain("redirect=");
+});
+
 When("I click the login button", async function (this: ICustomWorld) {
   const connectButton = this.page!.getByRole("button", { name: "Sign in" });
   await connectButton.click();
@@ -70,4 +77,9 @@ Then("I should see the not authorized page", async function (this: ICustomWorld)
   const unauthorizedHeading = this.page!.getByRole("heading", { name: "You are not authorized" });
   await expect(unauthorizedHeading).toBeVisible();
   expect(this.page?.url()).toContain("/not-authorized");
+});
+
+Then("I should land on {string}", async function (this: ICustomWorld, expectedPath: string) {
+  await this.page!.waitForURL((url) => url.pathname === expectedPath, { timeout: 10000 });
+  expect(new URL(this.page!.url()).pathname).toBe(expectedPath);
 });

--- a/packages/app/tests/lib/prividium-auth/index.spec.ts
+++ b/packages/app/tests/lib/prividium-auth/index.spec.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PrividiumAuth } from "@/lib/prividium-auth";
+import { PRIVIDIUM_AUTH_CONSTANTS } from "@/lib/prividium-auth/constants";
+
+const CONFIG = {
+  clientId: "block-explorer",
+  redirectUri: "https://explorer.test/auth/callback",
+  userPanelUrl: "https://user-panel.test",
+};
+
+describe("PrividiumAuth redirect lifecycle:", () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // window.location.href is read-only; replace with a mutable stub for the login() redirect.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: {
+        ...originalLocation,
+        hash: "",
+        href: originalLocation.origin,
+      } as Location,
+    });
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+    sessionStorage.clear();
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("stashes the redirectPath in sessionStorage when login(path) is called", () => {
+    const auth = new PrividiumAuth(CONFIG);
+
+    auth.login("/tx/0xabc");
+
+    expect(sessionStorage.getItem(PRIVIDIUM_AUTH_CONSTANTS.REDIRECT_KEY)).toBe("/tx/0xabc");
+  });
+
+  it("clears any stale redirect when login() is called without a path", () => {
+    sessionStorage.setItem(PRIVIDIUM_AUTH_CONSTANTS.REDIRECT_KEY, "/tx/0xstale");
+    const auth = new PrividiumAuth(CONFIG);
+
+    auth.login();
+
+    expect(sessionStorage.getItem(PRIVIDIUM_AUTH_CONSTANTS.REDIRECT_KEY)).toBeNull();
+  });
+
+  it("handleCallback() returns the stashed redirect and clears REDIRECT_KEY", () => {
+    const auth = new PrividiumAuth(CONFIG);
+    auth.login("/tx/0xabc");
+    const savedState = sessionStorage.getItem(PRIVIDIUM_AUTH_CONSTANTS.STATE_KEY)!;
+    window.location.hash = `#token=mock-jwt&state=${savedState}`;
+
+    const result = auth.handleCallback();
+
+    expect(result).toEqual({
+      token: "mock-jwt",
+      state: savedState,
+      redirect: "/tx/0xabc",
+    });
+    expect(sessionStorage.getItem(PRIVIDIUM_AUTH_CONSTANTS.REDIRECT_KEY)).toBeNull();
+    expect(sessionStorage.getItem(PRIVIDIUM_AUTH_CONSTANTS.STATE_KEY)).toBeNull();
+  });
+
+  it("handleCallback() returns redirect: null when nothing was stashed", () => {
+    const auth = new PrividiumAuth(CONFIG);
+    auth.login();
+    const savedState = sessionStorage.getItem(PRIVIDIUM_AUTH_CONSTANTS.STATE_KEY)!;
+    window.location.hash = `#token=mock-jwt&state=${savedState}`;
+
+    const result = auth.handleCallback();
+
+    expect(result?.redirect).toBeNull();
+  });
+
+  // Guards against a future refactor that swaps router.push for window.location.href = redirect,
+  // which would turn the lax isValidRedirectPath into an exploitable open redirect.
+  // Today, `router.push` + pushState same-origin check prevents cross-origin navigation;
+  // this test ensures the stashed value itself is returned verbatim so the view layer
+  // remains the only place that decides how to navigate.
+  it("handleCallback() returns the redirect verbatim (view layer owns navigation safety)", () => {
+    const auth = new PrividiumAuth(CONFIG);
+    auth.login("/tx/0xabc?foo=bar#section");
+    const savedState = sessionStorage.getItem(PRIVIDIUM_AUTH_CONSTANTS.STATE_KEY)!;
+    window.location.hash = `#token=mock-jwt&state=${savedState}`;
+
+    const result = auth.handleCallback();
+
+    expect(result?.redirect).toBe("/tx/0xabc?foo=bar#section");
+  });
+});

--- a/packages/app/tests/lib/prividium-auth/index.spec.ts
+++ b/packages/app/tests/lib/prividium-auth/index.spec.ts
@@ -9,11 +9,26 @@ const CONFIG = {
   userPanelUrl: "https://user-panel.test",
 };
 
+// `crypto` isn't a Node global until v19; jsdom doesn't provide it either. Stub for CI.
+if (typeof (globalThis as { crypto?: Crypto }).crypto === "undefined") {
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: {
+      getRandomValues: (array: Uint8Array) => {
+        for (let i = 0; i < array.length; i++) {
+          array[i] = i;
+        }
+        return array;
+      },
+    },
+  });
+}
+
 describe("PrividiumAuth redirect lifecycle:", () => {
   const originalLocation = window.location;
 
   beforeEach(() => {
-    // window.location.href is read-only; replace with a mutable stub for the login() redirect.
+    // jsdom's `window.location.href` is read-only; swap in a mutable stub so login() can set it.
     Object.defineProperty(window, "location", {
       configurable: true,
       writable: true,
@@ -83,12 +98,8 @@ describe("PrividiumAuth redirect lifecycle:", () => {
     expect(result?.redirect).toBeNull();
   });
 
-  // Guards against a future refactor that swaps router.push for window.location.href = redirect,
-  // which would turn the lax isValidRedirectPath into an exploitable open redirect.
-  // Today, `router.push` + pushState same-origin check prevents cross-origin navigation;
-  // this test ensures the stashed value itself is returned verbatim so the view layer
-  // remains the only place that decides how to navigate.
-  it("handleCallback() returns the redirect verbatim (view layer owns navigation safety)", () => {
+  // Returned verbatim so the view layer owns navigation safety (no cross-origin sanitization here).
+  it("handleCallback() returns the redirect verbatim", () => {
     const auth = new PrividiumAuth(CONFIG);
     auth.login("/tx/0xabc?foo=bar#section");
     const savedState = sessionStorage.getItem(PRIVIDIUM_AUTH_CONSTANTS.STATE_KEY)!;


### PR DESCRIPTION
## Summary

- Stashes the `?redirect` query param in `sessionStorage` when `PrividiumAuth.login()` fires and surfaces it from `handleCallback()` so `/auth/callback` can navigate to the original destination instead of `/`.
- Adds unit coverage for the redirect lifecycle and an E2E scenario that asserts deep-link preservation end-to-end.