### PR TITLE
feat: add Prividium color theme

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -16,7 +16,7 @@ import useRuntimeConfig from "@/composables/useRuntimeConfig";
 import enUS from "./locales/en.json";
 
 import { useSentry } from "@/utils/logger";
-import setColorScheme from "@/utils/setColorScheme";
+import setColorScheme, { prividiumColors } from "@/utils/setColorScheme";
 
 import "@/assets/tailwind.scss";
 
@@ -38,7 +38,10 @@ app.use(i18n);
 app.use(testId);
 const runtimeConfig = useRuntimeConfig();
 
-setColorScheme(runtimeConfig.theme?.colors);
+const themeColors =
+  runtimeConfig.theme?.colors ?? (runtimeConfig.appEnvironment === "prividium" ? prividiumColors : undefined);
+
+setColorScheme(themeColors);
 
 const context = useContext();
 

--- a/packages/app/src/utils/setColorScheme.ts
+++ b/packages/app/src/utils/setColorScheme.ts
@@ -23,6 +23,21 @@ const defaultColors: ColorsConfig = {
   warning: tailwindColors.yellow,
 };
 
+export const prividiumColors: ColorsConfig = {
+  primary: {
+    50: "#eff6ff",
+    100: "#dbeafe",
+    200: "#bfdbfe",
+    300: "#93c5fd",
+    400: "#60a5fa",
+    500: "#3b82f6",
+    600: "#2563eb",
+    700: "#1d4ed8",
+    800: "#1e40af",
+    900: "#020617",
+  },
+};
+
 export default function setColorScheme(colors: ColorsConfig = defaultColors) {
   const root = document.documentElement;
 

--- a/packages/app/tests/e2e/features/copying.feature
+++ b/packages/app/tests/e2e/features/copying.feature
@@ -166,7 +166,7 @@ Feature: Copying
 
     Examples:
       | Row             | Text                                       |
-      | USDC            | 0x8DfcCCBB134E36EE145bE17E682ED46EaF4b6c5b |
+      | USDC            | 0x4A76CCA1b7527d4dc78f87FB57257c8ACc5dE05B |
 
   @id275:I @mainnet
   Scenario Outline: Check "<Row>" hashes copying for Tokens page


### PR DESCRIPTION
> [!WARNING]
> **e2e smoke test touched an unrelated live-data fixture.** The `@testnetSmokeSuite` test `Check "USDC" hashes copying for Tokens page` was failing on this branch for reasons unrelated to the color theme: a newer `USDC` token (`0x4A76CCA1b7527d4dc78f87FB57257c8ACc5dE05B`) was deployed to `zksync-os-testnet-alpha` and now sorts first on the Tokens page (default order `liquidity DESC NULLS LAST, blockNumber DESC`; both USDC tokens have null liquidity, so the more recently deployed one wins). The test selects the first `USDC` row, so the expected clipboard value was updated from the old contract (`0x8DfcCCBB134E36EE145bE17E682ED46EaF4b6c5b`). 

# What ❔

Adds a Prividium-specific color theme to the block explorer, activated when the app runs with `APP_ENVIRONMENT=prividium`.

- New `prividiumColors` palette in `setColorScheme.ts` with a blue `primary` scale ported from the Prividium admin app (`adminv2`), which uses Tailwind's blue anchored on `#1d4ed8` (700).
- `main.ts` selects the palette by environment: an explicit runtime theme (`VITE_THEME_CONFIG` / `##runtimeConfig`) still takes precedence, then Prividium gets blue, otherwise the default ZKsync theme is untouched.
- The darkest shade `primary-900` (`#020617`, dark slate) backs the main header and hero banner so they read as a dark, neutral bar rather than bright blue.

Closes matter-labs/zksync-prividium#672

<img width="1638" height="982" alt="image" src="https://github.com/user-attachments/assets/fdcfe85b-0ecd-458a-a91a-801e872549e1" />

## Why ❔

The explorer ships with the default ZKsync purple scheme. When deployed in Prividium environments it should match Prividium's branding. Colors are applied at runtime via CSS variables (`setColorScheme` writes `--color-*` onto `:root`), so theming by environment needs no build-time changes and keeps existing runtime overrides working. The `VITE_APP_ENVIRONMENT=prividium` build arg is already wired in `docker-compose-prividium.yaml`, so no deployment changes are required.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
