### PR TITLE
fix(data-fetcher): authenticate bridge event emitter before indexing transfers

### DIFF
--- a/packages/data-fetcher/.env.example
+++ b/packages/data-fetcher/.env.example
@@ -19,3 +19,11 @@ RPC_BATCH_STALL_TIME_MS=0
 MAX_BLOCKS_BATCH_SIZE=20
 
 RPC_HEALTH_CHECK_TIMEOUT_MS=20_000
+
+# Comma-separated list of L2 addresses (besides the canonical bridges reported by
+# zks_getBridgeContracts) whose legacy FinalizeDeposit / WithdrawalInitiated events should be
+# indexed as real bridge transfers, e.g. third-party custom token bridges. Deployment-specific:
+# emitters not in this list and not a canonical bridge are skipped and counted via the
+# skipped_untrusted_legacy_bridge_logs_total metric. For ZKsync Era mainnet this should include at
+# least the Lido wstETH bridge.
+# TRUSTED_LEGACY_BRIDGE_ADDRESSES=0xe1d6a50e7101c8f8db77352897ee3f1ac53f782b

--- a/packages/data-fetcher/README.md
+++ b/packages/data-fetcher/README.md
@@ -16,6 +16,7 @@ $ npm install
 cp .env.example .env
 ```
 - In order to tell the service where to get the blockchain data from set the value of the `BLOCKCHAIN_RPC_URL` env var to your blockchain RPC API URL. For ZKsync Era testnet it can be set to `https://sepolia.era.zksync.dev`. For ZKsync Era mainnet - `https://mainnet.era.zksync.io`.
+- Legacy bridge events (`FinalizeDeposit` / `WithdrawalInitiated`) are only indexed when emitted by a trusted bridge: the canonical bridges reported by `zks_getBridgeContracts` plus any addresses listed in the optional `TRUSTED_LEGACY_BRIDGE_ADDRESSES` env var (comma-separated). Add legitimate third-party/custom token bridges there so their transfers are not dropped — for ZKsync Era mainnet this should include at least the Lido wstETH bridge `0xe1d6a50e7101c8f8db77352897ee3f1ac53f782b`. Skipped emitters are counted by the `skipped_untrusted_legacy_bridge_logs_total` metric.
 
 ## Running the app
 

--- a/packages/data-fetcher/src/blockchain/blockchain.service.spec.ts
+++ b/packages/data-fetcher/src/blockchain/blockchain.service.spec.ts
@@ -1,4 +1,5 @@
 import { mock } from "jest-mock-extended";
+import { register } from "prom-client";
 import { Log, Block, TransactionReceipt, TransactionResponse } from "ethers";
 import { Test, TestingModule } from "@nestjs/testing";
 import { Logger } from "@nestjs/common";
@@ -1677,6 +1678,40 @@ describe("BlockchainService", () => {
       const result = await blockchainService.getTrustedLegacyBridgeAddresses();
       expect(result.has("0xe1d6a50e7101c8f8db77352897ee3f1ac53f782b")).toBe(true);
       expect(result.size).toBe(1);
+    });
+
+    it("caches the fallback on a deterministic failure and does not re-call the node", async () => {
+      jest.spyOn(provider, "send").mockRejectedValue({ code: -32601, message: "Method not found" });
+      await blockchainService.getTrustedLegacyBridgeAddresses();
+      await blockchainService.getTrustedLegacyBridgeAddresses();
+      expect(provider.send).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries on a transient network failure rather than caching the fallback", async () => {
+      jest.spyOn(provider, "send").mockRejectedValue({ code: "NETWORK_ERROR", message: "boom" });
+      await blockchainService.getTrustedLegacyBridgeAddresses();
+      await blockchainService.getTrustedLegacyBridgeAddresses();
+      expect(provider.send).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("isTrustedLegacyBridgeEmitter", () => {
+    const bridgeContracts = { l2LegacySharedBridge: "0x11F943b2c77b743AB90f4A0Ae7d5A4e7FCA3E102" };
+
+    it("returns true for a log emitted by a trusted bridge", async () => {
+      jest.spyOn(provider, "send").mockResolvedValue(bridgeContracts);
+      const log = mock<Log>({ address: "0x11f943b2c77b743ab90f4a0ae7d5a4e7fca3e102" });
+      expect(await blockchainService.isTrustedLegacyBridgeEmitter(log, "withdrawal")).toBe(true);
+    });
+
+    it("returns false and counts the skip for an untrusted emitter", async () => {
+      jest.spyOn(provider, "send").mockResolvedValue(bridgeContracts);
+      const log = mock<Log>({ address: "0x9999999999999999999999999999999999999999" });
+      const metric = register.getSingleMetric("skipped_untrusted_legacy_bridge_logs_total");
+      const total = async () => (await metric.get()).values.reduce((sum, v) => sum + v.value, 0);
+      const before = await total();
+      expect(await blockchainService.isTrustedLegacyBridgeEmitter(log, "withdrawal")).toBe(false);
+      expect(await total()).toBeGreaterThan(before);
     });
   });
 });

