### PR TITLE
fix(prividium): invalidate explorer session when upstream JWT is revoked

### DIFF
--- a/packages/api/src/api/pipes/addUserRoles.pipe.spec.ts
+++ b/packages/api/src/api/pipes/addUserRoles.pipe.spec.ts
@@ -1,7 +1,7 @@
 import { AddUserRolesPipe } from "./addUserRoles.pipe";
 import { ConfigService } from "@nestjs/config";
 import { mock } from "jest-mock-extended";
-import { InternalServerErrorException } from "@nestjs/common";
+import { BadGatewayException } from "@nestjs/common";
 import { PrividiumApiError } from "../../errors/prividiumApiError";
 
 describe("AddUserRolesPipe", () => {
@@ -160,10 +160,10 @@ describe("AddUserRolesPipe", () => {
 
     const pipe = new AddUserRolesPipe(configServiceMock);
 
-    await expect(pipe.transform({ address: "0x01", token: "token1" })).rejects.toThrow(InternalServerErrorException);
+    await expect(pipe.transform({ address: "0x01", token: "token1" })).rejects.toThrow(BadGatewayException);
   });
 
-  it("throws if server returns non 200 status", async () => {
+  it("throws PrividiumApiError if server returns 401", async () => {
     fetchSpy.mockResolvedValueOnce({
       status: 401,
       json: jest.fn().mockResolvedValue({
@@ -176,6 +176,17 @@ describe("AddUserRolesPipe", () => {
     await expect(pipe.transform({ address: "0x01", token: "token1" })).rejects.toThrow(PrividiumApiError);
   });
 
+  it("throws BadGatewayException if server returns a non-401 error status", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      status: 503,
+      json: jest.fn().mockResolvedValue({}),
+    });
+
+    const pipe = new AddUserRolesPipe(configServiceMock);
+
+    await expect(pipe.transform({ address: "0x01", token: "token1" })).rejects.toThrow(BadGatewayException);
+  });
+
   it("throws if server returns non parseable json", async () => {
     fetchSpy.mockResolvedValueOnce({
       status: 200,
@@ -184,7 +195,7 @@ describe("AddUserRolesPipe", () => {
 
     const pipe = new AddUserRolesPipe(configServiceMock);
 
-    await expect(pipe.transform({ address: "0x01", token: "token1" })).rejects.toThrow(InternalServerErrorException);
+    await expect(pipe.transform({ address: "0x01", token: "token1" })).rejects.toThrow(BadGatewayException);
   });
 
   it("throws if server do not complete request", async () => {
@@ -192,6 +203,6 @@ describe("AddUserRolesPipe", () => {
 
     const pipe = new AddUserRolesPipe(configServiceMock);
 
-    await expect(pipe.transform({ address: "0x01", token: "token1" })).rejects.toThrow(InternalServerErrorException);
+    await expect(pipe.transform({ address: "0x01", token: "token1" })).rejects.toThrow(BadGatewayException);
   });
 });

--- a/packages/api/src/api/pipes/addUserRoles.pipe.ts
+++ b/packages/api/src/api/pipes/addUserRoles.pipe.ts
@@ -1,4 +1,4 @@
-import { PipeTransform, Injectable, InternalServerErrorException } from "@nestjs/common";
+import { PipeTransform, Injectable, BadGatewayException } from "@nestjs/common";
 import { UserParam } from "../../user/user.decorator";
 import { ConfigService } from "@nestjs/config";
 import { z } from "zod";
@@ -35,8 +35,8 @@ export function parseUserProfile(data: unknown): Permissions {
   return { hasFullReadAccess, hasAdminRead };
 }
 
-function throwError(): never {
-  throw new InternalServerErrorException("Authentication failed");
+function throwUpstreamError(): never {
+  throw new BadGatewayException("Auth service unavailable");
 }
 
 @Injectable()
@@ -48,18 +48,22 @@ export class AddUserRolesPipe implements PipeTransform<UserParam | null, Promise
 
     const response = await fetch(new URL("/api/profiles/me", this.config.get("prividium.permissionsApiUrl")), {
       headers: { Authorization: `Bearer ${value.token}` },
-    }).catch(throwError);
+    }).catch(throwUpstreamError);
 
-    if (response.status !== 200) {
+    if (response.status === 401) {
       throw new PrividiumApiError("Authentication failed", 401);
     }
 
-    const json = await response.json().catch(throwError);
+    if (response.status !== 200) {
+      throwUpstreamError();
+    }
+
+    const json = await response.json().catch(throwUpstreamError);
     const profile = (() => {
       try {
         return parseUserProfile(json);
       } catch {
-        return throwError();
+        return throwUpstreamError();
       }
     })();
 

--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -1,4 +1,6 @@
 import { Module, Logger, MiddlewareConsumer, NestModule, DynamicModule, Inject } from "@nestjs/common";
+import { APP_FILTER } from "@nestjs/core";
+import { SessionInvalidationFilter } from "./middlewares/sessionInvalidation.filter";
 import { TypeOrmModule, TypeOrmModuleOptions } from "@nestjs/typeorm";
 import { ConfigModule, ConfigService } from "@nestjs/config";
 import { HealthModule } from "./health/health.module";
@@ -81,6 +83,14 @@ export class AppModule implements NestModule {
             prividium,
           },
         },
+        ...(prividium
+          ? [
+              {
+                provide: APP_FILTER,
+                useClass: SessionInvalidationFilter,
+              },
+            ]
+          : []),
       ],
       imports: [
         /// Only enable prividium modules for prividium chains

--- a/packages/api/src/middlewares/sessionInvalidation.filter.spec.ts
+++ b/packages/api/src/middlewares/sessionInvalidation.filter.spec.ts
@@ -1,0 +1,63 @@
+import { ArgumentsHost, BadGatewayException, ForbiddenException, UnauthorizedException } from "@nestjs/common";
+import { mock } from "jest-mock-extended";
+import { Request, Response } from "express";
+import { SessionInvalidationFilter } from "./sessionInvalidation.filter";
+import { PrividiumApiError } from "../errors/prividiumApiError";
+
+describe("SessionInvalidationFilter", () => {
+  const buildHost = (req: Request, res: Response): ArgumentsHost =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => req,
+        getResponse: () => res,
+        getNext: () => jest.fn(),
+      }),
+      getArgByIndex: jest.fn(),
+      getArgs: jest.fn(),
+      getType: () => "http",
+    } as unknown as ArgumentsHost);
+
+  let filter: SessionInvalidationFilter;
+  let req: Request;
+  let res: Response;
+  let host: ArgumentsHost;
+
+  beforeEach(() => {
+    filter = new SessionInvalidationFilter();
+    // Stub the inherited BaseExceptionFilter.catch so we can isolate the session-nulling behavior.
+    jest.spyOn(Object.getPrototypeOf(SessionInvalidationFilter.prototype), "catch").mockImplementation(jest.fn());
+    req = mock<Request>();
+    res = mock<Response>();
+    host = buildHost(req, res);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("nulls req.session on 401 UnauthorizedException", () => {
+    req.session = { address: "0x01", token: "tok" };
+    filter.catch(new UnauthorizedException("nope"), host);
+    expect(req.session).toBeNull();
+  });
+
+  it("nulls req.session on 401 PrividiumApiError", () => {
+    req.session = { address: "0x01", token: "tok" };
+    filter.catch(new PrividiumApiError("Authentication failed", 401), host);
+    expect(req.session).toBeNull();
+  });
+
+  it("preserves req.session on 403 ForbiddenException", () => {
+    const session = { address: "0x01", token: "tok" };
+    req.session = session;
+    filter.catch(new ForbiddenException("forbidden"), host);
+    expect(req.session).toBe(session);
+  });
+
+  it("preserves req.session on 502 BadGatewayException", () => {
+    const session = { address: "0x01", token: "tok" };
+    req.session = session;
+    filter.catch(new BadGatewayException("upstream down"), host);
+    expect(req.session).toBe(session);
+  });
+});

--- a/packages/api/src/middlewares/sessionInvalidation.filter.ts
+++ b/packages/api/src/middlewares/sessionInvalidation.filter.ts
@@ -1,0 +1,20 @@
+import { ArgumentsHost, Catch, HttpException } from "@nestjs/common";
+import { BaseExceptionFilter } from "@nestjs/core";
+import { Request } from "express";
+
+/**
+ * Nulls req.session on any 401 so cookie-session emits a clearing Set-Cookie alongside the
+ * 401 response. Needed because the @User(AddUserRolesPipe) parameter pipe revalidates the
+ * upstream JWT after the auth middleware has already refreshed the cookie — if the pipe
+ * then rejects, the cookie would otherwise be sent back refreshed instead of cleared.
+ */
+@Catch(HttpException)
+export class SessionInvalidationFilter extends BaseExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    if (exception.getStatus() === 401) {
+      const req = host.switchToHttp().getRequest<Request>();
+      req.session = null;
+    }
+    super.catch(exception, host);
+  }
+}

--- a/packages/app/src/composables/common/useFetch.ts
+++ b/packages/app/src/composables/common/useFetch.ts
@@ -24,7 +24,7 @@ export function useFetch<T>(getRequestUrl: (...params: string[]) => URL, context
     failed.value = false;
 
     try {
-      const response = await FetchInstance.withCredentials(context)<T>(getRequestUrl(...params).toString());
+      const response = await FetchInstance.api(context)<T>(getRequestUrl(...params).toString());
 
       item.value = response;
     } catch (error) {

--- a/packages/app/src/composables/common/useFetchCollection.ts
+++ b/packages/app/src/composables/common/useFetchCollection.ts
@@ -45,9 +45,7 @@ export function useFetchCollection<T, TApiResponse = T>(
       url.searchParams.set("limit", pageSize.value.toString());
       url.searchParams.set("page", nextPage.toString());
 
-      const response = await FetchInstance.withCredentials(context)<Api.Response.Collection<TApiResponse>>(
-        url.toString()
-      );
+      const response = await FetchInstance.api(context)<Api.Response.Collection<TApiResponse>>(url.toString());
       data.value = itemMapper ? response.items?.map((item) => itemMapper(item)) : (response.items as unknown as T[]);
       total.value = response.meta.totalItems;
     } catch (error) {

--- a/packages/app/src/composables/useFetchInstance.ts
+++ b/packages/app/src/composables/useFetchInstance.ts
@@ -12,12 +12,13 @@ export class FetchInstance {
 
   public static api(context = useContext()) {
     return this.withCredentials(context, context.currentNetwork.value.apiUrl, ({ response }) => {
-      // For prividium response of 401 when the context indicates that the server logged out
-      // the user. To avoid complex state management, we force
-      // refresh preserving the current url as redirect url after login
-      if (context.currentNetwork.value.prividium && context.user.value.loggedIn && response.status === 401) {
-        window.location.href = `/login?redirect=${encodeURIComponent(window.location.pathname)}`;
+      if (response.status !== 401 || !context.currentNetwork.value.prividium || !context.user.value.loggedIn) {
+        return;
       }
+
+      // API invalidated the session
+      context.user.value = { loggedIn: false };
+      window.location.href = `/login?redirect=${encodeURIComponent(window.location.pathname)}`;
     });
   }
 
@@ -25,7 +26,7 @@ export class FetchInstance {
     return this.withBaseUrl(context.currentNetwork.value.verificationApiUrl ?? "");
   }
 
-  public static withCredentials(context: Context, baseUrl?: string, onResponse?: OnResponse) {
+  private static withCredentials(context: Context, baseUrl?: string, onResponse?: OnResponse) {
     const prividium = !!context.currentNetwork.value.prividium;
     if (prividium) {
       return baseUrl

--- a/packages/app/tests/composables/common/useFetch.spec.ts
+++ b/packages/app/tests/composables/common/useFetch.spec.ts
@@ -5,8 +5,10 @@ import { $fetch } from "ohmyfetch";
 import composable, { type UseFetch } from "@/composables/common/useFetch";
 
 vi.mock("ohmyfetch", () => {
+  const fetchSpy = vi.fn(() => null);
+  (fetchSpy as unknown as { create: SpyInstance }).create = vi.fn(() => fetchSpy);
   return {
-    $fetch: vi.fn(() => null),
+    $fetch: fetchSpy,
   };
 });
 

--- a/packages/app/tests/composables/common/useFetchCollection.spec.ts
+++ b/packages/app/tests/composables/common/useFetchCollection.spec.ts
@@ -5,8 +5,10 @@ import { $fetch } from "ohmyfetch";
 import composable, { type UseFetchCollection } from "@/composables/common/useFetchCollection";
 
 vi.mock("ohmyfetch", () => {
+  const fetchSpy = vi.fn(() => null);
+  (fetchSpy as unknown as { create: SpyInstance }).create = vi.fn(() => fetchSpy);
   return {
-    $fetch: vi.fn(() => null),
+    $fetch: fetchSpy,
   };
 });
 

--- a/packages/app/tests/composables/useBlocks.spec.ts
+++ b/packages/app/tests/composables/useBlocks.spec.ts
@@ -7,28 +7,30 @@ import { useContextMock } from "./../mocks";
 import useBlocks from "@/composables/useBlocks";
 
 vi.mock("ohmyfetch", () => {
-  return {
-    $fetch: vi.fn(() =>
-      Promise.resolve({
-        items: [
-          {
-            hash: "0x5a606c1c09d5be2f73c413f27758459a959a642fd3dca2af05d153aac29e229b",
-            l1TxCount: 0,
-            l2TxCount: 1,
-            number: 105205,
-            status: "sealed",
-            timestamp: "2022-04-13T13:09:31.000Z",
-          },
-        ],
-        meta: {
-          totalItems: 1,
-          page: 1,
-          pageSize: 10,
-          totalPages: 1,
-          itemCount: 1,
+  const fetchSpy = vi.fn(() =>
+    Promise.resolve({
+      items: [
+        {
+          hash: "0x5a606c1c09d5be2f73c413f27758459a959a642fd3dca2af05d153aac29e229b",
+          l1TxCount: 0,
+          l2TxCount: 1,
+          number: 105205,
+          status: "sealed",
+          timestamp: "2022-04-13T13:09:31.000Z",
         },
-      })
-    ),
+      ],
+      meta: {
+        totalItems: 1,
+        page: 1,
+        pageSize: 10,
+        totalPages: 1,
+        itemCount: 1,
+      },
+    })
+  );
+  (fetchSpy as unknown as { create: SpyInstance }).create = vi.fn(() => fetchSpy);
+  return {
+    $fetch: fetchSpy,
   };
 });
 

--- a/packages/app/tests/composables/useNetworkStats.spec.ts
+++ b/packages/app/tests/composables/useNetworkStats.spec.ts
@@ -10,8 +10,10 @@ import type { UseFetch } from "@/composables/common/useFetch";
 import type { SpyInstance } from "vitest";
 
 vi.mock("ohmyfetch", () => {
+  const fetchSpy = vi.fn(() => new Promise((resolve) => setImmediate(resolve)));
+  (fetchSpy as unknown as { create: SpyInstance }).create = vi.fn(() => fetchSpy);
   return {
-    $fetch: vi.fn(() => new Promise((resolve) => setImmediate(resolve))),
+    $fetch: fetchSpy,
   };
 });
 

--- a/packages/app/tests/composables/useTransfers.spec.ts
+++ b/packages/app/tests/composables/useTransfers.spec.ts
@@ -28,26 +28,28 @@ const baseTransferPayload = {
 };
 
 vi.mock("ohmyfetch", () => {
+  const fetchSpy = vi.fn(() =>
+    Promise.resolve({
+      items: [
+        { ...baseTransferPayload, type: "transfer" },
+        { ...baseTransferPayload, token: null, type: "transfer" },
+        { ...baseTransferPayload, type: "deposit" },
+        { ...baseTransferPayload, type: "withdrawal" },
+        { ...baseTransferPayload, type: "deposit", chainId: "11" },
+        { ...baseTransferPayload, type: "deposit", chainId: "270" },
+      ],
+      meta: {
+        totalItems: 6,
+        page: 1,
+        pageSize: 10,
+        totalPages: 1,
+        itemCount: 1,
+      },
+    })
+  );
+  (fetchSpy as unknown as { create: SpyInstance }).create = vi.fn(() => fetchSpy);
   return {
-    $fetch: vi.fn(() =>
-      Promise.resolve({
-        items: [
-          { ...baseTransferPayload, type: "transfer" },
-          { ...baseTransferPayload, token: null, type: "transfer" },
-          { ...baseTransferPayload, type: "deposit" },
-          { ...baseTransferPayload, type: "withdrawal" },
-          { ...baseTransferPayload, type: "deposit", chainId: "11" },
-          { ...baseTransferPayload, type: "deposit", chainId: "270" },
-        ],
-        meta: {
-          totalItems: 6,
-          page: 1,
-          pageSize: 10,
-          totalPages: 1,
-          itemCount: 1,
-        },
-      })
-    ),
+    $fetch: fetchSpy,
   };
 });
 


### PR DESCRIPTION
# What ❔

When the user logs out from the User Panel in Prividium, the explorer kept treating the session as alive: refresh showed empty tables and direct links like `/address/0x...` looped between `/login` and the target.

Root cause was twofold:
- The BFF cookie session was a snapshot of `{ address, token, wallets, expiresAt }` captured at login. The `@User(AddUserRolesPipe)` parameter pipe did revalidate the JWT against permissions-api on every BFF call, but when that revalidation failed with 401 the pipe's exception bubbled up *after* `AuthMiddleware` had already mutated `req.session._nowInMinutes`, so `cookie-session` emitted a refresh `Set-Cookie` instead of a clear.
- The frontend's 401 interceptor only ran for calls made via `FetchInstance.api(...)`. List composables (`common/useFetch`, `common/useFetchCollection`) used `FetchInstance.withCredentials(context)` without an `onResponse` handler, so home/transactions/blocks pages received 401s silently and rendered empty tables instead of redirecting.

## Why ❔

- Fix proper session cleanup after logout in user panel for Prividium

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.

Closes https://github.com/matter-labs/zksync-prividium/issues/1002