### PR TITLE
fix: skip indexing pending transactions early

### DIFF
--- a/packages/data-fetcher/src/block/block.service.ts
+++ b/packages/data-fetcher/src/block/block.service.ts
@@ -46,7 +46,7 @@ export class BlockService {
     const blockTraces = block && (await this.blockchainService.debugTraceBlock(blockNumber));
     stopGetBlockInfoDurationMetric();
 
-    if (!block) {
+    if (!block || !blockTraces) {
       return null;
     }
 

--- a/packages/data-fetcher/src/transaction/transaction.service.spec.ts
+++ b/packages/data-fetcher/src/transaction/transaction.service.spec.ts
@@ -75,12 +75,20 @@ describe("TransactionService", () => {
 
   describe("getData", () => {
     const trace = {} as TransactionTrace;
+    const blockHash = "0xblockhash";
     const blockDetails = mock<Block>({
       number: 1,
+      hash: blockHash,
     });
-    const transaction = mock<TransactionResponse>({ hash: "0", from: "0x36615cf349d7f6344891b1e7ca7c72883f5dc049" });
+    const transaction = mock<TransactionResponse>({
+      hash: "0",
+      from: "0x36615cf349d7f6344891b1e7ca7c72883f5dc049",
+      blockHash,
+      index: 0,
+    });
     const transactionReceipt = mock<TransactionReceipt>({
       index: 0,
+      blockHash,
       logs: [mock<Log>(), mock<Log>()],
       status: 1,
     });
@@ -177,6 +185,42 @@ describe("TransactionService", () => {
       );
     });
 
+    it("throws error if transaction index is null", async () => {
+      jest
+        .spyOn(blockchainServiceMock, "getTransaction")
+        .mockResolvedValue(mock<TransactionResponse>({ ...transaction, index: null as unknown as number }));
+      await expect(transactionService.getData(transaction.hash, trace, blockDetails)).rejects.toThrowError(
+        /Inconsistent transaction state for 0 in block #1/
+      );
+    });
+
+    it("throws error if transaction receipt index is null", async () => {
+      jest
+        .spyOn(blockchainServiceMock, "getTransactionReceipt")
+        .mockResolvedValue(mock<TransactionReceipt>({ ...transactionReceipt, index: null as unknown as number }));
+      await expect(transactionService.getData(transaction.hash, trace, blockDetails)).rejects.toThrowError(
+        /Inconsistent transaction state for 0 in block #1/
+      );
+    });
+
+    it("throws error if transaction blockHash does not match the block hash", async () => {
+      jest
+        .spyOn(blockchainServiceMock, "getTransaction")
+        .mockResolvedValue(mock<TransactionResponse>({ ...transaction, blockHash: "0xotherhash" }));
+      await expect(transactionService.getData(transaction.hash, trace, blockDetails)).rejects.toThrowError(
+        /Inconsistent transaction state for 0 in block #1/
+      );
+    });
+
+    it("throws error if transaction receipt blockHash does not match the block hash", async () => {
+      jest
+        .spyOn(blockchainServiceMock, "getTransactionReceipt")
+        .mockResolvedValue(mock<TransactionReceipt>({ ...transactionReceipt, blockHash: "0xotherhash" }));
+      await expect(transactionService.getData(transaction.hash, trace, blockDetails)).rejects.toThrowError(
+        /Inconsistent transaction state for 0 in block #1/
+      );
+    });
+
     it("tracks sender balance for the transaction", async () => {
       await transactionService.getData(transaction.hash, trace, blockDetails);
       expect(balanceServiceMock.trackSenderBalance).toHaveBeenCalledTimes(1);
@@ -235,6 +279,7 @@ describe("TransactionService", () => {
       beforeEach(() => {
         (blockchainServiceMock.getTransactionReceipt as jest.Mock).mockResolvedValueOnce({
           index: 0,
+          blockHash,
           logs: [],
           status: 0,
         });

--- a/packages/data-fetcher/src/transaction/transaction.service.ts
+++ b/packages/data-fetcher/src/transaction/transaction.service.ts
@@ -61,6 +61,23 @@ export class TransactionService {
       throw new Error(`Some of the blockchain transaction APIs returned null for a transaction ${transactionHash}`);
     }
 
+    // Guard against the RPC reporting the transaction as pending (e.g. transient reorg
+    // or a behind-the-tip node behind a load balancer). Throwing forces a retry on a consistent
+    // view, instead of inserting nulls that violate NOT NULL constraints downstream.
+    if (
+      transaction.index == null ||
+      transactionReceipt.index == null ||
+      transaction.blockHash !== block.hash ||
+      transactionReceipt.blockHash !== block.hash
+    ) {
+      throw new Error(
+        `Inconsistent transaction state for ${transactionHash} in block #${block.number}: ` +
+          `expected blockHash ${block.hash}, got tx.blockHash=${transaction.blockHash} ` +
+          `(index=${transaction.index}), receipt.blockHash=${transactionReceipt.blockHash} ` +
+          `(index=${transactionReceipt.index})`
+      );
+    }
+
     this.balanceService.trackSenderBalance(transaction.from.toLowerCase(), block.number);
 
     const transactionInfo = {

--- a/packages/data-fetcher/src/transaction/transactionTraces.service.ts
+++ b/packages/data-fetcher/src/transaction/transactionTraces.service.ts
@@ -163,7 +163,7 @@ export class TransactionTracesService {
     }
 
     this.logger.debug({
-      message: "Requesting contracts' bytecode and bytecode hashes",
+      message: "Requesting contracts' bytecode",
       blockNumber: transaction.blockNumber,
     });
     transactionTraceData.contractAddresses = (


### PR DESCRIPTION
# What ❔

- skip indexing pending transactions early

## Why ❔

- if node is out of sync some transactions might still be in a pending state (tx index is null). The data-fetcher will throw an error and indexer will retry on the next iteration.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [+] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [+] Tests for the changes have been added / updated.