--- a/packages/data-fetcher/src/blockchain/blockchain.service.spec.ts
+++ b/packages/data-fetcher/src/blockchain/blockchain.service.spec.ts
@@ -1633,4 +1633,50 @@ describe("BlockchainService", () => {
       });
     });
   });
+
+  describe("getTrustedLegacyBridgeAddresses", () => {
+    const bridgeContracts = {
+      l2SharedDefaultBridge: "0x0000000000000000000000000000000000010003",
+      l2LegacySharedBridge: "0x11F943b2c77b743AB90f4A0Ae7d5A4e7FCA3E102",
+      l2Erc20DefaultBridge: "0x0000000000000000000000000000000000010003",
+      l2WethBridge: "0x0000000000000000000000000000000000000000",
+    };
+
+    it("returns the lower-cased canonical bridge addresses from zks_getBridgeContracts, excluding the zero address", async () => {
+      jest.spyOn(provider, "send").mockResolvedValue(bridgeContracts);
+      const result = await blockchainService.getTrustedLegacyBridgeAddresses();
+      expect(provider.send).toHaveBeenCalledWith("zks_getBridgeContracts", []);
+      expect(result.has("0x0000000000000000000000000000000000010003")).toBe(true);
+      expect(result.has("0x11f943b2c77b743ab90f4a0ae7d5a4e7fca3e102")).toBe(true);
+      expect(result.has("0x0000000000000000000000000000000000000000")).toBe(false);
+    });
+
+    it("caches the result and does not call the node again on subsequent calls", async () => {
+      jest.spyOn(provider, "send").mockResolvedValue(bridgeContracts);
+      await blockchainService.getTrustedLegacyBridgeAddresses();
+      await blockchainService.getTrustedLegacyBridgeAddresses();
+      expect(provider.send).toHaveBeenCalledTimes(1);
+    });
+
+    it("includes the configured allowlist of custom bridge addresses", async () => {
+      (configServiceMock.get as jest.Mock).mockImplementation((configName) =>
+        configName === "trustedLegacyBridgeAddresses" ? ["0xe1d6a50e7101c8f8db77352897ee3f1ac53f782b"] : undefined
+      );
+      blockchainService = new BlockchainService(configServiceMock, provider, app.get(metricProviderKey));
+      jest.spyOn(provider, "send").mockResolvedValue(bridgeContracts);
+      const result = await blockchainService.getTrustedLegacyBridgeAddresses();
+      expect(result.has("0xe1d6a50e7101c8f8db77352897ee3f1ac53f782b")).toBe(true);
+    });
+
+    it("falls back to the configured allowlist when zks_getBridgeContracts is unavailable", async () => {
+      (configServiceMock.get as jest.Mock).mockImplementation((configName) =>
+        configName === "trustedLegacyBridgeAddresses" ? ["0xe1d6a50e7101c8f8db77352897ee3f1ac53f782b"] : undefined
+      );
+      blockchainService = new BlockchainService(configServiceMock, provider, app.get(metricProviderKey));
+      jest.spyOn(provider, "send").mockRejectedValue({ code: -32601, message: "Method not found" });
+      const result = await blockchainService.getTrustedLegacyBridgeAddresses();
+      expect(result.has("0xe1d6a50e7101c8f8db77352897ee3f1ac53f782b")).toBe(true);
+      expect(result.size).toBe(1);
+    });
+  });
 });

