### PR TITLE
feat(prividium): replace admin role name check with system permissions checks

### DIFF
--- a/packages/api/src/address/address.controller.spec.ts
+++ b/packages/api/src/address/address.controller.spec.ts
@@ -270,7 +270,7 @@ describe("AddressController", () => {
       let user: MockProxy<UserWithRoles>;
       const mockUser = "0xc0ffee254729296a45a3885639AC7E10F9d54979";
       beforeEach(() => {
-        user = mock<UserWithRoles>({ address: mockUser, hasFullReadAccess: false, roles: [] });
+        user = mock<UserWithRoles>({ address: mockUser, hasFullReadAccess: false });
       });
 
       it("throws if address is an account and is not own address", async () => {
@@ -442,7 +442,6 @@ describe("AddressController", () => {
           user = mock<UserWithRoles>({
             address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
             hasFullReadAccess: false,
-            roles: [],
             token: "token1",
           });
         });
@@ -531,7 +530,6 @@ describe("AddressController", () => {
         user = mock<UserWithRoles>({
           address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
           hasFullReadAccess: false,
-          roles: [],
           token: "token",
         });
       });

--- a/packages/api/src/address/address.controller.spec.ts
+++ b/packages/api/src/address/address.controller.spec.ts
@@ -270,7 +270,7 @@ describe("AddressController", () => {
       let user: MockProxy<UserWithRoles>;
       const mockUser = "0xc0ffee254729296a45a3885639AC7E10F9d54979";
       beforeEach(() => {
-        user = mock<UserWithRoles>({ address: mockUser, isAdmin: false, roles: [] });
+        user = mock<UserWithRoles>({ address: mockUser, hasFullReadAccess: false, roles: [] });
       });
 
       it("throws if address is an account and is not own address", async () => {
@@ -441,7 +441,7 @@ describe("AddressController", () => {
         beforeEach(() => {
           user = mock<UserWithRoles>({
             address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-            isAdmin: false,
+            hasFullReadAccess: false,
             roles: [],
             token: "token1",
           });
@@ -452,7 +452,7 @@ describe("AddressController", () => {
         });
 
         it("returns logs for admin user", async () => {
-          user.isAdmin = true;
+          user.hasFullReadAccess = true;
           const result = await controller.getAddressLogs(address, pagingOptions, user);
           expect(result).toBe(transactionLogs);
           expect(logServiceMock.findAll).toHaveBeenCalledWith(
@@ -530,7 +530,7 @@ describe("AddressController", () => {
       beforeEach(() => {
         user = mock<UserWithRoles>({
           address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-          isAdmin: false,
+          hasFullReadAccess: false,
           roles: [],
           token: "token",
         });

--- a/packages/api/src/address/address.controller.spec.ts
+++ b/packages/api/src/address/address.controller.spec.ts
@@ -16,7 +16,7 @@ import { Transfer, TransferType } from "../transfer/transfer.entity";
 import { Address } from "./address.entity";
 import { ForbiddenException } from "@nestjs/common";
 import { Wallet, zeroPadValue } from "ethers";
-import { UserWithRoles } from "../api/pipes/addUserRoles.pipe";
+import { UserWithPermissions } from "../api/pipes/addUserRoles.pipe";
 import { ConfigService } from "@nestjs/config";
 
 jest.mock("../common/utils", () => ({
@@ -267,10 +267,10 @@ describe("AddressController", () => {
     });
 
     describe("when user is provided", () => {
-      let user: MockProxy<UserWithRoles>;
+      let user: MockProxy<UserWithPermissions>;
       const mockUser = "0xc0ffee254729296a45a3885639AC7E10F9d54979";
       beforeEach(() => {
-        user = mock<UserWithRoles>({ address: mockUser, hasFullReadAccess: false });
+        user = mock<UserWithPermissions>({ address: mockUser, hasFullReadAccess: false });
       });
 
       it("throws if address is an account and is not own address", async () => {
@@ -437,9 +437,9 @@ describe("AddressController", () => {
       });
 
       describe("when user is provided", () => {
-        let user: MockProxy<UserWithRoles>;
+        let user: MockProxy<UserWithPermissions>;
         beforeEach(() => {
-          user = mock<UserWithRoles>({
+          user = mock<UserWithPermissions>({
             address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
             hasFullReadAccess: false,
             token: "token1",
@@ -525,9 +525,9 @@ describe("AddressController", () => {
     });
 
     describe("when user is provided", () => {
-      let user: MockProxy<UserWithRoles>;
+      let user: MockProxy<UserWithPermissions>;
       beforeEach(() => {
-        user = mock<UserWithRoles>({
+        user = mock<UserWithPermissions>({
           address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
           hasFullReadAccess: false,
           token: "token",

--- a/packages/api/src/address/address.controller.ts
+++ b/packages/api/src/address/address.controller.ts
@@ -75,7 +75,7 @@ export class AddressController {
     let includeCreatorAddress = true;
     let includeCreatorTxHash = true;
 
-    if (user && !user.isAdmin) {
+    if (user && !user.hasFullReadAccess) {
       // If address is an account and is not own address, forbid access
       if (addressType === AddressType.Account && !isAddressEqual(user.address, address)) {
         throw new ForbiddenException();
@@ -153,7 +153,7 @@ export class AddressController {
     @Query() pagingOptions: PagingOptionsWithMaxItemsLimitDto,
     @User(AddUserRolesPipe) user: UserWithRoles
   ): Promise<Pagination<LogDto>> {
-    if (user && !user.isAdmin) {
+    if (user && !user.hasFullReadAccess) {
       throw new ForbiddenException();
     }
 
@@ -185,7 +185,7 @@ export class AddressController {
     @Query() pagingOptions: PagingOptionsWithMaxItemsLimitDto,
     @User(AddUserRolesPipe) user: UserWithRoles
   ): Promise<Pagination<TransferDto>> {
-    const userFilters = user && !user.isAdmin ? { visibleBy: user.address } : {};
+    const userFilters = user && !user.hasFullReadAccess ? { visibleBy: user.address } : {};
 
     const filterTransfersListOptions = buildBlockFilter(
       listFilterOptions.fromBlock,

--- a/packages/api/src/address/address.controller.ts
+++ b/packages/api/src/address/address.controller.ts
@@ -26,7 +26,7 @@ import { TransferDto } from "../transfer/transfer.dto";
 import { swagger } from "../config/featureFlags";
 import { constants } from "../config/docs";
 import { User } from "../user/user.decorator";
-import { AddUserRolesPipe, UserWithRoles } from "../api/pipes/addUserRoles.pipe";
+import { AddUserRolesPipe, UserWithPermissions } from "../api/pipes/addUserRoles.pipe";
 
 const entityName = "address";
 
@@ -64,7 +64,7 @@ export class AddressController {
   @ApiBadRequestResponse({ description: "Specified address is invalid" })
   public async getAddress(
     @Param("address", new ParseAddressPipe()) address: string,
-    @User(AddUserRolesPipe) user: UserWithRoles
+    @User(AddUserRolesPipe) user: UserWithPermissions
   ): Promise<AccountDto | ContractDto> {
     const addressRecord = await this.addressService.findOne(address);
     const addressType = !!(addressRecord && addressRecord.bytecode.length > 2)
@@ -151,7 +151,7 @@ export class AddressController {
   public async getAddressLogs(
     @Param("address", new ParseAddressPipe()) address: string,
     @Query() pagingOptions: PagingOptionsWithMaxItemsLimitDto,
-    @User(AddUserRolesPipe) user: UserWithRoles
+    @User(AddUserRolesPipe) user: UserWithPermissions
   ): Promise<Pagination<LogDto>> {
     if (user && !user.hasFullReadAccess) {
       throw new ForbiddenException();
@@ -183,7 +183,7 @@ export class AddressController {
     @Query() filterAddressTransferOptions: FilterAddressTransfersOptionsDto,
     @Query() listFilterOptions: ListFiltersDto,
     @Query() pagingOptions: PagingOptionsWithMaxItemsLimitDto,
-    @User(AddUserRolesPipe) user: UserWithRoles
+    @User(AddUserRolesPipe) user: UserWithPermissions
   ): Promise<Pagination<TransferDto>> {
     const userFilters = user && !user.hasFullReadAccess ? { visibleBy: user.address } : {};
 

--- a/packages/api/src/api/pipes/addUserRoles.pipe.spec.ts
+++ b/packages/api/src/api/pipes/addUserRoles.pipe.spec.ts
@@ -8,11 +8,9 @@ describe("AddUserRolesPipe", () => {
   let fetchSpy: jest.SpyInstance;
   let configServiceMock: ConfigService;
   let pipe: AddUserRolesPipe;
-  const adminRoleName = "admin";
 
   const configServiceValues = {
     "prividium.permissionsApiUrl": "https://permissions-api.example.com",
-    "prividium.adminRoleName": adminRoleName,
   };
 
   beforeEach(() => {
@@ -39,11 +37,11 @@ describe("AddUserRolesPipe", () => {
     expect(user.isAdmin).toBe(false);
   });
 
-  it("sets is admin to false when there there is a list of roles but non of them is admin", async () => {
+  it("sets is admin to false when roles have no systemPermissions", async () => {
     fetchSpy.mockResolvedValueOnce({
       status: 200,
       json: jest.fn().mockResolvedValue({
-        roles: ["role1", "trader", "admi", "dmin"].map((r) => ({ roleName: r })),
+        roles: ["role1", "trader", "viewer"].map((r) => ({ roleName: r })),
       }),
     });
 
@@ -51,11 +49,50 @@ describe("AddUserRolesPipe", () => {
     expect(user.isAdmin).toBe(false);
   });
 
-  it("sets is admin to true when user has admin role", async () => {
+  it("sets is admin to false when roles have unrelated systemPermissions only", async () => {
     fetchSpy.mockResolvedValueOnce({
       status: 200,
       json: jest.fn().mockResolvedValue({
-        roles: [adminRoleName].map((r) => ({ roleName: r })),
+        roles: [{ roleName: "deployer", systemPermissions: ["contract_deployment", "admin_read"] }],
+      }),
+    });
+
+    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    expect(user.isAdmin).toBe(false);
+  });
+
+  it("sets is admin to true when a role has full_read_access permission", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        roles: [{ roleName: "admin", systemPermissions: ["full_read_access", "contract_deployment"] }],
+      }),
+    });
+
+    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    expect(user.isAdmin).toBe(true);
+  });
+
+  it("sets is admin to true when a role has full_sequencer_rpc_access permission", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        roles: [{ roleName: "superuser", systemPermissions: ["full_sequencer_rpc_access"] }],
+      }),
+    });
+
+    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    expect(user.isAdmin).toBe(true);
+  });
+
+  it("sets is admin to true when the permission is on any role in the list", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        roles: [
+          { roleName: "trader", systemPermissions: ["contract_deployment"] },
+          { roleName: "reader", systemPermissions: ["full_read_access"] },
+        ],
       }),
     });
 

--- a/packages/api/src/api/pipes/addUserRoles.pipe.spec.ts
+++ b/packages/api/src/api/pipes/addUserRoles.pipe.spec.ts
@@ -85,6 +85,43 @@ describe("AddUserRolesPipe", () => {
     expect(user.hasFullReadAccess).toBe(true);
   });
 
+  it("sets hasAdminRead to false when no role has admin_read permission", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        roles: [{ roleName: "trader", systemPermissions: ["contract_deployment"] }],
+      }),
+    });
+
+    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    expect(user.hasAdminRead).toBe(false);
+  });
+
+  it("sets hasAdminRead to true when a role has admin_read permission", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        roles: [{ roleName: "admin", systemPermissions: ["admin_read", "full_read_access"] }],
+      }),
+    });
+
+    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    expect(user.hasAdminRead).toBe(true);
+  });
+
+  it("sets hasAdminRead independently from hasFullReadAccess", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        roles: [{ roleName: "sequencer", systemPermissions: ["full_sequencer_rpc_access"] }],
+      }),
+    });
+
+    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    expect(user.hasFullReadAccess).toBe(true);
+    expect(user.hasAdminRead).toBe(false);
+  });
+
   it("sets hasFullReadAccess to true when the permission is on any role in the list", async () => {
     fetchSpy.mockResolvedValueOnce({
       status: 200,

--- a/packages/api/src/api/pipes/addUserRoles.pipe.spec.ts
+++ b/packages/api/src/api/pipes/addUserRoles.pipe.spec.ts
@@ -100,18 +100,6 @@ describe("AddUserRolesPipe", () => {
     expect(user.hasFullReadAccess).toBe(true);
   });
 
-  it("sets received roles into roles array", async () => {
-    fetchSpy.mockResolvedValueOnce({
-      status: 200,
-      json: jest.fn().mockResolvedValue({
-        roles: ["role1", "another", "trader"].map((r) => ({ roleName: r })),
-      }),
-    });
-
-    const user = await pipe.transform({ address: "0x01", token: "token1" });
-    expect(user.roles).toEqual(["role1", "another", "trader"]);
-  });
-
   it("keeps original address and token values", async () => {
     fetchSpy.mockResolvedValueOnce({
       status: 200,

--- a/packages/api/src/api/pipes/addUserRoles.pipe.spec.ts
+++ b/packages/api/src/api/pipes/addUserRoles.pipe.spec.ts
@@ -25,7 +25,7 @@ describe("AddUserRolesPipe", () => {
     fetchSpy.mockRestore();
   });
 
-  it("sets is admin to false when empty list of roles is returned", async () => {
+  it("sets hasFullReadAccess to false when empty list of roles is returned", async () => {
     fetchSpy.mockResolvedValueOnce({
       status: 200,
       json: jest.fn().mockResolvedValue({
@@ -34,10 +34,10 @@ describe("AddUserRolesPipe", () => {
     });
 
     const user = await pipe.transform({ address: "0x01", token: "token1" });
-    expect(user.isAdmin).toBe(false);
+    expect(user.hasFullReadAccess).toBe(false);
   });
 
-  it("sets is admin to false when roles have no systemPermissions", async () => {
+  it("sets hasFullReadAccess to false when roles have no systemPermissions", async () => {
     fetchSpy.mockResolvedValueOnce({
       status: 200,
       json: jest.fn().mockResolvedValue({
@@ -46,10 +46,10 @@ describe("AddUserRolesPipe", () => {
     });
 
     const user = await pipe.transform({ address: "0x01", token: "token1" });
-    expect(user.isAdmin).toBe(false);
+    expect(user.hasFullReadAccess).toBe(false);
   });
 
-  it("sets is admin to false when roles have unrelated systemPermissions only", async () => {
+  it("sets hasFullReadAccess to false when roles have unrelated systemPermissions only", async () => {
     fetchSpy.mockResolvedValueOnce({
       status: 200,
       json: jest.fn().mockResolvedValue({
@@ -58,10 +58,10 @@ describe("AddUserRolesPipe", () => {
     });
 
     const user = await pipe.transform({ address: "0x01", token: "token1" });
-    expect(user.isAdmin).toBe(false);
+    expect(user.hasFullReadAccess).toBe(false);
   });
 
-  it("sets is admin to true when a role has full_read_access permission", async () => {
+  it("sets hasFullReadAccess to true when a role has full_read_access permission", async () => {
     fetchSpy.mockResolvedValueOnce({
       status: 200,
       json: jest.fn().mockResolvedValue({
@@ -70,10 +70,10 @@ describe("AddUserRolesPipe", () => {
     });
 
     const user = await pipe.transform({ address: "0x01", token: "token1" });
-    expect(user.isAdmin).toBe(true);
+    expect(user.hasFullReadAccess).toBe(true);
   });
 
-  it("sets is admin to true when a role has full_sequencer_rpc_access permission", async () => {
+  it("sets hasFullReadAccess to true when a role has full_sequencer_rpc_access permission", async () => {
     fetchSpy.mockResolvedValueOnce({
       status: 200,
       json: jest.fn().mockResolvedValue({
@@ -82,10 +82,10 @@ describe("AddUserRolesPipe", () => {
     });
 
     const user = await pipe.transform({ address: "0x01", token: "token1" });
-    expect(user.isAdmin).toBe(true);
+    expect(user.hasFullReadAccess).toBe(true);
   });
 
-  it("sets is admin to true when the permission is on any role in the list", async () => {
+  it("sets hasFullReadAccess to true when the permission is on any role in the list", async () => {
     fetchSpy.mockResolvedValueOnce({
       status: 200,
       json: jest.fn().mockResolvedValue({
@@ -97,7 +97,7 @@ describe("AddUserRolesPipe", () => {
     });
 
     const user = await pipe.transform({ address: "0x01", token: "token1" });
-    expect(user.isAdmin).toBe(true);
+    expect(user.hasFullReadAccess).toBe(true);
   });
 
   it("sets received roles into roles array", async () => {

--- a/packages/api/src/api/pipes/addUserRoles.pipe.ts
+++ b/packages/api/src/api/pipes/addUserRoles.pipe.ts
@@ -9,6 +9,9 @@ export interface UserWithRoles extends UserParam {
   isAdmin: boolean;
 }
 
+// Permissions that grant unrestricted read access to all on-chain data in the explorer.
+const READ_ALL_PERMISSIONS = new Set(["full_read_access", "full_sequencer_rpc_access"]);
+
 function throwError(): never {
   throw new InternalServerErrorException("Authentication failed");
 }
@@ -30,7 +33,12 @@ export class AddUserRolesPipe implements PipeTransform<UserParam | null, Promise
 
     const validatedData = z
       .object({
-        roles: z.array(z.object({ roleName: z.string() })),
+        roles: z.array(
+          z.object({
+            roleName: z.string(),
+            systemPermissions: z.array(z.string()).optional(),
+          })
+        ),
       })
       .safeParse(await response.json().catch(throwError));
 
@@ -40,7 +48,9 @@ export class AddUserRolesPipe implements PipeTransform<UserParam | null, Promise
 
     const roles = validatedData.data.roles.map((r) => r.roleName);
 
-    const isAdmin = roles.some((role) => role === this.config.get("prividium.adminRoleName"));
+    const isAdmin = validatedData.data.roles.some((role) =>
+      role.systemPermissions?.some((p) => READ_ALL_PERMISSIONS.has(p))
+    );
 
     return {
       ...value,

--- a/packages/api/src/api/pipes/addUserRoles.pipe.ts
+++ b/packages/api/src/api/pipes/addUserRoles.pipe.ts
@@ -10,7 +10,7 @@ export interface UserWithRoles extends UserParam {
 }
 
 // Permissions that grant unrestricted read access to all on-chain data in the explorer.
-const READ_ALL_PERMISSIONS = new Set(["full_read_access", "full_sequencer_rpc_access"]);
+export const READ_ALL_PERMISSIONS = new Set(["full_read_access", "full_sequencer_rpc_access"]);
 
 function throwError(): never {
   throw new InternalServerErrorException("Authentication failed");

--- a/packages/api/src/api/pipes/addUserRoles.pipe.ts
+++ b/packages/api/src/api/pipes/addUserRoles.pipe.ts
@@ -4,9 +4,11 @@ import { ConfigService } from "@nestjs/config";
 import { z } from "zod";
 import { PrividiumApiError } from "../../errors/prividiumApiError";
 
-export interface UserWithRoles extends UserParam {
+type Permissions = {
   hasFullReadAccess: boolean;
-}
+};
+
+export type UserWithPermissions = UserParam & Permissions;
 
 // Permissions that grant unrestricted read access to all on-chain data in the explorer.
 export const READ_ALL_PERMISSIONS = new Set(["full_read_access", "full_sequencer_rpc_access"]);
@@ -20,7 +22,7 @@ const userProfileSchema = z.object({
   ),
 });
 
-export function parseUserProfile(data: unknown): { hasFullReadAccess: boolean } {
+export function parseUserProfile(data: unknown): Permissions {
   const result = userProfileSchema.safeParse(data);
   if (!result.success) {
     throw new Error(`Invalid user profile response: ${JSON.stringify(result.error)}`);
@@ -36,10 +38,10 @@ function throwError(): never {
 }
 
 @Injectable()
-export class AddUserRolesPipe implements PipeTransform<UserParam | null, Promise<UserWithRoles | null>> {
+export class AddUserRolesPipe implements PipeTransform<UserParam | null, Promise<UserWithPermissions | null>> {
   constructor(private config: ConfigService) {}
 
-  async transform(value: UserParam | null): Promise<UserWithRoles | null> {
+  async transform(value: UserParam | null): Promise<UserWithPermissions | null> {
     if (value === null) return null;
 
     const response = await fetch(new URL("/api/profiles/me", this.config.get("prividium.permissionsApiUrl")), {

--- a/packages/api/src/api/pipes/addUserRoles.pipe.ts
+++ b/packages/api/src/api/pipes/addUserRoles.pipe.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 import { PrividiumApiError } from "../../errors/prividiumApiError";
 
 export interface UserWithRoles extends UserParam {
-  roles: string[];
   hasFullReadAccess: boolean;
 }
 
@@ -21,16 +20,15 @@ const userProfileSchema = z.object({
   ),
 });
 
-export function parseUserProfile(data: unknown): { roles: string[]; hasFullReadAccess: boolean } {
+export function parseUserProfile(data: unknown): { hasFullReadAccess: boolean } {
   const result = userProfileSchema.safeParse(data);
   if (!result.success) {
     throw new Error(`Invalid user profile response: ${JSON.stringify(result.error)}`);
   }
-  const roles = result.data.roles.map((r) => r.roleName);
   const hasFullReadAccess = result.data.roles.some((r) =>
     r.systemPermissions?.some((p) => READ_ALL_PERMISSIONS.has(p))
   );
-  return { roles, hasFullReadAccess };
+  return { hasFullReadAccess };
 }
 
 function throwError(): never {
@@ -63,7 +61,6 @@ export class AddUserRolesPipe implements PipeTransform<UserParam | null, Promise
 
     return {
       ...value,
-      roles: profile.roles,
       hasFullReadAccess: profile.hasFullReadAccess,
     };
   }

--- a/packages/api/src/api/pipes/addUserRoles.pipe.ts
+++ b/packages/api/src/api/pipes/addUserRoles.pipe.ts
@@ -6,11 +6,32 @@ import { PrividiumApiError } from "../../errors/prividiumApiError";
 
 export interface UserWithRoles extends UserParam {
   roles: string[];
-  isAdmin: boolean;
+  hasFullReadAccess: boolean;
 }
 
 // Permissions that grant unrestricted read access to all on-chain data in the explorer.
 export const READ_ALL_PERMISSIONS = new Set(["full_read_access", "full_sequencer_rpc_access"]);
+
+const userProfileSchema = z.object({
+  roles: z.array(
+    z.object({
+      roleName: z.string(),
+      systemPermissions: z.array(z.string()).optional(),
+    })
+  ),
+});
+
+export function parseUserProfile(data: unknown): { roles: string[]; hasFullReadAccess: boolean } {
+  const result = userProfileSchema.safeParse(data);
+  if (!result.success) {
+    throw new Error(`Invalid user profile response: ${JSON.stringify(result.error)}`);
+  }
+  const roles = result.data.roles.map((r) => r.roleName);
+  const hasFullReadAccess = result.data.roles.some((r) =>
+    r.systemPermissions?.some((p) => READ_ALL_PERMISSIONS.has(p))
+  );
+  return { roles, hasFullReadAccess };
+}
 
 function throwError(): never {
   throw new InternalServerErrorException("Authentication failed");
@@ -31,31 +52,19 @@ export class AddUserRolesPipe implements PipeTransform<UserParam | null, Promise
       throw new PrividiumApiError("Authentication failed", 401);
     }
 
-    const validatedData = z
-      .object({
-        roles: z.array(
-          z.object({
-            roleName: z.string(),
-            systemPermissions: z.array(z.string()).optional(),
-          })
-        ),
-      })
-      .safeParse(await response.json().catch(throwError));
-
-    if (validatedData.success === false) {
-      throwError();
-    }
-
-    const roles = validatedData.data.roles.map((r) => r.roleName);
-
-    const isAdmin = validatedData.data.roles.some((role) =>
-      role.systemPermissions?.some((p) => READ_ALL_PERMISSIONS.has(p))
-    );
+    const json = await response.json().catch(throwError);
+    const profile = (() => {
+      try {
+        return parseUserProfile(json);
+      } catch {
+        return throwError();
+      }
+    })();
 
     return {
       ...value,
-      roles,
-      isAdmin,
+      roles: profile.roles,
+      hasFullReadAccess: profile.hasFullReadAccess,
     };
   }
 }

--- a/packages/api/src/api/pipes/addUserRoles.pipe.ts
+++ b/packages/api/src/api/pipes/addUserRoles.pipe.ts
@@ -6,6 +6,7 @@ import { PrividiumApiError } from "../../errors/prividiumApiError";
 
 type Permissions = {
   hasFullReadAccess: boolean;
+  hasAdminRead: boolean;
 };
 
 export type UserWithPermissions = UserParam & Permissions;
@@ -30,7 +31,8 @@ export function parseUserProfile(data: unknown): Permissions {
   const hasFullReadAccess = result.data.roles.some((r) =>
     r.systemPermissions?.some((p) => READ_ALL_PERMISSIONS.has(p))
   );
-  return { hasFullReadAccess };
+  const hasAdminRead = result.data.roles.some((r) => r.systemPermissions?.includes("admin_read"));
+  return { hasFullReadAccess, hasAdminRead };
 }
 
 function throwError(): never {
@@ -64,6 +66,7 @@ export class AddUserRolesPipe implements PipeTransform<UserParam | null, Promise
     return {
       ...value,
       hasFullReadAccess: profile.hasFullReadAccess,
+      hasAdminRead: profile.hasAdminRead,
     };
   }
 }

--- a/packages/api/src/auth/auth.controller.spec.ts
+++ b/packages/api/src/auth/auth.controller.spec.ts
@@ -70,10 +70,12 @@ describe("AuthController", () => {
         address: mockWalletAddress,
         wallets: mockWallets,
         hasFullReadAccess: true,
+        hasAdminRead: false,
       });
       expect(req.session.address).toBe(mockWalletAddress);
       expect(req.session.wallets).toEqual(mockWallets);
       expect(req.session.hasFullReadAccess).toBe(true);
+      expect(req.session.hasAdminRead).toBe(false);
       expect(req.session.token).toBe(mockToken);
       expect(fetchSpy).toHaveBeenCalledWith(expect.any(URL), {
         headers: { Authorization: `Bearer ${mockToken}` },
@@ -263,18 +265,28 @@ describe("AuthController", () => {
   });
 
   describe("GET /me", () => {
-    it("returns address, wallets and hasFullReadAccess stored in session", async () => {
+    it("returns address, wallets, hasFullReadAccess, and hasAdminRead stored in session", async () => {
       const mockWallets = [mockWalletAddress, mockWalletAddress2];
-      req.session = { address: mockWalletAddress, wallets: mockWallets, hasFullReadAccess: true };
+      req.session = { address: mockWalletAddress, wallets: mockWallets, hasFullReadAccess: true, hasAdminRead: true };
       const res = await controller.me(req);
-      expect(res).toEqual({ address: mockWalletAddress, wallets: mockWallets, hasFullReadAccess: true });
+      expect(res).toEqual({
+        address: mockWalletAddress,
+        wallets: mockWallets,
+        hasFullReadAccess: true,
+        hasAdminRead: true,
+      });
     });
 
-    it("returns hasFullReadAccess false when session has no hasFullReadAccess", async () => {
+    it("returns false for both flags when session has neither set", async () => {
       const mockWallets = [mockWalletAddress, mockWalletAddress2];
       req.session = { address: mockWalletAddress, wallets: mockWallets };
       const res = await controller.me(req);
-      expect(res).toEqual({ address: mockWalletAddress, wallets: mockWallets, hasFullReadAccess: false });
+      expect(res).toEqual({
+        address: mockWalletAddress,
+        wallets: mockWallets,
+        hasFullReadAccess: false,
+        hasAdminRead: false,
+      });
     });
   });
 });

--- a/packages/api/src/auth/auth.controller.spec.ts
+++ b/packages/api/src/auth/auth.controller.spec.ts
@@ -44,40 +44,88 @@ describe("AuthController", () => {
       fetchSpy.mockRestore();
     });
 
-    it("logins successfully with valid token", async () => {
+    it("logins successfully with valid token, sets isAdmin true when role has full_read_access", async () => {
       const mockWallets = [mockWalletAddress, mockWalletAddress2];
-      const mockRoles = [{ roleName: "admin" }, { roleName: "user" }];
+      const mockRoles = [
+        { roleName: "admin", systemPermissions: ["full_read_access", "contract_deployment"] },
+        { roleName: "user" },
+      ];
       fetchSpy
         .mockResolvedValueOnce({
           status: 200,
-          json: jest.fn().mockResolvedValue({
-            wallets: mockWallets,
-          }),
+          json: jest.fn().mockResolvedValue({ wallets: mockWallets }),
         })
         .mockResolvedValueOnce({
           status: 200,
-          json: jest.fn().mockResolvedValue({
-            type: "user",
-            expiresAt: new Date().toISOString(),
-          }),
+          json: jest.fn().mockResolvedValue({ type: "user", expiresAt: new Date().toISOString() }),
         })
         .mockResolvedValueOnce({
           status: 200,
-          json: jest.fn().mockResolvedValue({
-            roles: mockRoles,
-          }),
+          json: jest.fn().mockResolvedValue({ roles: mockRoles }),
         });
 
       const result = await controller.login(body, req);
 
-      expect(result).toEqual({ address: mockWalletAddress, wallets: mockWallets, roles: ["admin", "user"] });
+      expect(result).toEqual({
+        address: mockWalletAddress,
+        wallets: mockWallets,
+        roles: ["admin", "user"],
+        isAdmin: true,
+      });
       expect(req.session.address).toBe(mockWalletAddress);
       expect(req.session.wallets).toEqual(mockWallets);
       expect(req.session.roles).toEqual(["admin", "user"]);
+      expect(req.session.isAdmin).toBe(true);
       expect(req.session.token).toBe(mockToken);
       expect(fetchSpy).toHaveBeenCalledWith(expect.any(URL), {
         headers: { Authorization: `Bearer ${mockToken}` },
       });
+    });
+
+    it("logins successfully and sets isAdmin false when roles have no read-all permissions", async () => {
+      const mockWallets = [mockWalletAddress];
+      const mockRoles = [{ roleName: "trader", systemPermissions: ["contract_deployment"] }];
+      fetchSpy
+        .mockResolvedValueOnce({
+          status: 200,
+          json: jest.fn().mockResolvedValue({ wallets: mockWallets }),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          json: jest.fn().mockResolvedValue({ type: "user", expiresAt: new Date().toISOString() }),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          json: jest.fn().mockResolvedValue({ roles: mockRoles }),
+        });
+
+      const result = await controller.login(body, req);
+
+      expect(result.isAdmin).toBe(false);
+      expect(req.session.isAdmin).toBe(false);
+    });
+
+    it("logins successfully and sets isAdmin true when role has full_sequencer_rpc_access", async () => {
+      const mockWallets = [mockWalletAddress];
+      const mockRoles = [{ roleName: "superuser", systemPermissions: ["full_sequencer_rpc_access"] }];
+      fetchSpy
+        .mockResolvedValueOnce({
+          status: 200,
+          json: jest.fn().mockResolvedValue({ wallets: mockWallets }),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          json: jest.fn().mockResolvedValue({ type: "user", expiresAt: new Date().toISOString() }),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          json: jest.fn().mockResolvedValue({ roles: mockRoles }),
+        });
+
+      const result = await controller.login(body, req);
+
+      expect(result.isAdmin).toBe(true);
+      expect(req.session.isAdmin).toBe(true);
     });
 
     it("throws 403 error for 403 response from permissions API", async () => {
@@ -217,19 +265,19 @@ describe("AuthController", () => {
   });
 
   describe("GET /me", () => {
-    it("returns address, wallets and roles stored in session", async () => {
+    it("returns address, wallets, roles and isAdmin stored in session", async () => {
       const mockWallets = [mockWalletAddress, mockWalletAddress2];
       const mockRoles = ["admin", "user"];
-      req.session = { address: mockWalletAddress, wallets: mockWallets, roles: mockRoles };
+      req.session = { address: mockWalletAddress, wallets: mockWallets, roles: mockRoles, isAdmin: true };
       const res = await controller.me(req);
-      expect(res).toEqual({ address: mockWalletAddress, wallets: mockWallets, roles: mockRoles });
+      expect(res).toEqual({ address: mockWalletAddress, wallets: mockWallets, roles: mockRoles, isAdmin: true });
     });
 
-    it("returns empty roles array when session has no roles", async () => {
+    it("returns empty roles array and isAdmin false when session has no roles", async () => {
       const mockWallets = [mockWalletAddress, mockWalletAddress2];
       req.session = { address: mockWalletAddress, wallets: mockWallets };
       const res = await controller.me(req);
-      expect(res).toEqual({ address: mockWalletAddress, wallets: mockWallets, roles: [] });
+      expect(res).toEqual({ address: mockWalletAddress, wallets: mockWallets, roles: [], isAdmin: false });
     });
   });
 });

--- a/packages/api/src/auth/auth.controller.spec.ts
+++ b/packages/api/src/auth/auth.controller.spec.ts
@@ -44,7 +44,7 @@ describe("AuthController", () => {
       fetchSpy.mockRestore();
     });
 
-    it("logins successfully with valid token, sets isAdmin true when role has full_read_access", async () => {
+    it("logins successfully with valid token, sets hasFullReadAccess true when role has full_read_access", async () => {
       const mockWallets = [mockWalletAddress, mockWalletAddress2];
       const mockRoles = [
         { roleName: "admin", systemPermissions: ["full_read_access", "contract_deployment"] },
@@ -70,19 +70,19 @@ describe("AuthController", () => {
         address: mockWalletAddress,
         wallets: mockWallets,
         roles: ["admin", "user"],
-        isAdmin: true,
+        hasFullReadAccess: true,
       });
       expect(req.session.address).toBe(mockWalletAddress);
       expect(req.session.wallets).toEqual(mockWallets);
       expect(req.session.roles).toEqual(["admin", "user"]);
-      expect(req.session.isAdmin).toBe(true);
+      expect(req.session.hasFullReadAccess).toBe(true);
       expect(req.session.token).toBe(mockToken);
       expect(fetchSpy).toHaveBeenCalledWith(expect.any(URL), {
         headers: { Authorization: `Bearer ${mockToken}` },
       });
     });
 
-    it("logins successfully and sets isAdmin false when roles have no read-all permissions", async () => {
+    it("logins successfully and sets hasFullReadAccess false when roles have no read-all permissions", async () => {
       const mockWallets = [mockWalletAddress];
       const mockRoles = [{ roleName: "trader", systemPermissions: ["contract_deployment"] }];
       fetchSpy
@@ -101,11 +101,11 @@ describe("AuthController", () => {
 
       const result = await controller.login(body, req);
 
-      expect(result.isAdmin).toBe(false);
-      expect(req.session.isAdmin).toBe(false);
+      expect(result.hasFullReadAccess).toBe(false);
+      expect(req.session.hasFullReadAccess).toBe(false);
     });
 
-    it("logins successfully and sets isAdmin true when role has full_sequencer_rpc_access", async () => {
+    it("logins successfully and sets hasFullReadAccess true when role has full_sequencer_rpc_access", async () => {
       const mockWallets = [mockWalletAddress];
       const mockRoles = [{ roleName: "superuser", systemPermissions: ["full_sequencer_rpc_access"] }];
       fetchSpy
@@ -124,8 +124,8 @@ describe("AuthController", () => {
 
       const result = await controller.login(body, req);
 
-      expect(result.isAdmin).toBe(true);
-      expect(req.session.isAdmin).toBe(true);
+      expect(result.hasFullReadAccess).toBe(true);
+      expect(req.session.hasFullReadAccess).toBe(true);
     });
 
     it("throws 403 error for 403 response from permissions API", async () => {
@@ -265,19 +265,24 @@ describe("AuthController", () => {
   });
 
   describe("GET /me", () => {
-    it("returns address, wallets, roles and isAdmin stored in session", async () => {
+    it("returns address, wallets, roles and hasFullReadAccess stored in session", async () => {
       const mockWallets = [mockWalletAddress, mockWalletAddress2];
       const mockRoles = ["admin", "user"];
-      req.session = { address: mockWalletAddress, wallets: mockWallets, roles: mockRoles, isAdmin: true };
+      req.session = { address: mockWalletAddress, wallets: mockWallets, roles: mockRoles, hasFullReadAccess: true };
       const res = await controller.me(req);
-      expect(res).toEqual({ address: mockWalletAddress, wallets: mockWallets, roles: mockRoles, isAdmin: true });
+      expect(res).toEqual({
+        address: mockWalletAddress,
+        wallets: mockWallets,
+        roles: mockRoles,
+        hasFullReadAccess: true,
+      });
     });
 
-    it("returns empty roles array and isAdmin false when session has no roles", async () => {
+    it("returns empty roles array and hasFullReadAccess false when session has no roles", async () => {
       const mockWallets = [mockWalletAddress, mockWalletAddress2];
       req.session = { address: mockWalletAddress, wallets: mockWallets };
       const res = await controller.me(req);
-      expect(res).toEqual({ address: mockWalletAddress, wallets: mockWallets, roles: [], isAdmin: false });
+      expect(res).toEqual({ address: mockWalletAddress, wallets: mockWallets, roles: [], hasFullReadAccess: false });
     });
   });
 });

--- a/packages/api/src/auth/auth.controller.spec.ts
+++ b/packages/api/src/auth/auth.controller.spec.ts
@@ -69,12 +69,10 @@ describe("AuthController", () => {
       expect(result).toEqual({
         address: mockWalletAddress,
         wallets: mockWallets,
-        roles: ["admin", "user"],
         hasFullReadAccess: true,
       });
       expect(req.session.address).toBe(mockWalletAddress);
       expect(req.session.wallets).toEqual(mockWallets);
-      expect(req.session.roles).toEqual(["admin", "user"]);
       expect(req.session.hasFullReadAccess).toBe(true);
       expect(req.session.token).toBe(mockToken);
       expect(fetchSpy).toHaveBeenCalledWith(expect.any(URL), {

--- a/packages/api/src/auth/auth.controller.spec.ts
+++ b/packages/api/src/auth/auth.controller.spec.ts
@@ -265,24 +265,18 @@ describe("AuthController", () => {
   });
 
   describe("GET /me", () => {
-    it("returns address, wallets, roles and hasFullReadAccess stored in session", async () => {
+    it("returns address, wallets and hasFullReadAccess stored in session", async () => {
       const mockWallets = [mockWalletAddress, mockWalletAddress2];
-      const mockRoles = ["admin", "user"];
-      req.session = { address: mockWalletAddress, wallets: mockWallets, roles: mockRoles, hasFullReadAccess: true };
+      req.session = { address: mockWalletAddress, wallets: mockWallets, hasFullReadAccess: true };
       const res = await controller.me(req);
-      expect(res).toEqual({
-        address: mockWalletAddress,
-        wallets: mockWallets,
-        roles: mockRoles,
-        hasFullReadAccess: true,
-      });
+      expect(res).toEqual({ address: mockWalletAddress, wallets: mockWallets, hasFullReadAccess: true });
     });
 
-    it("returns empty roles array and hasFullReadAccess false when session has no roles", async () => {
+    it("returns hasFullReadAccess false when session has no hasFullReadAccess", async () => {
       const mockWallets = [mockWalletAddress, mockWalletAddress2];
       req.session = { address: mockWalletAddress, wallets: mockWallets };
       const res = await controller.me(req);
-      expect(res).toEqual({ address: mockWalletAddress, wallets: mockWallets, roles: [], hasFullReadAccess: false });
+      expect(res).toEqual({ address: mockWalletAddress, wallets: mockWallets, hasFullReadAccess: false });
     });
   });
 });

--- a/packages/api/src/auth/auth.controller.ts
+++ b/packages/api/src/auth/auth.controller.ts
@@ -52,7 +52,7 @@ export class AuthController {
   public async login(
     @Body() body: VerifySignatureDto,
     @Req() req: Request
-  ): Promise<{ address: string; wallets: string[]; hasFullReadAccess: boolean }> {
+  ): Promise<{ address: string; wallets: string[]; hasFullReadAccess: boolean; hasAdminRead: boolean }> {
     try {
       const wallets = await this.fetchUserWallets(body.token);
 
@@ -60,7 +60,7 @@ export class AuthController {
         throw new HttpException("No wallets associated with the user", 400);
       }
 
-      const [sessionExpirationIso, { hasFullReadAccess }] = await Promise.all([
+      const [sessionExpirationIso, { hasFullReadAccess, hasAdminRead }] = await Promise.all([
         this.fetchExpirationTimeIso(body.token),
         this.fetchUserProfile(body.token),
       ]);
@@ -71,8 +71,9 @@ export class AuthController {
       req.session.address = address;
       req.session.token = body.token;
       req.session.hasFullReadAccess = hasFullReadAccess;
+      req.session.hasAdminRead = hasAdminRead;
       req.session.expiresAt = sessionExpirationIso;
-      return { address, wallets, hasFullReadAccess };
+      return { address, wallets, hasFullReadAccess, hasAdminRead };
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;
@@ -128,6 +129,7 @@ export class AuthController {
       address: req.session.address,
       wallets: req.session.wallets,
       hasFullReadAccess: req.session.hasFullReadAccess ?? false,
+      hasAdminRead: req.session.hasAdminRead ?? false,
     };
   }
 
@@ -154,7 +156,7 @@ export class AuthController {
     return validatedData.data.wallets;
   }
 
-  private async fetchUserProfile(token: string): Promise<{ hasFullReadAccess: boolean }> {
+  private async fetchUserProfile(token: string): Promise<{ hasFullReadAccess: boolean; hasAdminRead: boolean }> {
     const response = await fetch(new URL("/api/profiles/me", this.configService.get("prividium.permissionsApiUrl")), {
       headers: { Authorization: `Bearer ${token}` },
     });

--- a/packages/api/src/auth/auth.controller.ts
+++ b/packages/api/src/auth/auth.controller.ts
@@ -121,7 +121,6 @@ export class AuthController {
       properties: {
         address: { type: "string" },
         wallets: { type: "array", items: { type: "string" } },
-        roles: { type: "array", items: { type: "string" } },
       },
     },
   })
@@ -129,7 +128,6 @@ export class AuthController {
     return {
       address: req.session.address,
       wallets: req.session.wallets,
-      roles: req.session.roles ?? [],
       hasFullReadAccess: req.session.hasFullReadAccess ?? false,
     };
   }

--- a/packages/api/src/auth/auth.controller.ts
+++ b/packages/api/src/auth/auth.controller.ts
@@ -52,7 +52,7 @@ export class AuthController {
   public async login(
     @Body() body: VerifySignatureDto,
     @Req() req: Request
-  ): Promise<{ address: string; wallets: string[]; roles: string[]; hasFullReadAccess: boolean }> {
+  ): Promise<{ address: string; wallets: string[]; hasFullReadAccess: boolean }> {
     try {
       const wallets = await this.fetchUserWallets(body.token);
 
@@ -60,7 +60,7 @@ export class AuthController {
         throw new HttpException("No wallets associated with the user", 400);
       }
 
-      const [sessionExpirationIso, { roles, hasFullReadAccess }] = await Promise.all([
+      const [sessionExpirationIso, { hasFullReadAccess }] = await Promise.all([
         this.fetchExpirationTimeIso(body.token),
         this.fetchUserProfile(body.token),
       ]);
@@ -70,10 +70,9 @@ export class AuthController {
       req.session.wallets = wallets;
       req.session.address = address;
       req.session.token = body.token;
-      req.session.roles = roles;
       req.session.hasFullReadAccess = hasFullReadAccess;
       req.session.expiresAt = sessionExpirationIso;
-      return { address, wallets, roles, hasFullReadAccess };
+      return { address, wallets, hasFullReadAccess };
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;
@@ -155,7 +154,7 @@ export class AuthController {
     return validatedData.data.wallets;
   }
 
-  private async fetchUserProfile(token: string): Promise<{ roles: string[]; hasFullReadAccess: boolean }> {
+  private async fetchUserProfile(token: string): Promise<{ hasFullReadAccess: boolean }> {
     const response = await fetch(new URL("/api/profiles/me", this.configService.get("prividium.permissionsApiUrl")), {
       headers: { Authorization: `Bearer ${token}` },
     });

--- a/packages/api/src/auth/auth.controller.ts
+++ b/packages/api/src/auth/auth.controller.ts
@@ -22,16 +22,13 @@ import { VerifySignatureDto, SwitchWalletDto } from "./auth.dto";
 import { ConfigService } from "@nestjs/config";
 import { z } from "zod";
 import { PrividiumApiError } from "../errors/prividiumApiError";
-import { READ_ALL_PERMISSIONS } from "../api/pipes/addUserRoles.pipe";
+import { parseUserProfile } from "../api/pipes/addUserRoles.pipe";
 
 const entityName = "auth";
 const userWalletsSchema = z.object({ wallets: z.array(z.string()) });
 const currentSessionSchema = z.object({
   type: z.string(),
   expiresAt: z.string().datetime(),
-});
-const userProfileSchema = z.object({
-  roles: z.array(z.object({ roleName: z.string(), systemPermissions: z.array(z.string()).optional() })),
 });
 
 @ApiTags("Auth BFF")
@@ -55,7 +52,7 @@ export class AuthController {
   public async login(
     @Body() body: VerifySignatureDto,
     @Req() req: Request
-  ): Promise<{ address: string; wallets: string[]; roles: string[]; isAdmin: boolean }> {
+  ): Promise<{ address: string; wallets: string[]; roles: string[]; hasFullReadAccess: boolean }> {
     try {
       const wallets = await this.fetchUserWallets(body.token);
 
@@ -63,7 +60,7 @@ export class AuthController {
         throw new HttpException("No wallets associated with the user", 400);
       }
 
-      const [sessionExpirationIso, { roles, isAdmin }] = await Promise.all([
+      const [sessionExpirationIso, { roles, hasFullReadAccess }] = await Promise.all([
         this.fetchExpirationTimeIso(body.token),
         this.fetchUserProfile(body.token),
       ]);
@@ -74,9 +71,9 @@ export class AuthController {
       req.session.address = address;
       req.session.token = body.token;
       req.session.roles = roles;
-      req.session.isAdmin = isAdmin;
+      req.session.hasFullReadAccess = hasFullReadAccess;
       req.session.expiresAt = sessionExpirationIso;
-      return { address, wallets, roles, isAdmin };
+      return { address, wallets, roles, hasFullReadAccess };
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;
@@ -133,7 +130,7 @@ export class AuthController {
       address: req.session.address,
       wallets: req.session.wallets,
       roles: req.session.roles ?? [],
-      isAdmin: req.session.isAdmin ?? false,
+      hasFullReadAccess: req.session.hasFullReadAccess ?? false,
     };
   }
 
@@ -160,7 +157,7 @@ export class AuthController {
     return validatedData.data.wallets;
   }
 
-  private async fetchUserProfile(token: string): Promise<{ roles: string[]; isAdmin: boolean }> {
+  private async fetchUserProfile(token: string): Promise<{ roles: string[]; hasFullReadAccess: boolean }> {
     const response = await fetch(new URL("/api/profiles/me", this.configService.get("prividium.permissionsApiUrl")), {
       headers: { Authorization: `Bearer ${token}` },
     });
@@ -169,15 +166,7 @@ export class AuthController {
       throw new PrividiumApiError("Invalid or expired token", 403);
     }
 
-    const data = await response.json();
-    const validatedData = userProfileSchema.safeParse(data);
-    if (!validatedData.success) {
-      throw new Error(`Invalid response from Prividium API: ${JSON.stringify(validatedData.error)}`);
-    }
-
-    const roles = validatedData.data.roles.map((r) => r.roleName);
-    const isAdmin = validatedData.data.roles.some((r) => r.systemPermissions?.some((p) => READ_ALL_PERMISSIONS.has(p)));
-    return { roles, isAdmin };
+    return parseUserProfile(await response.json());
   }
 
   private async fetchExpirationTimeIso(token: string): Promise<string> {

--- a/packages/api/src/auth/auth.controller.ts
+++ b/packages/api/src/auth/auth.controller.ts
@@ -22,6 +22,7 @@ import { VerifySignatureDto, SwitchWalletDto } from "./auth.dto";
 import { ConfigService } from "@nestjs/config";
 import { z } from "zod";
 import { PrividiumApiError } from "../errors/prividiumApiError";
+import { READ_ALL_PERMISSIONS } from "../api/pipes/addUserRoles.pipe";
 
 const entityName = "auth";
 const userWalletsSchema = z.object({ wallets: z.array(z.string()) });
@@ -30,7 +31,7 @@ const currentSessionSchema = z.object({
   expiresAt: z.string().datetime(),
 });
 const userProfileSchema = z.object({
-  roles: z.array(z.object({ roleName: z.string() })),
+  roles: z.array(z.object({ roleName: z.string(), systemPermissions: z.array(z.string()).optional() })),
 });
 
 @ApiTags("Auth BFF")
@@ -54,7 +55,7 @@ export class AuthController {
   public async login(
     @Body() body: VerifySignatureDto,
     @Req() req: Request
-  ): Promise<{ address: string; wallets: string[]; roles: string[] }> {
+  ): Promise<{ address: string; wallets: string[]; roles: string[]; isAdmin: boolean }> {
     try {
       const wallets = await this.fetchUserWallets(body.token);
 
@@ -62,9 +63,9 @@ export class AuthController {
         throw new HttpException("No wallets associated with the user", 400);
       }
 
-      const [sessionExpirationIso, roles] = await Promise.all([
+      const [sessionExpirationIso, { roles, isAdmin }] = await Promise.all([
         this.fetchExpirationTimeIso(body.token),
-        this.fetchUserRoles(body.token),
+        this.fetchUserProfile(body.token),
       ]);
 
       // Store all wallets and use first address as default
@@ -73,8 +74,9 @@ export class AuthController {
       req.session.address = address;
       req.session.token = body.token;
       req.session.roles = roles;
+      req.session.isAdmin = isAdmin;
       req.session.expiresAt = sessionExpirationIso;
-      return { address, wallets, roles };
+      return { address, wallets, roles, isAdmin };
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;
@@ -127,7 +129,12 @@ export class AuthController {
     },
   })
   public async me(@Req() req: Request) {
-    return { address: req.session.address, wallets: req.session.wallets, roles: req.session.roles ?? [] };
+    return {
+      address: req.session.address,
+      wallets: req.session.wallets,
+      roles: req.session.roles ?? [],
+      isAdmin: req.session.isAdmin ?? false,
+    };
   }
 
   private clearSession(req: Request) {
@@ -153,7 +160,7 @@ export class AuthController {
     return validatedData.data.wallets;
   }
 
-  private async fetchUserRoles(token: string): Promise<string[]> {
+  private async fetchUserProfile(token: string): Promise<{ roles: string[]; isAdmin: boolean }> {
     const response = await fetch(new URL("/api/profiles/me", this.configService.get("prividium.permissionsApiUrl")), {
       headers: { Authorization: `Bearer ${token}` },
     });
@@ -168,7 +175,9 @@ export class AuthController {
       throw new Error(`Invalid response from Prividium API: ${JSON.stringify(validatedData.error)}`);
     }
 
-    return validatedData.data.roles.map((r) => r.roleName);
+    const roles = validatedData.data.roles.map((r) => r.roleName);
+    const isAdmin = validatedData.data.roles.some((r) => r.systemPermissions?.some((p) => READ_ALL_PERMISSIONS.has(p)));
+    return { roles, isAdmin };
   }
 
   private async fetchExpirationTimeIso(token: string): Promise<string> {

--- a/packages/api/src/config/index.spec.ts
+++ b/packages/api/src/config/index.spec.ts
@@ -370,7 +370,6 @@ describe("config", () => {
       gracefulShutdownTimeoutMs: 0,
       indexerStateCacheTtlMs: 1000,
       prividium: {
-        adminRoleName: "admin",
         sessionMaxAge: 1000,
         appUrl: "http://localhost:3020",
         sessionSameSite: "strict",

--- a/packages/api/src/config/index.ts
+++ b/packages/api/src/config/index.ts
@@ -100,7 +100,6 @@ export default () => {
     CONTRACT_VERIFICATION_API_URL,
     GRACEFUL_SHUTDOWN_TIMEOUT_MS,
     CHAIN_ID,
-    PRIVIDIUM_ADMIN_ROLE_NAME,
     PRIVIDIUM_APP_URL,
     PRIVIDIUM_DISABLE_TX_VISIBILITY_BY_TOPICS,
     PRIVIDIUM_PERMISSIONS_API_URL,
@@ -186,7 +185,6 @@ export default () => {
       {
         permissionsApiUrl: z.string({ message: INVALID_PERMISSIONS_API_URL_MSG }).url(INVALID_PERMISSIONS_API_URL_MSG),
         sessionSecret: z.string({ message: PRIVIDIUM_SESSION_SECRET_MSG }).nonempty(PRIVIDIUM_SESSION_SECRET_MSG),
-        adminRoleName: z.string().default("admin"),
         sessionMaxAge: z.coerce
           .number({ message: PRIVIDIUM_SESSION_MAX_AGE_MSG })
           .int({ message: PRIVIDIUM_SESSION_MAX_AGE_MSG })
@@ -209,7 +207,6 @@ export default () => {
     );
 
     const result = prividiumSchema.safeParse({
-      adminRoleName: PRIVIDIUM_ADMIN_ROLE_NAME,
       permissionsApiUrl: PRIVIDIUM_PERMISSIONS_API_URL,
       sessionSecret: PRIVIDIUM_SESSION_SECRET,
       sessionMaxAge: PRIVIDIUM_SESSION_MAX_AGE,

--- a/packages/api/src/cookie-session.d.ts
+++ b/packages/api/src/cookie-session.d.ts
@@ -7,6 +7,7 @@ declare global {
       address?: string;
       wallets?: string[];
       roles?: string[];
+      isAdmin?: boolean;
       expiresAt?: string;
     }
   }

--- a/packages/api/src/cookie-session.d.ts
+++ b/packages/api/src/cookie-session.d.ts
@@ -6,7 +6,6 @@ declare global {
       token?: string;
       address?: string;
       wallets?: string[];
-      roles?: string[];
       hasFullReadAccess?: boolean;
       expiresAt?: string;
     }

--- a/packages/api/src/cookie-session.d.ts
+++ b/packages/api/src/cookie-session.d.ts
@@ -7,6 +7,7 @@ declare global {
       address?: string;
       wallets?: string[];
       hasFullReadAccess?: boolean;
+      hasAdminRead?: boolean;
       expiresAt?: string;
     }
   }

--- a/packages/api/src/cookie-session.d.ts
+++ b/packages/api/src/cookie-session.d.ts
@@ -7,7 +7,7 @@ declare global {
       address?: string;
       wallets?: string[];
       roles?: string[];
-      isAdmin?: boolean;
+      hasFullReadAccess?: boolean;
       expiresAt?: string;
     }
   }

--- a/packages/api/src/middlewares/auth.middleware.spec.ts
+++ b/packages/api/src/middlewares/auth.middleware.spec.ts
@@ -109,7 +109,7 @@ describe("AuthMiddleware", () => {
   it("blocks traffic for api route when user is not admin", async () => {
     (AddUserRolesPipe as jest.Mock).mockImplementation(() => ({
       transform: jest.fn().mockResolvedValue({
-        isAdmin: false,
+        hasFullReadAccess: false,
       }),
     }));
     const middleware = new AuthMiddleware(configServiceMock);
@@ -127,7 +127,7 @@ describe("AuthMiddleware", () => {
   it("allows traffic for api route when user is admin", async () => {
     (AddUserRolesPipe as jest.Mock).mockImplementation(() => ({
       transform: jest.fn().mockResolvedValue({
-        isAdmin: true,
+        hasFullReadAccess: true,
       }),
     }));
     const middleware = new AuthMiddleware(configServiceMock);

--- a/packages/api/src/middlewares/auth.middleware.ts
+++ b/packages/api/src/middlewares/auth.middleware.ts
@@ -27,7 +27,7 @@ export class AuthMiddleware implements NestMiddleware {
       }
       const addUserRolesPipe = new AddUserRolesPipe(this.configService);
       const userWithRoles = await addUserRolesPipe.transform({ address: "", token });
-      if (!userWithRoles.isAdmin) {
+      if (!userWithRoles.hasFullReadAccess) {
         // Only admin users can access the API for now
         throw new ForbiddenException({ message: "Forbidden request" });
       }

--- a/packages/api/src/prividium.spec.ts
+++ b/packages/api/src/prividium.spec.ts
@@ -126,7 +126,12 @@ describe("applySwaggerAuthMiddleware", () => {
       req.session = { address: "0x123", token: "valid-token" } as any;
       next();
     });
-    transformSpy.mockResolvedValue({ address: "0x123", token: "valid-token", roles: ["user"], isAdmin: false });
+    transformSpy.mockResolvedValue({
+      address: "0x123",
+      token: "valid-token",
+      roles: ["user"],
+      hasFullReadAccess: false,
+    });
     applySwaggerAuthMiddleware(app as unknown as NestExpressApplication, configService);
     app.get("/docs", (_req, res) => res.send("docs"));
 
@@ -140,7 +145,12 @@ describe("applySwaggerAuthMiddleware", () => {
       req.session = { address: "0x123", token: "valid-token" } as any;
       next();
     });
-    transformSpy.mockResolvedValue({ address: "0x123", token: "valid-token", roles: ["admin"], isAdmin: true });
+    transformSpy.mockResolvedValue({
+      address: "0x123",
+      token: "valid-token",
+      roles: ["admin"],
+      hasFullReadAccess: true,
+    });
     applySwaggerAuthMiddleware(app as unknown as NestExpressApplication, configService);
     app.get("/docs", (_req, res) => res.send("docs"));
 

--- a/packages/api/src/prividium.ts
+++ b/packages/api/src/prividium.ts
@@ -56,7 +56,7 @@ export function applySwaggerAuthMiddleware(app: NestExpressApplication, configSe
         address: req.session.address,
         token: req.session.token,
       });
-      if (!userWithRoles?.isAdmin) {
+      if (!userWithRoles?.hasFullReadAccess) {
         res.status(403).json({ message: "Forbidden" });
         return;
       }

--- a/packages/api/src/prividium.ts
+++ b/packages/api/src/prividium.ts
@@ -56,7 +56,7 @@ export function applySwaggerAuthMiddleware(app: NestExpressApplication, configSe
         address: req.session.address,
         token: req.session.token,
       });
-      if (!userWithRoles?.hasFullReadAccess) {
+      if (!userWithRoles?.hasAdminRead && !userWithRoles?.hasFullReadAccess) {
         res.status(403).json({ message: "Forbidden" });
         return;
       }

--- a/packages/api/src/token/token.controller.spec.ts
+++ b/packages/api/src/token/token.controller.spec.ts
@@ -9,7 +9,7 @@ import { TransferService } from "../transfer/transfer.service";
 import { Token } from "./token.entity";
 import { Transfer } from "../transfer/transfer.entity";
 import { PagingOptionsWithMaxItemsLimitDto } from "../common/dtos";
-import { UserWithRoles } from "../api/pipes/addUserRoles.pipe";
+import { UserWithPermissions } from "../api/pipes/addUserRoles.pipe";
 
 describe("TokenController", () => {
   const tokenAddress = "tokenAddress";
@@ -135,10 +135,10 @@ describe("TokenController", () => {
       });
 
       describe("when user is provided", () => {
-        let user: MockProxy<UserWithRoles>;
+        let user: MockProxy<UserWithPermissions>;
         const mockUser = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
         beforeEach(() => {
-          user = mock<UserWithRoles>({ address: mockUser, token: "token", hasFullReadAccess: false });
+          user = mock<UserWithPermissions>({ address: mockUser, token: "token", hasFullReadAccess: false });
         });
 
         it("includes visibleBy filter", async () => {

--- a/packages/api/src/token/token.controller.spec.ts
+++ b/packages/api/src/token/token.controller.spec.ts
@@ -138,7 +138,7 @@ describe("TokenController", () => {
         let user: MockProxy<UserWithRoles>;
         const mockUser = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
         beforeEach(() => {
-          user = mock<UserWithRoles>({ address: mockUser, token: "token", isAdmin: false });
+          user = mock<UserWithRoles>({ address: mockUser, token: "token", hasFullReadAccess: false });
         });
 
         it("includes visibleBy filter", async () => {

--- a/packages/api/src/token/token.controller.ts
+++ b/packages/api/src/token/token.controller.ts
@@ -20,7 +20,7 @@ import { ParseAddressPipe, ADDRESS_REGEX_PATTERN } from "../common/pipes/parseAd
 import { swagger } from "../config/featureFlags";
 import { constants } from "../config/docs";
 import { User } from "../user/user.decorator";
-import { AddUserRolesPipe, UserWithRoles } from "../api/pipes/addUserRoles.pipe";
+import { AddUserRolesPipe, UserWithPermissions } from "../api/pipes/addUserRoles.pipe";
 
 const entityName = "tokens";
 
@@ -91,7 +91,7 @@ export class TokenController {
   public async getTokenTransfers(
     @Param("address", new ParseAddressPipe()) address: string,
     @Query() pagingOptions: PagingOptionsWithMaxItemsLimitDto,
-    @User(AddUserRolesPipe) user: UserWithRoles
+    @User(AddUserRolesPipe) user: UserWithPermissions
   ): Promise<Pagination<TransferDto>> {
     if (!(await this.tokenService.exists(address))) {
       throw new NotFoundException();

--- a/packages/api/src/token/token.controller.ts
+++ b/packages/api/src/token/token.controller.ts
@@ -97,7 +97,7 @@ export class TokenController {
       throw new NotFoundException();
     }
 
-    const userFilters: FilterTransfersOptions = user && !user.isAdmin ? { visibleBy: user.address } : {};
+    const userFilters: FilterTransfersOptions = user && !user.hasFullReadAccess ? { visibleBy: user.address } : {};
     return await this.transferService.findAll(
       {
         tokenAddress: address,

--- a/packages/api/src/transaction/transaction.controller.spec.ts
+++ b/packages/api/src/transaction/transaction.controller.spec.ts
@@ -115,7 +115,7 @@ describe("TransactionController", () => {
       let user: MockProxy<UserWithRoles>;
       const mockUser = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
       beforeEach(() => {
-        user = mock<UserWithRoles>({ address: mockUser, roles: [], hasFullReadAccess: false, token: "token1" });
+        user = mock<UserWithRoles>({ address: mockUser, hasFullReadAccess: false, token: "token1" });
       });
 
       it("passes visibleBy when no address is provided", async () => {
@@ -277,7 +277,6 @@ describe("TransactionController", () => {
           user = mock<UserWithRoles>({
             address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
             hasFullReadAccess: false,
-            roles: [],
             token: "token1",
           });
         });
@@ -340,7 +339,6 @@ describe("TransactionController", () => {
           user = mock<UserWithRoles>({
             address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
             hasFullReadAccess: false,
-            roles: [],
             token: "token1",
           });
         });

--- a/packages/api/src/transaction/transaction.controller.spec.ts
+++ b/packages/api/src/transaction/transaction.controller.spec.ts
@@ -115,7 +115,7 @@ describe("TransactionController", () => {
       let user: MockProxy<UserWithRoles>;
       const mockUser = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
       beforeEach(() => {
-        user = mock<UserWithRoles>({ address: mockUser, roles: [], isAdmin: false, token: "token1" });
+        user = mock<UserWithRoles>({ address: mockUser, roles: [], hasFullReadAccess: false, token: "token1" });
       });
 
       it("passes visibleBy when no address is provided", async () => {
@@ -206,7 +206,7 @@ describe("TransactionController", () => {
       const mockUser = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 
       beforeEach(() => {
-        user = mock<UserWithRoles>({ address: mockUser, isAdmin: false });
+        user = mock<UserWithRoles>({ address: mockUser, hasFullReadAccess: false });
         (serviceMock.findOne as jest.Mock).mockResolvedValue(transaction);
       });
 
@@ -226,7 +226,7 @@ describe("TransactionController", () => {
           transactionHash,
           mock<UserWithRoles>({
             address: mockUser,
-            isAdmin: true,
+            hasFullReadAccess: true,
           })
         );
         expect(serviceMock.isTransactionVisibleByUser).not.toHaveBeenCalled();
@@ -276,7 +276,7 @@ describe("TransactionController", () => {
         beforeEach(() => {
           user = mock<UserWithRoles>({
             address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-            isAdmin: false,
+            hasFullReadAccess: false,
             roles: [],
             token: "token1",
           });
@@ -339,7 +339,7 @@ describe("TransactionController", () => {
         beforeEach(() => {
           user = mock<UserWithRoles>({
             address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-            isAdmin: false,
+            hasFullReadAccess: false,
             roles: [],
             token: "token1",
           });

--- a/packages/api/src/transaction/transaction.controller.spec.ts
+++ b/packages/api/src/transaction/transaction.controller.spec.ts
@@ -11,7 +11,7 @@ import { Transfer } from "../transfer/transfer.entity";
 import { Log } from "../log/log.entity";
 import { PagingOptionsWithMaxItemsLimitDto } from "../common/dtos";
 import { FilterTransactionsOptionsDto } from "./dtos/filterTransactionsOptions.dto";
-import { UserWithRoles } from "../api/pipes/addUserRoles.pipe";
+import { UserWithPermissions } from "../api/pipes/addUserRoles.pipe";
 import { ConfigService } from "@nestjs/config";
 import clearAllMocks = jest.clearAllMocks;
 
@@ -112,10 +112,10 @@ describe("TransactionController", () => {
     });
 
     describe("when user is provided", () => {
-      let user: MockProxy<UserWithRoles>;
+      let user: MockProxy<UserWithPermissions>;
       const mockUser = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
       beforeEach(() => {
-        user = mock<UserWithRoles>({ address: mockUser, hasFullReadAccess: false, token: "token1" });
+        user = mock<UserWithPermissions>({ address: mockUser, hasFullReadAccess: false, token: "token1" });
       });
 
       it("passes visibleBy when no address is provided", async () => {
@@ -202,11 +202,11 @@ describe("TransactionController", () => {
     });
 
     describe("when user is provided", () => {
-      let user: MockProxy<UserWithRoles>;
+      let user: MockProxy<UserWithPermissions>;
       const mockUser = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 
       beforeEach(() => {
-        user = mock<UserWithRoles>({ address: mockUser, hasFullReadAccess: false });
+        user = mock<UserWithPermissions>({ address: mockUser, hasFullReadAccess: false });
         (serviceMock.findOne as jest.Mock).mockResolvedValue(transaction);
       });
 
@@ -224,7 +224,7 @@ describe("TransactionController", () => {
       it("returns the transaction when user is admin", async () => {
         const result = await controller.getTransaction(
           transactionHash,
-          mock<UserWithRoles>({
+          mock<UserWithPermissions>({
             address: mockUser,
             hasFullReadAccess: true,
           })
@@ -272,9 +272,9 @@ describe("TransactionController", () => {
       });
 
       describe("when user is provided", () => {
-        let user: MockProxy<UserWithRoles>;
+        let user: MockProxy<UserWithPermissions>;
         beforeEach(() => {
-          user = mock<UserWithRoles>({
+          user = mock<UserWithPermissions>({
             address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
             hasFullReadAccess: false,
             token: "token1",
@@ -334,9 +334,9 @@ describe("TransactionController", () => {
       });
 
       describe("when user is provided", () => {
-        let user: MockProxy<UserWithRoles>;
+        let user: MockProxy<UserWithPermissions>;
         beforeEach(() => {
-          user = mock<UserWithRoles>({
+          user = mock<UserWithPermissions>({
             address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
             hasFullReadAccess: false,
             token: "token1",

--- a/packages/api/src/transaction/transaction.controller.ts
+++ b/packages/api/src/transaction/transaction.controller.ts
@@ -53,7 +53,7 @@ export class TransactionController {
       {
         ...filterTransactionsOptions,
         ...blockRangeFilter,
-        ...(user && !user.isAdmin && { visibleBy: user.address }),
+        ...(user && !user.hasFullReadAccess && { visibleBy: user.address }),
       },
       {
         filterOptions: { ...filterTransactionsOptions, ...listFilterOptions },
@@ -83,7 +83,7 @@ export class TransactionController {
       throw new NotFoundException();
     }
 
-    if (user && !user.isAdmin) {
+    if (user && !user.hasFullReadAccess) {
       const isVisibleByUser = await this.transactionService.isTransactionVisibleByUser(transactionDetail, user);
       if (!isVisibleByUser) {
         throw new NotFoundException();
@@ -115,7 +115,7 @@ export class TransactionController {
     if (!(await this.transactionService.exists(transactionHash))) {
       throw new NotFoundException();
     }
-    const userFilters = user && !user.isAdmin ? { visibleBy: user.address } : {};
+    const userFilters = user && !user.hasFullReadAccess ? { visibleBy: user.address } : {};
 
     const transfers = await this.transferService.findAll(
       { transactionHash, ...userFilters },
@@ -148,7 +148,7 @@ export class TransactionController {
     if (!(await this.transactionService.exists(transactionHash))) {
       throw new NotFoundException();
     }
-    const userFilters = user && !user.isAdmin ? { visibleBy: user.address } : {};
+    const userFilters = user && !user.hasFullReadAccess ? { visibleBy: user.address } : {};
 
     return await this.logService.findAll(
       { transactionHash, ...userFilters },

--- a/packages/api/src/transaction/transaction.controller.ts
+++ b/packages/api/src/transaction/transaction.controller.ts
@@ -22,7 +22,7 @@ import { ParseTransactionHashPipe, TX_HASH_REGEX_PATTERN } from "../common/pipes
 import { swagger } from "../config/featureFlags";
 import { constants } from "../config/docs";
 import { User } from "../user/user.decorator";
-import { AddUserRolesPipe, UserWithRoles } from "../api/pipes/addUserRoles.pipe";
+import { AddUserRolesPipe, UserWithPermissions } from "../api/pipes/addUserRoles.pipe";
 
 const entityName = "transactions";
 
@@ -43,7 +43,7 @@ export class TransactionController {
     @Query() filterTransactionsOptions: FilterTransactionsOptionsDto,
     @Query() listFilterOptions: ListFiltersDto,
     @Query() pagingOptions: PagingOptionsWithMaxItemsLimitDto,
-    @User(AddUserRolesPipe) user: UserWithRoles
+    @User(AddUserRolesPipe) user: UserWithPermissions
   ): Promise<Pagination<TransactionDto>> {
     const blockRangeFilter =
       filterTransactionsOptions.blockNumber == null
@@ -76,7 +76,7 @@ export class TransactionController {
   @ApiNotFoundResponse({ description: "Transaction with the specified hash does not exist" })
   public async getTransaction(
     @Param("transactionHash", new ParseTransactionHashPipe()) transactionHash: string,
-    @User(AddUserRolesPipe) user: UserWithRoles
+    @User(AddUserRolesPipe) user: UserWithPermissions
   ): Promise<TransactionDto> {
     const transactionDetail = await this.transactionService.findOne(transactionHash);
     if (!transactionDetail) {
@@ -110,7 +110,7 @@ export class TransactionController {
   public async getTransactionTransfers(
     @Param("transactionHash", new ParseTransactionHashPipe()) transactionHash: string,
     @Query() pagingOptions: PagingOptionsWithMaxItemsLimitDto,
-    @User(AddUserRolesPipe) user: UserWithRoles
+    @User(AddUserRolesPipe) user: UserWithPermissions
   ): Promise<Pagination<TransferDto>> {
     if (!(await this.transactionService.exists(transactionHash))) {
       throw new NotFoundException();
@@ -143,7 +143,7 @@ export class TransactionController {
   public async getTransactionLogs(
     @Param("transactionHash", new ParseTransactionHashPipe()) transactionHash: string,
     @Query() pagingOptions: PagingOptionsWithMaxItemsLimitDto,
-    @User(AddUserRolesPipe) user: UserWithRoles
+    @User(AddUserRolesPipe) user: UserWithPermissions
   ): Promise<Pagination<LogDto>> {
     if (!(await this.transactionService.exists(transactionHash))) {
       throw new NotFoundException();

--- a/packages/api/test/prividium-api.e2e-spec.ts
+++ b/packages/api/test/prividium-api.e2e-spec.ts
@@ -150,7 +150,6 @@ describe("Prividium API (e2e)", () => {
       await agent.get("/auth/me").expect(200, {
         address: mockWalletAddress,
         wallets: [mockWalletAddress],
-        roles: ["user"],
         hasFullReadAccess: false,
       });
 

--- a/packages/api/test/prividium-api.e2e-spec.ts
+++ b/packages/api/test/prividium-api.e2e-spec.ts
@@ -140,6 +140,7 @@ describe("Prividium API (e2e)", () => {
         address: mockWalletAddress,
         wallets: [mockWalletAddress],
         hasFullReadAccess: false,
+        hasAdminRead: false,
       });
       expect(fetchSpy).toHaveBeenCalledWith(expect.any(URL), {
         headers: { Authorization: `Bearer ${mockToken}` },
@@ -150,6 +151,7 @@ describe("Prividium API (e2e)", () => {
         address: mockWalletAddress,
         wallets: [mockWalletAddress],
         hasFullReadAccess: false,
+        hasAdminRead: false,
       });
 
       // Logout user

--- a/packages/api/test/prividium-api.e2e-spec.ts
+++ b/packages/api/test/prividium-api.e2e-spec.ts
@@ -140,7 +140,7 @@ describe("Prividium API (e2e)", () => {
         address: mockWalletAddress,
         wallets: [mockWalletAddress],
         roles: ["user"],
-        isAdmin: false,
+        hasFullReadAccess: false,
       });
       expect(fetchSpy).toHaveBeenCalledWith(expect.any(URL), {
         headers: { Authorization: `Bearer ${mockToken}` },
@@ -151,7 +151,7 @@ describe("Prividium API (e2e)", () => {
         address: mockWalletAddress,
         wallets: [mockWalletAddress],
         roles: ["user"],
-        isAdmin: false,
+        hasFullReadAccess: false,
       });
 
       // Logout user

--- a/packages/api/test/prividium-api.e2e-spec.ts
+++ b/packages/api/test/prividium-api.e2e-spec.ts
@@ -136,7 +136,12 @@ describe("Prividium API (e2e)", () => {
       // Login with token
       const loginResponse = await agent.post("/auth/login").send({ token: mockToken }).expect(201);
 
-      expect(loginResponse.body).toEqual({ address: mockWalletAddress, wallets: [mockWalletAddress], roles: ["user"] });
+      expect(loginResponse.body).toEqual({
+        address: mockWalletAddress,
+        wallets: [mockWalletAddress],
+        roles: ["user"],
+        isAdmin: false,
+      });
       expect(fetchSpy).toHaveBeenCalledWith(expect.any(URL), {
         headers: { Authorization: `Bearer ${mockToken}` },
       });
@@ -146,6 +151,7 @@ describe("Prividium API (e2e)", () => {
         address: mockWalletAddress,
         wallets: [mockWalletAddress],
         roles: ["user"],
+        isAdmin: false,
       });
 
       // Logout user
@@ -288,7 +294,9 @@ describe("Prividium API (e2e)", () => {
         })
         .mockResolvedValueOnce({
           status: 200,
-          json: jest.fn().mockResolvedValue({ roles: [{ roleName: "admin" }] }),
+          json: jest.fn().mockResolvedValue({
+            roles: [{ roleName: "admin", systemPermissions: ["full_read_access"] }],
+          }),
         });
 
       await agent.post("/auth/login").send({ token: mockToken }).expect(201);
@@ -296,7 +304,9 @@ describe("Prividium API (e2e)", () => {
       // Mock the roles check for /docs access (admin)
       fetchSpy.mockResolvedValueOnce({
         status: 200,
-        json: jest.fn().mockResolvedValue({ roles: [{ roleName: "admin" }] }),
+        json: jest.fn().mockResolvedValue({
+          roles: [{ roleName: "admin", systemPermissions: ["full_read_access"] }],
+        }),
       });
 
       const response = await agent.get("/docs");

--- a/packages/api/test/prividium-api.e2e-spec.ts
+++ b/packages/api/test/prividium-api.e2e-spec.ts
@@ -139,7 +139,6 @@ describe("Prividium API (e2e)", () => {
       expect(loginResponse.body).toEqual({
         address: mockWalletAddress,
         wallets: [mockWalletAddress],
-        roles: ["user"],
         hasFullReadAccess: false,
       });
       expect(fetchSpy).toHaveBeenCalledWith(expect.any(URL), {

--- a/packages/app/src/components/Contract.vue
+++ b/packages/app/src/components/Contract.vue
@@ -117,7 +117,7 @@ const runtimeConfig = useRuntimeConfig();
 const context = useContext();
 
 const isPrividium = runtimeConfig.appEnvironment === "prividium";
-const isAdmin = computed(() => context.user.value.loggedIn && context.user.value.isAdmin);
+const isAdmin = computed(() => context.user.value.loggedIn && context.user.value.hasFullReadAccess);
 const showEventsTab = computed(() => !isPrividium || isAdmin.value);
 
 const props = defineProps({

--- a/packages/app/src/components/Contract.vue
+++ b/packages/app/src/components/Contract.vue
@@ -117,8 +117,8 @@ const runtimeConfig = useRuntimeConfig();
 const context = useContext();
 
 const isPrividium = runtimeConfig.appEnvironment === "prividium";
-const isAdmin = computed(() => context.user.value.loggedIn && context.user.value.hasFullReadAccess);
-const showEventsTab = computed(() => !isPrividium || isAdmin.value);
+const hasFullReadAccess = computed(() => context.user.value.loggedIn && context.user.value.hasFullReadAccess);
+const showEventsTab = computed(() => !isPrividium || hasFullReadAccess.value);
 
 const props = defineProps({
   contract: {

--- a/packages/app/src/components/Contract.vue
+++ b/packages/app/src/components/Contract.vue
@@ -117,7 +117,7 @@ const runtimeConfig = useRuntimeConfig();
 const context = useContext();
 
 const isPrividium = runtimeConfig.appEnvironment === "prividium";
-const isAdmin = computed(() => context.user.value.loggedIn && context.user.value.roles.includes("admin"));
+const isAdmin = computed(() => context.user.value.loggedIn && context.user.value.isAdmin);
 const showEventsTab = computed(() => !isPrividium || isAdmin.value);
 
 const props = defineProps({

--- a/packages/app/src/components/Token.vue
+++ b/packages/app/src/components/Token.vue
@@ -95,7 +95,7 @@ const runtimeConfig = useRuntimeConfig();
 const context = useContext();
 
 const isPrividium = runtimeConfig.appEnvironment === "prividium";
-const isAdmin = computed(() => context.user.value.loggedIn && context.user.value.roles.includes("admin"));
+const isAdmin = computed(() => context.user.value.loggedIn && context.user.value.isAdmin);
 const showEventsTab = computed(() => !isPrividium || isAdmin.value);
 
 const props = defineProps({

--- a/packages/app/src/components/Token.vue
+++ b/packages/app/src/components/Token.vue
@@ -95,8 +95,8 @@ const runtimeConfig = useRuntimeConfig();
 const context = useContext();
 
 const isPrividium = runtimeConfig.appEnvironment === "prividium";
-const isAdmin = computed(() => context.user.value.loggedIn && context.user.value.hasFullReadAccess);
-const showEventsTab = computed(() => !isPrividium || isAdmin.value);
+const hasFullReadAccess = computed(() => context.user.value.loggedIn && context.user.value.hasFullReadAccess);
+const showEventsTab = computed(() => !isPrividium || hasFullReadAccess.value);
 
 const props = defineProps({
   contract: {

--- a/packages/app/src/components/Token.vue
+++ b/packages/app/src/components/Token.vue
@@ -95,7 +95,7 @@ const runtimeConfig = useRuntimeConfig();
 const context = useContext();
 
 const isPrividium = runtimeConfig.appEnvironment === "prividium";
-const isAdmin = computed(() => context.user.value.loggedIn && context.user.value.isAdmin);
+const isAdmin = computed(() => context.user.value.loggedIn && context.user.value.hasFullReadAccess);
 const showEventsTab = computed(() => !isPrividium || isAdmin.value);
 
 const props = defineProps({

--- a/packages/app/src/components/header/TheHeader.vue
+++ b/packages/app/src/components/header/TheHeader.vue
@@ -167,7 +167,7 @@ const { currentNetwork, user } = useContext();
 const runtimeConfig = useRuntimeConfig();
 
 const isPrividium = runtimeConfig.appEnvironment === "prividium";
-const isAdmin = computed(() => user.value.loggedIn && user.value.isAdmin);
+const isAdmin = computed(() => user.value.loggedIn && user.value.hasFullReadAccess);
 const showAdminLinks = computed(() => !isPrividium || isAdmin.value);
 
 const navigation = reactive([

--- a/packages/app/src/components/header/TheHeader.vue
+++ b/packages/app/src/components/header/TheHeader.vue
@@ -167,8 +167,8 @@ const { currentNetwork, user } = useContext();
 const runtimeConfig = useRuntimeConfig();
 
 const isPrividium = runtimeConfig.appEnvironment === "prividium";
-const isAdmin = computed(() => user.value.loggedIn && user.value.hasFullReadAccess);
-const showAdminLinks = computed(() => !isPrividium || isAdmin.value);
+const hasAdminRead = computed(() => user.value.loggedIn && user.value.hasAdminRead);
+const showAdminLinks = computed(() => !isPrividium || hasAdminRead.value);
 
 const navigation = reactive([
   {

--- a/packages/app/src/components/header/TheHeader.vue
+++ b/packages/app/src/components/header/TheHeader.vue
@@ -167,7 +167,7 @@ const { currentNetwork, user } = useContext();
 const runtimeConfig = useRuntimeConfig();
 
 const isPrividium = runtimeConfig.appEnvironment === "prividium";
-const isAdmin = computed(() => user.value.loggedIn && user.value.roles.includes("admin"));
+const isAdmin = computed(() => user.value.loggedIn && user.value.isAdmin);
 const showAdminLinks = computed(() => !isPrividium || isAdmin.value);
 
 const navigation = reactive([

--- a/packages/app/src/composables/useContext.ts
+++ b/packages/app/src/composables/useContext.ts
@@ -11,7 +11,9 @@ import type { NetworkConfig } from "@/configs";
 import { checksumAddress } from "@/utils/formatters";
 import { getWindowLocation } from "@/utils/helpers";
 
-export type UserContext = { address: string; wallets: string[]; roles: string[]; loggedIn: true } | { loggedIn: false };
+export type UserContext =
+  | { address: string; wallets: string[]; roles: string[]; isAdmin: boolean; loggedIn: true }
+  | { loggedIn: false };
 
 const network = useStorage("selectedNetwork_v2", DEFAULT_NETWORK.name);
 const isReady = ref(false);

--- a/packages/app/src/composables/useContext.ts
+++ b/packages/app/src/composables/useContext.ts
@@ -12,7 +12,7 @@ import { checksumAddress } from "@/utils/formatters";
 import { getWindowLocation } from "@/utils/helpers";
 
 export type UserContext =
-  | { address: string; wallets: string[]; hasFullReadAccess: boolean; loggedIn: true }
+  | { address: string; wallets: string[]; hasFullReadAccess: boolean; hasAdminRead: boolean; loggedIn: true }
   | { loggedIn: false };
 
 const network = useStorage("selectedNetwork_v2", DEFAULT_NETWORK.name);

--- a/packages/app/src/composables/useContext.ts
+++ b/packages/app/src/composables/useContext.ts
@@ -12,7 +12,7 @@ import { checksumAddress } from "@/utils/formatters";
 import { getWindowLocation } from "@/utils/helpers";
 
 export type UserContext =
-  | { address: string; wallets: string[]; roles: string[]; isAdmin: boolean; loggedIn: true }
+  | { address: string; wallets: string[]; hasFullReadAccess: boolean; loggedIn: true }
   | { loggedIn: false };
 
 const network = useStorage("selectedNetwork_v2", DEFAULT_NETWORK.name);

--- a/packages/app/src/composables/useLogin.ts
+++ b/packages/app/src/composables/useLogin.ts
@@ -51,11 +51,13 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
         address: string;
         wallets: string[];
         hasFullReadAccess: boolean;
+        hasAdminRead: boolean;
       }>("/auth/me");
       context.user.value = {
         address: response.address,
         wallets: response.wallets,
         hasFullReadAccess: response.hasFullReadAccess,
+        hasAdminRead: response.hasAdminRead,
         loggedIn: true,
       };
     } catch (err) {
@@ -90,6 +92,7 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
           address: string;
           wallets: string[];
           hasFullReadAccess: boolean;
+          hasAdminRead: boolean;
         }>("/auth/login", {
           method: "POST",
           body: { token: result.token },
@@ -98,6 +101,7 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
           address: response.address,
           wallets: response.wallets,
           hasFullReadAccess: response.hasFullReadAccess,
+          hasAdminRead: response.hasAdminRead,
           loggedIn: true,
         };
       }

--- a/packages/app/src/composables/useLogin.ts
+++ b/packages/app/src/composables/useLogin.ts
@@ -47,13 +47,17 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
 
   const initializeLogin = async () => {
     try {
-      const response = await FetchInstance.api(context)<{ address: string; wallets: string[]; roles: string[] }>(
-        "/auth/me"
-      );
+      const response = await FetchInstance.api(context)<{
+        address: string;
+        wallets: string[];
+        roles: string[];
+        isAdmin: boolean;
+      }>("/auth/me");
       context.user.value = {
         address: response.address,
         wallets: response.wallets,
         roles: response.roles,
+        isAdmin: response.isAdmin,
         loggedIn: true,
       };
     } catch (err) {
@@ -84,17 +88,20 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
 
       if (result && result.token) {
         // Exchange JWT for cookie session
-        const response = await FetchInstance.api(context)<{ address: string; wallets: string[]; roles: string[] }>(
-          "/auth/login",
-          {
-            method: "POST",
-            body: { token: result.token },
-          }
-        );
+        const response = await FetchInstance.api(context)<{
+          address: string;
+          wallets: string[];
+          roles: string[];
+          isAdmin: boolean;
+        }>("/auth/login", {
+          method: "POST",
+          body: { token: result.token },
+        });
         context.user.value = {
           address: response.address,
           wallets: response.wallets,
           roles: response.roles,
+          isAdmin: response.isAdmin,
           loggedIn: true,
         };
       }

--- a/packages/app/src/composables/useLogin.ts
+++ b/packages/app/src/composables/useLogin.ts
@@ -50,14 +50,12 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
       const response = await FetchInstance.api(context)<{
         address: string;
         wallets: string[];
-        roles: string[];
-        isAdmin: boolean;
+        hasFullReadAccess: boolean;
       }>("/auth/me");
       context.user.value = {
         address: response.address,
         wallets: response.wallets,
-        roles: response.roles,
-        isAdmin: response.isAdmin,
+        hasFullReadAccess: response.hasFullReadAccess,
         loggedIn: true,
       };
     } catch (err) {
@@ -91,8 +89,7 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
         const response = await FetchInstance.api(context)<{
           address: string;
           wallets: string[];
-          roles: string[];
-          isAdmin: boolean;
+          hasFullReadAccess: boolean;
         }>("/auth/login", {
           method: "POST",
           body: { token: result.token },
@@ -100,8 +97,7 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
         context.user.value = {
           address: response.address,
           wallets: response.wallets,
-          roles: response.roles,
-          isAdmin: response.isAdmin,
+          hasFullReadAccess: response.hasFullReadAccess,
           loggedIn: true,
         };
       }

--- a/packages/app/src/router/index.ts
+++ b/packages/app/src/router/index.ts
@@ -16,8 +16,8 @@ router.beforeEach((to) => {
 
   if (isPrividium && to.meta.requiresAdmin) {
     const { user } = useContext();
-    const isAdmin = user.value.loggedIn && user.value.hasFullReadAccess;
-    if (!isAdmin) {
+    const hasAdminRead = user.value.loggedIn && user.value.hasAdminRead;
+    if (!hasAdminRead) {
       return { name: "not-authorized" };
     }
   }

--- a/packages/app/src/router/index.ts
+++ b/packages/app/src/router/index.ts
@@ -16,7 +16,7 @@ router.beforeEach((to) => {
 
   if (isPrividium && to.meta.requiresAdmin) {
     const { user } = useContext();
-    const isAdmin = user.value.loggedIn && user.value.roles.includes("admin");
+    const isAdmin = user.value.loggedIn && user.value.isAdmin;
     if (!isAdmin) {
       return { name: "not-authorized" };
     }

--- a/packages/app/src/router/index.ts
+++ b/packages/app/src/router/index.ts
@@ -16,7 +16,7 @@ router.beforeEach((to) => {
 
   if (isPrividium && to.meta.requiresAdmin) {
     const { user } = useContext();
-    const isAdmin = user.value.loggedIn && user.value.isAdmin;
+    const isAdmin = user.value.loggedIn && user.value.hasFullReadAccess;
     if (!isAdmin) {
       return { name: "not-authorized" };
     }

--- a/packages/app/tests/components/ConnectMetamaskButton.spec.ts
+++ b/packages/app/tests/components/ConnectMetamaskButton.spec.ts
@@ -150,7 +150,6 @@ describe("ConnectMetaMaskButton:", () => {
         loggedIn: true,
         address: "0x0cc725e6ba24e7db79f62f22a7994a8ee33adc1b",
         wallets: ["0x0cc725e6ba24e7db79f62f22a7994a8ee33adc1b"],
-        roles: [],
       })),
       currentNetwork: computed(() => ({
         name: "test",
@@ -268,7 +267,6 @@ describe("ConnectMetaMaskButton:", () => {
         loggedIn: true,
         address: "0x0cc725e6ba24e7db79f62f22a7994a8ee33adc1b",
         wallets: ["0x0cc725e6ba24e7db79f62f22a7994a8ee33adc1b"],
-        roles: [],
       })),
       currentNetwork: computed(() => ({
         name: "test",

--- a/packages/app/tests/components/ConnectMetamaskButton.spec.ts
+++ b/packages/app/tests/components/ConnectMetamaskButton.spec.ts
@@ -150,6 +150,8 @@ describe("ConnectMetaMaskButton:", () => {
         loggedIn: true,
         address: "0x0cc725e6ba24e7db79f62f22a7994a8ee33adc1b",
         wallets: ["0x0cc725e6ba24e7db79f62f22a7994a8ee33adc1b"],
+        hasFullReadAccess: false,
+        hasAdminRead: false,
       })),
       currentNetwork: computed(() => ({
         name: "test",
@@ -267,6 +269,8 @@ describe("ConnectMetaMaskButton:", () => {
         loggedIn: true,
         address: "0x0cc725e6ba24e7db79f62f22a7994a8ee33adc1b",
         wallets: ["0x0cc725e6ba24e7db79f62f22a7994a8ee33adc1b"],
+        hasFullReadAccess: false,
+        hasAdminRead: false,
       })),
       currentNetwork: computed(() => ({
         name: "test",

--- a/packages/app/tests/components/Contract.spec.ts
+++ b/packages/app/tests/components/Contract.spec.ts
@@ -1,3 +1,4 @@
+import { computed } from "vue";
 import { createI18n } from "vue-i18n";
 
 import { afterEach, beforeEach, describe, expect, it, type SpyInstance, vi } from "vitest";
@@ -34,7 +35,15 @@ describe("Contract:", () => {
   let mockContext: SpyInstance;
 
   beforeEach(() => {
-    mockContext = useContextMock();
+    mockContext = useContextMock({
+      user: computed(() => ({
+        address: "0x000000000000000000000000000000000000800A",
+        wallets: ["0x000000000000000000000000000000000000800A"],
+        roles: [],
+        isAdmin: true,
+        loggedIn: true as const,
+      })),
+    });
   });
 
   afterEach(() => {

--- a/packages/app/tests/components/Contract.spec.ts
+++ b/packages/app/tests/components/Contract.spec.ts
@@ -39,8 +39,7 @@ describe("Contract:", () => {
       user: computed(() => ({
         address: "0x000000000000000000000000000000000000800A",
         wallets: ["0x000000000000000000000000000000000000800A"],
-        roles: [],
-        isAdmin: true,
+        hasFullReadAccess: true,
         loggedIn: true as const,
       })),
     });

--- a/packages/app/tests/components/Contract.spec.ts
+++ b/packages/app/tests/components/Contract.spec.ts
@@ -40,6 +40,7 @@ describe("Contract:", () => {
         address: "0x000000000000000000000000000000000000800A",
         wallets: ["0x000000000000000000000000000000000000800A"],
         hasFullReadAccess: true,
+        hasAdminRead: false,
         loggedIn: true as const,
       })),
     });

--- a/packages/app/tests/e2e/src/helpers/prividium-auth-mocks.ts
+++ b/packages/app/tests/e2e/src/helpers/prividium-auth-mocks.ts
@@ -24,7 +24,7 @@ export async function setupAuthMocks(page: Page, options: AuthMockOptions) {
         await route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify({ address: userAddress, roles: [] }),
+          body: JSON.stringify({ address: userAddress }),
         });
       } else {
         console.log("[Mock] /auth/login - Unauthorized, returning 403");
@@ -45,7 +45,7 @@ export async function setupAuthMocks(page: Page, options: AuthMockOptions) {
         await route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify({ address: userAddress, roles: [] }),
+          body: JSON.stringify({ address: userAddress }),
         });
       } else {
         console.log("[Mock] /auth/me - User not logged in (isLoggedIn:", authState.isLoggedIn, "), returning 401");

--- a/packages/app/tests/mocks.ts
+++ b/packages/app/tests/mocks.ts
@@ -176,6 +176,7 @@ export const useContextMock = (params: any = {}) => {
       address: "0x000000000000000000000000000000000000800A",
       wallets: ["0x000000000000000000000000000000000000800A"],
       hasFullReadAccess: false,
+      hasAdminRead: false,
       loggedIn: true,
     })),
     identifyNetwork: () => undefined,

--- a/packages/app/tests/mocks.ts
+++ b/packages/app/tests/mocks.ts
@@ -175,8 +175,7 @@ export const useContextMock = (params: any = {}) => {
     user: computed(() => ({
       address: "0x000000000000000000000000000000000000800A",
       wallets: ["0x000000000000000000000000000000000000800A"],
-      roles: [],
-      isAdmin: false,
+      hasFullReadAccess: false,
       loggedIn: true,
     })),
     identifyNetwork: () => undefined,

--- a/packages/app/tests/mocks.ts
+++ b/packages/app/tests/mocks.ts
@@ -176,6 +176,7 @@ export const useContextMock = (params: any = {}) => {
       address: "0x000000000000000000000000000000000000800A",
       wallets: ["0x000000000000000000000000000000000000800A"],
       roles: [],
+      isAdmin: false,
       loggedIn: true,
     })),
     identifyNetwork: () => undefined,

--- a/packages/app/tests/router/index.spec.ts
+++ b/packages/app/tests/router/index.spec.ts
@@ -58,7 +58,7 @@ describe("Router Navigation Guard", () => {
       const isPrividium = mockAppEnvironment() === "prividium";
 
       if (isPrividium && to.meta.requiresAdmin) {
-        const isAdmin = mockUser.value.loggedIn && mockUser.value.isAdmin;
+        const isAdmin = mockUser.value.loggedIn && mockUser.value.hasFullReadAccess;
         if (!isAdmin) {
           return { name: "not-authorized" };
         }
@@ -99,8 +99,7 @@ describe("Router Navigation Guard", () => {
         loggedIn: true,
         address: "0x123",
         wallets: ["0x123"],
-        roles: ["user"],
-        isAdmin: false,
+        hasFullReadAccess: false,
       };
 
       await router.push("/contracts/verify");
@@ -112,8 +111,7 @@ describe("Router Navigation Guard", () => {
         loggedIn: true,
         address: "0x123",
         wallets: ["0x123"],
-        roles: ["admin"],
-        isAdmin: true,
+        hasFullReadAccess: true,
       };
 
       await router.push("/contracts/verify");
@@ -132,8 +130,7 @@ describe("Router Navigation Guard", () => {
         loggedIn: true,
         address: "0x123",
         wallets: ["0x123"],
-        roles: ["user"],
-        isAdmin: false,
+        hasFullReadAccess: false,
       };
 
       await router.push("/public");

--- a/packages/app/tests/router/index.spec.ts
+++ b/packages/app/tests/router/index.spec.ts
@@ -58,8 +58,8 @@ describe("Router Navigation Guard", () => {
       const isPrividium = mockAppEnvironment() === "prividium";
 
       if (isPrividium && to.meta.requiresAdmin) {
-        const isAdmin = mockUser.value.loggedIn && mockUser.value.hasFullReadAccess;
-        if (!isAdmin) {
+        const hasAdminRead = mockUser.value.loggedIn && mockUser.value.hasAdminRead;
+        if (!hasAdminRead) {
           return { name: "not-authorized" };
         }
       }
@@ -100,6 +100,7 @@ describe("Router Navigation Guard", () => {
         address: "0x123",
         wallets: ["0x123"],
         hasFullReadAccess: false,
+        hasAdminRead: false,
       };
 
       await router.push("/contracts/verify");
@@ -112,6 +113,7 @@ describe("Router Navigation Guard", () => {
         address: "0x123",
         wallets: ["0x123"],
         hasFullReadAccess: true,
+        hasAdminRead: true,
       };
 
       await router.push("/contracts/verify");
@@ -131,6 +133,7 @@ describe("Router Navigation Guard", () => {
         address: "0x123",
         wallets: ["0x123"],
         hasFullReadAccess: false,
+        hasAdminRead: false,
       };
 
       await router.push("/public");

--- a/packages/app/tests/router/index.spec.ts
+++ b/packages/app/tests/router/index.spec.ts
@@ -58,7 +58,7 @@ describe("Router Navigation Guard", () => {
       const isPrividium = mockAppEnvironment() === "prividium";
 
       if (isPrividium && to.meta.requiresAdmin) {
-        const isAdmin = mockUser.value.loggedIn && mockUser.value.roles?.includes("admin");
+        const isAdmin = mockUser.value.loggedIn && mockUser.value.isAdmin;
         if (!isAdmin) {
           return { name: "not-authorized" };
         }
@@ -100,6 +100,7 @@ describe("Router Navigation Guard", () => {
         address: "0x123",
         wallets: ["0x123"],
         roles: ["user"],
+        isAdmin: false,
       };
 
       await router.push("/contracts/verify");
@@ -112,6 +113,7 @@ describe("Router Navigation Guard", () => {
         address: "0x123",
         wallets: ["0x123"],
         roles: ["admin"],
+        isAdmin: true,
       };
 
       await router.push("/contracts/verify");
@@ -131,6 +133,7 @@ describe("Router Navigation Guard", () => {
         address: "0x123",
         wallets: ["0x123"],
         roles: ["user"],
+        isAdmin: false,
       };
 
       await router.push("/public");


### PR DESCRIPTION
# What ❔

Replace hardcoded admin role name checks with permission-based checks throughout the Block Explorer (API and frontend) running in Prividium Mode.

Previously, `isAdmin` was determined by matching the user's role name against the configurable `PRIVIDIUM_ADMIN_ROLE_NAME` environment variable. This tied access control to role naming conventions rather than what a role actually permits.

Now two independent boolean flags are computed from \`systemPermissions\` returned by the Permissions API (`/api/profiles/me`):

- `hasFullReadAccess` — true if any role has `full_read_access` or `full_sequencer_rpc_access`. Controls data visibility: unfiltered access to chain data, events tab.
- `hasAdminRead` — true if any role has `admin_read`. Controls admin UI: nav links, contract verification route.

**Why two separate flags, not raw permissions or roles?**

The backend is the right place to interpret Prividium permission semantics. Returning raw permission strings or role objects to the frontend would require duplicating the mapping logic (`full_read_access || full_sequencer_rpc_access → view all data`) in both backend and frontend. Computed named booleans keep that logic in one place and give the frontend a stable, intent-named interface.

The two flags are intentionally independent: \`full_sequencer_rpc_access\` grants full data read but not admin panel access. An operator can grant sequencer-level read without admin rights.

**Changes:**

- `AddUserRolesPipe` / `auth.controller.ts`: shared `parseUserProfile()` helper computes both flags from `systemPermissions`; both stored in session at login and returned by `/auth/me` and `/auth/login`
- `AuthMiddleware` / `/docs` guard: use appropriate flag per context
- Config: removed `PRIVIDIUM_ADMIN_ROLE_NAME` env var and `adminRoleName` config field
- Frontend `UserContext`: replaced `roles: string[]` + `isAdmin: boolean` with `hasFullReadAccess` and `hasAdminRead`; `roles` removed from API responses as the frontend never consumed it
- Local variables previously named `isAdmin` renamed to `hasFullReadAccess` or `hasAdminRead` to reflect which check they actually perform

## Why ❔

Role names are operator-defined and vary between deployments. Checking `systemPermissions` directly ties the explorer's behaviour to what permissions actually mean, making it correct across all Prividium deployments regardless of role naming.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.