--- a/packages/data-fetcher/src/blockchain/blockchain.service.ts
+++ b/packages/data-fetcher/src/blockchain/blockchain.service.ts
@@ -15,8 +15,21 @@ import {
 import { JsonRpcProviderBase } from "../rpcProvider";
 import { BLOCKCHAIN_RPC_CALL_DURATION_METRIC_NAME, BlockchainRpcCallMetricLabel } from "../metrics";
 import { RetryableContract } from "./retryableContract";
-import { L2_NATIVE_TOKEN_VAULT_ADDRESS, L2_ACCOUNT_CODE_STORAGE_ADDRESS, CONTRACT_INTERFACES } from "../constants";
+import {
+  L2_NATIVE_TOKEN_VAULT_ADDRESS,
+  L2_ACCOUNT_CODE_STORAGE_ADDRESS,
+  CONTRACT_INTERFACES,
+  ETH_L1_ADDRESS,
+} from "../constants";
 import isBaseToken from "../utils/isBaseToken";
+
+// L2 bridge addresses reported by the node that may legitimately emit legacy bridge events.
+const ZKS_BRIDGE_CONTRACT_KEYS = [
+  "l2SharedDefaultBridge",
+  "l2LegacySharedBridge",
+  "l2Erc20DefaultBridge",
+  "l2WethBridge",
+];
 
 export interface TransactionTrace {
   type: string;
@@ -42,6 +55,8 @@ export class BlockchainService {
   private readonly rpcCallsQuickRetryTimeout: number;
   private readonly rpcCallRetriesMaxTotalTimeout: number;
   private readonly errorCodesForQuickRetry: string[] = ["NETWORK_ERROR", "ECONNRESET", "ECONNREFUSED", "TIMEOUT"];
+  private readonly configuredTrustedLegacyBridgeAddresses: string[];
+  private trustedLegacyBridgeAddresses: Set<string> | null = null;
 
   public constructor(
     configService: ConfigService,
@@ -53,6 +68,38 @@ export class BlockchainService {
     this.rpcCallsDefaultRetryTimeout = configService.get<number>("blockchain.rpcCallDefaultRetryTimeout");
     this.rpcCallsQuickRetryTimeout = configService.get<number>("blockchain.rpcCallQuickRetryTimeout");
     this.rpcCallRetriesMaxTotalTimeout = configService.get<number>("blockchain.rpcCallRetriesMaxTotalTimeout");
+    this.configuredTrustedLegacyBridgeAddresses = configService.get<string[]>("trustedLegacyBridgeAddresses") || [];
+  }
+
+  // Returns the set of L2 addresses (lower-cased) whose legacy FinalizeDeposit / WithdrawalInitiated
+  // events may be trusted as real bridge transfers: the canonical bridges reported by the node via
+  // zks_getBridgeContracts, plus any deployment-specific custom bridges configured via env. The result
+  // is cached. Chains that don't implement zks_getBridgeContracts (e.g. ZKsync OS) gracefully fall back
+  // to the configured allowlist only; on those chains legacy bridge events do not occur.
+  public async getTrustedLegacyBridgeAddresses(): Promise<Set<string>> {
+    if (this.trustedLegacyBridgeAddresses) {
+      return this.trustedLegacyBridgeAddresses;
+    }
+    const addresses = new Set<string>(this.configuredTrustedLegacyBridgeAddresses);
+    try {
+      const bridgeContracts = await this.provider.send("zks_getBridgeContracts", []);
+      for (const key of ZKS_BRIDGE_CONTRACT_KEYS) {
+        const address = bridgeContracts?.[key];
+        if (address && address.toLowerCase() !== ETH_L1_ADDRESS) {
+          addresses.add(address.toLowerCase());
+        }
+      }
+      // Only cache once we have successfully resolved the canonical bridges, so transient RPC
+      // failures are retried rather than permanently degrading to the configured allowlist.
+      this.trustedLegacyBridgeAddresses = addresses;
+    } catch (error) {
+      this.logger.warn({
+        message:
+          "zks_getBridgeContracts is unavailable; trusting only the configured legacy bridge addresses for this chain",
+        code: error.code,
+      });
+    }
+    return addresses;
   }
 
   private async rpcCall<T>(action: () => Promise<T>, functionName: string, retriesTotalTimeAwaited = 0): Promise<T> {

--- a/packages/data-fetcher/src/blockchain/blockchain.service.ts
+++ b/packages/data-fetcher/src/blockchain/blockchain.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from "@nestjs/common";
-import { Histogram } from "prom-client";
+import { Counter, Histogram, register } from "prom-client";
 import { InjectMetric } from "@willsoto/nestjs-prometheus";
 import { Listener, toBeHex } from "ethers";
 import { ConfigService } from "@nestjs/config";
@@ -30,6 +30,20 @@ const ZKS_BRIDGE_CONTRACT_KEYS = [
   "l2Erc20DefaultBridge",
   "l2WethBridge",
 ];
+
+// Counts legacy bridge logs skipped because their emitter is not a trusted bridge. Lets operators
+// detect legitimate custom bridges that need to be added to TRUSTED_LEGACY_BRIDGE_ADDRESSES instead
+// of having those transfers silently dropped. Defined at module level (and guarded against double
+// registration) because the transfer handlers are plain objects that cannot receive an injected
+// metric; it is registered on the default prom-client registry that the /metrics endpoint collects.
+const SKIPPED_UNTRUSTED_LEGACY_BRIDGE_LOG_METRIC_NAME = "skipped_untrusted_legacy_bridge_logs_total";
+const skippedUntrustedLegacyBridgeLogsMetric =
+  (register.getSingleMetric(SKIPPED_UNTRUSTED_LEGACY_BRIDGE_LOG_METRIC_NAME) as Counter<"type">) ||
+  new Counter({
+    name: SKIPPED_UNTRUSTED_LEGACY_BRIDGE_LOG_METRIC_NAME,
+    help: "Number of legacy bridge logs skipped because the emitter is not a trusted bridge.",
+    labelNames: ["type"],
+  });
 
 export interface TransactionTrace {
   type: string;
@@ -89,10 +103,14 @@ export class BlockchainService {
           addresses.add(address.toLowerCase());
         }
       }
-      // Only cache once we have successfully resolved the canonical bridges, so transient RPC
-      // failures are retried rather than permanently degrading to the configured allowlist.
       this.trustedLegacyBridgeAddresses = addresses;
     } catch (error) {
+      // Cache the fallback for deterministic failures (e.g. a chain that doesn't implement
+      // zks_getBridgeContracts, which returns -32601) so we don't re-issue a failing call for every
+      // legacy log. Transient network errors are left uncached so they are retried on the next call.
+      if (!this.errorCodesForQuickRetry.includes(error.code)) {
+        this.trustedLegacyBridgeAddresses = addresses;
+      }
       this.logger.warn({
         message:
           "zks_getBridgeContracts is unavailable; trusting only the configured legacy bridge addresses for this chain",
@@ -100,6 +118,26 @@ export class BlockchainService {
       });
     }
     return addresses;
+  }
+
+  // Whether a legacy bridge event from the given log may be trusted as a real bridge transfer.
+  // Emitters outside the trusted set are skipped (and counted) so that attacker-emitted ABI-shaped
+  // logs are not indexed as bridge transfers; the metric/log surfaces legitimate custom bridges that
+  // should be added to TRUSTED_LEGACY_BRIDGE_ADDRESSES.
+  public async isTrustedLegacyBridgeEmitter(log: Log, transferType: string): Promise<boolean> {
+    const trustedBridgeAddresses = await this.getTrustedLegacyBridgeAddresses();
+    if (trustedBridgeAddresses.has(log.address.toLowerCase())) {
+      return true;
+    }
+    skippedUntrustedLegacyBridgeLogsMetric.inc({ type: transferType });
+    this.logger.debug({
+      message:
+        "Skipped a legacy bridge log from an untrusted emitter; add it to TRUSTED_LEGACY_BRIDGE_ADDRESSES if it is a legitimate bridge",
+      type: transferType,
+      emitter: log.address,
+      transactionHash: log.transactionHash,
+    });
+    return false;
   }
 
   private async rpcCall<T>(action: () => Promise<T>, functionName: string, retriesTotalTimeAwaited = 0): Promise<T> {

--- a/packages/data-fetcher/src/config.spec.ts
+++ b/packages/data-fetcher/src/config.spec.ts
@@ -9,6 +9,7 @@ describe("config", () => {
 
     defaultConfig = {
       port: 3040,
+      trustedLegacyBridgeAddresses: [],
       blockchain: {
         rpcUrl: "http://localhost:3050",
         rpcCallDefaultRetryTimeout: 30000,
@@ -34,6 +35,25 @@ describe("config", () => {
 
   it("sets default values", () => {
     expect(config()).toEqual(defaultConfig);
+  });
+
+  describe("when TRUSTED_LEGACY_BRIDGE_ADDRESSES is specified in env vars", () => {
+    beforeEach(() => {
+      process.env = {
+        TRUSTED_LEGACY_BRIDGE_ADDRESSES:
+          "0xE1d6A50E7101C8f8db77352897Ee3F1aC53f782b, 0x11F943b2c77b743AB90f4A0Ae7d5A4e7FCA3E102",
+      };
+    });
+
+    it("parses the addresses into a lower-cased, trimmed list", () => {
+      expect(config()).toEqual({
+        ...defaultConfig,
+        trustedLegacyBridgeAddresses: [
+          "0xe1d6a50e7101c8f8db77352897ee3f1ac53f782b",
+          "0x11f943b2c77b743ab90f4a0ae7d5a4e7fca3e102",
+        ],
+      });
+    });
   });
 
   describe("when RPC_BATCH_MAX_COUNT is specified in env vars", () => {

--- a/packages/data-fetcher/src/config.ts
+++ b/packages/data-fetcher/src/config.ts
@@ -16,10 +16,18 @@ export default () => {
     MAX_BLOCKS_BATCH_SIZE,
     GRACEFUL_SHUTDOWN_TIMEOUT_MS,
     RPC_HEALTH_CHECK_TIMEOUT_MS,
+    TRUSTED_LEGACY_BRIDGE_ADDRESSES,
   } = process.env;
 
   return {
     port: parseInt(PORT, 10) || 3040,
+    // Additional L2 addresses (besides the canonical bridges reported by zks_getBridgeContracts)
+    // whose legacy FinalizeDeposit / WithdrawalInitiated events are trusted as real bridge transfers,
+    // e.g. third-party custom token bridges. Comma-separated, lower-cased. Deployment-specific.
+    trustedLegacyBridgeAddresses: (TRUSTED_LEGACY_BRIDGE_ADDRESSES || "")
+      .split(",")
+      .map((address) => address.trim().toLowerCase())
+      .filter((address) => address.length > 0),
     blockchain: {
       rpcUrl: BLOCKCHAIN_RPC_URL || "http://localhost:3050",
 

--- a/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/assetRouter.handler.spec.ts
+++ b/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/assetRouter.handler.spec.ts
@@ -1,0 +1,18 @@
+import { Log } from "ethers";
+import { mock } from "jest-mock-extended";
+import { L2_ASSET_ROUTER_ADDRESS } from "../../../constants";
+import { assetRouterFinalizeDepositHandler } from "./assetRouter.handler";
+
+describe("assetRouterFinalizeDepositHandler", () => {
+  describe("matches", () => {
+    it("returns true when the log is emitted by the trusted L2 Asset Router", () => {
+      const log = mock<Log>({ address: L2_ASSET_ROUTER_ADDRESS });
+      expect(assetRouterFinalizeDepositHandler.matches(log, null)).toBe(true);
+    });
+
+    it("returns false when the log is emitted by any other (attacker) contract", () => {
+      const log = mock<Log>({ address: "0x1234567890aBcDeF1234567890AbCdEf12345678" });
+      expect(assetRouterFinalizeDepositHandler.matches(log, null)).toBe(false);
+    });
+  });
+});

--- a/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/assetRouter.handler.ts
+++ b/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/assetRouter.handler.ts
@@ -6,11 +6,14 @@ import { TransferType } from "../../transfer.service";
 import { TokenType } from "../../../token/token.service";
 import { unixTimeToDate } from "../../../utils/date";
 import parseLog from "../../../utils/parseLog";
-import { BASE_TOKEN_ADDRESS, CONTRACT_INTERFACES, ETH_L1_ADDRESS } from "../../../constants";
+import { BASE_TOKEN_ADDRESS, CONTRACT_INTERFACES, ETH_L1_ADDRESS, L2_ASSET_ROUTER_ADDRESS } from "../../../constants";
 import { isBaseToken } from "../../../utils/token";
 
 export const assetRouterFinalizeDepositHandler: ExtractTransferHandler = {
-  matches: (): boolean => true,
+  // Only the trusted L2 Asset Router (a system contract at the same fixed address on Era and every
+  // ZK chain) may emit authoritative bridge deposit events. Without this check any contract could emit
+  // an ABI-shaped DepositFinalizedAssetRouter log and have it indexed as a real bridge deposit.
+  matches: (log: Log): boolean => log.address.toLowerCase() === L2_ASSET_ROUTER_ADDRESS,
   extract: async (log: Log, blockchainService: BlockchainService, block: Block): Promise<Transfer> => {
     const parsedLog = parseLog(CONTRACT_INTERFACES.L2_ASSET_ROUTER, log);
     if (!parsedLog) {

--- a/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/default.handler.spec.ts
+++ b/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/default.handler.spec.ts
@@ -31,9 +31,7 @@ describe("defaultFinalizeDepositHandler", () => {
       timestamp: new Date().getTime() / 1000,
     });
     blockchainService = mock<BlockchainService>();
-    blockchainService.getTrustedLegacyBridgeAddresses.mockResolvedValue(
-      new Set(["0xc7e0220d02d549c4846a6ec31d89c3b670ebe35c"])
-    );
+    blockchainService.isTrustedLegacyBridgeEmitter.mockResolvedValue(true);
   });
 
   describe("matches", () => {
@@ -51,9 +49,7 @@ describe("defaultFinalizeDepositHandler", () => {
     });
 
     it("returns null when the log is emitted by an address that is not a trusted bridge", async () => {
-      blockchainService.getTrustedLegacyBridgeAddresses.mockResolvedValue(
-        new Set(["0x1111111111111111111111111111111111111111"])
-      );
+      blockchainService.isTrustedLegacyBridgeEmitter.mockResolvedValue(false);
       const result = await defaultFinalizeDepositHandler.extract(log, blockchainService, blockDetails);
       expect(result).toBeNull();
     });

--- a/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/default.handler.spec.ts
+++ b/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/default.handler.spec.ts
@@ -1,5 +1,5 @@
 import { Log, Block } from "ethers";
-import { mock } from "jest-mock-extended";
+import { mock, MockProxy } from "jest-mock-extended";
 import { BlockchainService } from "../../../blockchain/blockchain.service";
 import { ZERO_HASH_64 } from "../../../constants";
 import { TransferType } from "../../transfer.service";
@@ -10,7 +10,7 @@ import { BASE_TOKEN_ADDRESS } from "../../../../src/constants";
 describe("defaultFinalizeDepositHandler", () => {
   let log: Log;
   let blockDetails: Block;
-  let blockchainService: BlockchainService;
+  let blockchainService: MockProxy<BlockchainService>;
   beforeEach(() => {
     log = mock<Log>({
       transactionIndex: 1,
@@ -31,6 +31,9 @@ describe("defaultFinalizeDepositHandler", () => {
       timestamp: new Date().getTime() / 1000,
     });
     blockchainService = mock<BlockchainService>();
+    blockchainService.getTrustedLegacyBridgeAddresses.mockResolvedValue(
+      new Set(["0xc7e0220d02d549c4846a6ec31d89c3b670ebe35c"])
+    );
   });
 
   describe("matches", () => {
@@ -43,6 +46,14 @@ describe("defaultFinalizeDepositHandler", () => {
   describe("extract", () => {
     it("returns null when log cannot be parsed", async () => {
       log = mock<Log>({ ...log, data: "0x", topics: [] });
+      const result = await defaultFinalizeDepositHandler.extract(log, blockchainService, blockDetails);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when the log is emitted by an address that is not a trusted bridge", async () => {
+      blockchainService.getTrustedLegacyBridgeAddresses.mockResolvedValue(
+        new Set(["0x1111111111111111111111111111111111111111"])
+      );
       const result = await defaultFinalizeDepositHandler.extract(log, blockchainService, blockDetails);
       expect(result).toBeNull();
     });

--- a/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/default.handler.ts
+++ b/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/default.handler.ts
@@ -1,4 +1,5 @@
 import { type Log, type Block } from "ethers";
+import { BlockchainService } from "../../../blockchain/blockchain.service";
 import { Transfer } from "../../interfaces/transfer.interface";
 import { ExtractTransferHandler } from "../../interfaces/extractTransferHandler.interface";
 import { TransferType } from "../../transfer.service";
@@ -9,7 +10,14 @@ import { BASE_TOKEN_ADDRESS, CONTRACT_INTERFACES, ETH_L1_ADDRESS } from "../../.
 import { isBaseToken } from "../../../utils/token";
 export const defaultFinalizeDepositHandler: ExtractTransferHandler = {
   matches: (): boolean => true,
-  extract: async (log: Log, _, block: Block): Promise<Transfer> => {
+  extract: async (log: Log, blockchainService: BlockchainService, block: Block): Promise<Transfer> => {
+    // The legacy FinalizeDeposit event has no single authoritative emitter (the canonical shared bridge
+    // plus deployment-specific custom token bridges), so authenticate against the trusted bridge set
+    // rather than indexing any contract's ABI-shaped log as a real bridge deposit.
+    const trustedBridgeAddresses = await blockchainService.getTrustedLegacyBridgeAddresses();
+    if (!trustedBridgeAddresses.has(log.address.toLowerCase())) {
+      return null;
+    }
     const parsedLog = parseLog(CONTRACT_INTERFACES.L2_SHARED_BRIDGE, log);
     if (!parsedLog) {
       return null;

--- a/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/default.handler.ts
+++ b/packages/data-fetcher/src/transfer/extractHandlers/finalizeDeposit/default.handler.ts
@@ -14,8 +14,7 @@ export const defaultFinalizeDepositHandler: ExtractTransferHandler = {
     // The legacy FinalizeDeposit event has no single authoritative emitter (the canonical shared bridge
     // plus deployment-specific custom token bridges), so authenticate against the trusted bridge set
     // rather than indexing any contract's ABI-shaped log as a real bridge deposit.
-    const trustedBridgeAddresses = await blockchainService.getTrustedLegacyBridgeAddresses();
-    if (!trustedBridgeAddresses.has(log.address.toLowerCase())) {
+    if (!(await blockchainService.isTrustedLegacyBridgeEmitter(log, TransferType.Deposit))) {
       return null;
     }
     const parsedLog = parseLog(CONTRACT_INTERFACES.L2_SHARED_BRIDGE, log);

--- a/packages/data-fetcher/src/transfer/extractHandlers/withdrawalInitiated/assetRouter.handler.spec.ts
+++ b/packages/data-fetcher/src/transfer/extractHandlers/withdrawalInitiated/assetRouter.handler.spec.ts
@@ -1,0 +1,18 @@
+import { Log } from "ethers";
+import { mock } from "jest-mock-extended";
+import { L2_ASSET_ROUTER_ADDRESS } from "../../../constants";
+import { assetRouterWithdrawalInitiatedHandler } from "./assetRouter.handler";
+
+describe("assetRouterWithdrawalInitiatedHandler", () => {
+  describe("matches", () => {
+    it("returns true when the log is emitted by the trusted L2 Asset Router", () => {
+      const log = mock<Log>({ address: L2_ASSET_ROUTER_ADDRESS });
+      expect(assetRouterWithdrawalInitiatedHandler.matches(log, null)).toBe(true);
+    });
+
+    it("returns false when the log is emitted by any other (attacker) contract", () => {
+      const log = mock<Log>({ address: "0x1234567890aBcDeF1234567890AbCdEf12345678" });
+      expect(assetRouterWithdrawalInitiatedHandler.matches(log, null)).toBe(false);
+    });
+  });
+});

--- a/packages/data-fetcher/src/transfer/extractHandlers/withdrawalInitiated/assetRouter.handler.ts
+++ b/packages/data-fetcher/src/transfer/extractHandlers/withdrawalInitiated/assetRouter.handler.ts
@@ -8,10 +8,13 @@ import { TokenType } from "../../../token/token.service";
 import { unixTimeToDate } from "../../../utils/date";
 import parseLog from "../../../utils/parseLog";
 import { isBaseToken } from "../../../utils/token";
-import { BASE_TOKEN_ADDRESS, CONTRACT_INTERFACES, ETH_L1_ADDRESS } from "../../../constants";
+import { BASE_TOKEN_ADDRESS, CONTRACT_INTERFACES, ETH_L1_ADDRESS, L2_ASSET_ROUTER_ADDRESS } from "../../../constants";
 
 export const assetRouterWithdrawalInitiatedHandler: ExtractTransferHandler = {
-  matches: (): boolean => true,
+  // Only the trusted L2 Asset Router (a system contract at the same fixed address on Era and every
+  // ZK chain) may emit authoritative bridge withdrawal events. Without this check any contract could emit
+  // an ABI-shaped WithdrawalInitiatedAssetRouter log and have it indexed as a real bridge withdrawal.
+  matches: (log: Log): boolean => log.address.toLowerCase() === L2_ASSET_ROUTER_ADDRESS,
   extract: async (log: Log, blockchainService: BlockchainService, block: Block): Promise<Transfer> => {
     const parsedLog = parseLog(CONTRACT_INTERFACES.L2_ASSET_ROUTER, log);
     if (!parsedLog) {

--- a/packages/data-fetcher/src/transfer/extractHandlers/withdrawalInitiated/default.handler.spec.ts
+++ b/packages/data-fetcher/src/transfer/extractHandlers/withdrawalInitiated/default.handler.spec.ts
@@ -1,5 +1,5 @@
 import { Log, Block } from "ethers";
-import { mock } from "jest-mock-extended";
+import { mock, MockProxy } from "jest-mock-extended";
 import { BlockchainService } from "../../../blockchain/blockchain.service";
 import { ZERO_HASH_64 } from "../../../constants";
 import { TransferType } from "../../transfer.service";
@@ -10,7 +10,7 @@ import { BASE_TOKEN_ADDRESS } from "../../../../src/constants";
 describe("defaultWithdrawalInitiatedHandler", () => {
   let log: Log;
   let blockDetails: Block;
-  let blockchainService: BlockchainService;
+  let blockchainService: MockProxy<BlockchainService>;
   beforeEach(() => {
     log = mock<Log>({
       transactionIndex: 1,
@@ -31,6 +31,9 @@ describe("defaultWithdrawalInitiatedHandler", () => {
       timestamp: new Date().getTime() / 1000,
     });
     blockchainService = mock<BlockchainService>();
+    blockchainService.getTrustedLegacyBridgeAddresses.mockResolvedValue(
+      new Set(["0xc7e0220d02d549c4846a6ec31d89c3b670ebe35c"])
+    );
   });
 
   describe("matches", () => {
@@ -43,6 +46,14 @@ describe("defaultWithdrawalInitiatedHandler", () => {
   describe("extract", () => {
     it("returns null when log cannot be parsed", async () => {
       log = mock<Log>({ ...log, data: "0x", topics: [] });
+      const result = await defaultWithdrawalInitiatedHandler.extract(log, blockchainService, blockDetails);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when the log is emitted by an address that is not a trusted bridge", async () => {
+      blockchainService.getTrustedLegacyBridgeAddresses.mockResolvedValue(
+        new Set(["0x1111111111111111111111111111111111111111"])
+      );
       const result = await defaultWithdrawalInitiatedHandler.extract(log, blockchainService, blockDetails);
       expect(result).toBeNull();
     });

--- a/packages/data-fetcher/src/transfer/extractHandlers/withdrawalInitiated/default.handler.spec.ts
+++ b/packages/data-fetcher/src/transfer/extractHandlers/withdrawalInitiated/default.handler.spec.ts
@@ -31,9 +31,7 @@ describe("defaultWithdrawalInitiatedHandler", () => {
       timestamp: new Date().getTime() / 1000,
     });
     blockchainService = mock<BlockchainService>();
-    blockchainService.getTrustedLegacyBridgeAddresses.mockResolvedValue(
-      new Set(["0xc7e0220d02d549c4846a6ec31d89c3b670ebe35c"])
-    );
+    blockchainService.isTrustedLegacyBridgeEmitter.mockResolvedValue(true);
   });
 
   describe("matches", () => {
@@ -51,9 +49,7 @@ describe("defaultWithdrawalInitiatedHandler", () => {
     });
 
     it("returns null when the log is emitted by an address that is not a trusted bridge", async () => {
-      blockchainService.getTrustedLegacyBridgeAddresses.mockResolvedValue(
-        new Set(["0x1111111111111111111111111111111111111111"])
-      );
+      blockchainService.isTrustedLegacyBridgeEmitter.mockResolvedValue(false);
       const result = await defaultWithdrawalInitiatedHandler.extract(log, blockchainService, blockDetails);
       expect(result).toBeNull();
     });

--- a/packages/data-fetcher/src/transfer/extractHandlers/withdrawalInitiated/default.handler.ts
+++ b/packages/data-fetcher/src/transfer/extractHandlers/withdrawalInitiated/default.handler.ts
@@ -15,8 +15,7 @@ export const defaultWithdrawalInitiatedHandler: ExtractTransferHandler = {
     // The legacy WithdrawalInitiated event has no single authoritative emitter (the canonical shared bridge
     // plus deployment-specific custom token bridges), so authenticate against the trusted bridge set
     // rather than indexing any contract's ABI-shaped log as a real bridge withdrawal.
-    const trustedBridgeAddresses = await blockchainService.getTrustedLegacyBridgeAddresses();
-    if (!trustedBridgeAddresses.has(log.address.toLowerCase())) {
+    if (!(await blockchainService.isTrustedLegacyBridgeEmitter(log, TransferType.Withdrawal))) {
       return null;
     }
     const parsedLog = parseLog(CONTRACT_INTERFACES.L2_SHARED_BRIDGE, log);

--- a/packages/data-fetcher/src/transfer/extractHandlers/withdrawalInitiated/default.handler.ts
+++ b/packages/data-fetcher/src/transfer/extractHandlers/withdrawalInitiated/default.handler.ts
@@ -1,4 +1,5 @@
 import { type Log, type Block } from "ethers";
+import { BlockchainService } from "../../../blockchain/blockchain.service";
 import { Transfer } from "../../interfaces/transfer.interface";
 import { ExtractTransferHandler } from "../../interfaces/extractTransferHandler.interface";
 import { TransferType } from "../../transfer.service";
@@ -10,7 +11,14 @@ import { BASE_TOKEN_ADDRESS, CONTRACT_INTERFACES, ETH_L1_ADDRESS } from "../../.
 
 export const defaultWithdrawalInitiatedHandler: ExtractTransferHandler = {
   matches: (): boolean => true,
-  extract: async (log: Log, _, block: Block): Promise<Transfer> => {
+  extract: async (log: Log, blockchainService: BlockchainService, block: Block): Promise<Transfer> => {
+    // The legacy WithdrawalInitiated event has no single authoritative emitter (the canonical shared bridge
+    // plus deployment-specific custom token bridges), so authenticate against the trusted bridge set
+    // rather than indexing any contract's ABI-shaped log as a real bridge withdrawal.
+    const trustedBridgeAddresses = await blockchainService.getTrustedLegacyBridgeAddresses();
+    if (!trustedBridgeAddresses.has(log.address.toLowerCase())) {
+      return null;
+    }
     const parsedLog = parseLog(CONTRACT_INTERFACES.L2_SHARED_BRIDGE, log);
     if (!parsedLog) {
       return null;


### PR DESCRIPTION
## Problem

The bridge transfer handlers in `data-fetcher` select work purely by event **topic** and their `matches()` returned `true` unconditionally, never checking the log **emitter**. As a result any unprivileged L2 contract can emit ABI-shaped bridge logs and have them indexed as **real bridge deposits/withdrawals** with attacker-chosen `from` / `to` / `amount` / `token`:

- `DepositFinalizedAssetRouter` / `WithdrawalInitiatedAssetRouter` (Asset Router path)
- `FinalizeDeposit` / `WithdrawalInitiated` (legacy shared-bridge path)

These fabricated transfers surface in the explorer UI and the public API (e.g. on a victim address's `/transfers`), i.e. misrepresentation of transaction data. No fund safety impact; data-integrity only.

## Fix

**Asset Router handlers** — require the emitter to be the L2 Asset Router system contract (`L2_ASSET_ROUTER_ADDRESS`, `0x…010003`). This is deployed at the same fixed address on Era and every ZK chain, so the check is chain-agnostic with no config.

**Legacy shared-bridge handlers** — legacy events have **no single authoritative emitter** (the canonical shared bridge *plus* deployment-specific custom token bridges, e.g. Lido wstETH). They are authenticated against a trusted set built from:
1. `zks_getBridgeContracts` (canonical bridges; cached), and
2. a configurable allowlist via the new `TRUSTED_LEGACY_BRIDGE_ADDRESSES` env var (comma-separated).

Chains that don't implement `zks_getBridgeContracts` (e.g. ZKsync OS) fall back to the allowlist; they emit no legacy events.

## Verification

- **Unit tests:** full `data-fetcher` suite green (400 tests; new accept/reject cases for both handler families + `getTrustedLegacyBridgeAddresses`). Lint clean.
- **Cross-chain (live RPC):** every Asset Router deposit/withdrawal on **Era mainnet** (443+ samples) and the deposit on **ZKsync OS mainnet** is emitted solely by `0x…010003`; the patched handler accepts those and rejects other emitters.
- **Legacy (real Era log):** against the real Lido wstETH withdrawal — canonical-only set drops it (the trade-off), `TRUSTED_LEGACY_BRIDGE_ADDRESSES` re-includes it, and an attacker emitter is rejected.
- **End-to-end:** rebuilt data-fetcher rejects real on-chain attacker-emitted bridge logs while still parsing router/bridge-attributed ones.

## Operator note

To keep indexing legitimate **custom** legacy bridges, set `TRUSTED_LEGACY_BRIDGE_ADDRESSES`. For Era mainnet this includes at least the Lido wstETH bridge `0xe1d6a50e7101c8f8db77352897ee3f1ac53f782b`. Recommend scanning historical legacy-topic emitters per network to seed this list before rollout so no legitimate custom-bridge transfers are dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)