### PR TITLE
feat(app): support serving the explorer from a configurable base path

### DIFF
--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -23,6 +23,11 @@ ARG VITE_VERSION=
 ENV VITE_VERSION=$VITE_VERSION
 ARG VITE_APP_ENVIRONMENT=default
 ENV VITE_APP_ENVIRONMENT=$VITE_APP_ENVIRONMENT
+# Optional explicit base path baked in at build time. When empty (default),
+# the build uses a relative base so the image can be served from any subpath
+# configured at container start via the BASE_PATH env var. See vite.config.ts.
+ARG VITE_BASE_PATH=
+ENV VITE_BASE_PATH=$VITE_BASE_PATH
 ENV DOCKER_BUILD=true
 RUN npm run build
 
@@ -33,10 +38,23 @@ ENV CSP_REPORT_ONLY="default-src 'self'; child-src 'self' blob:; script-src 'sel
 RUN apk add --no-cache gomplate
 
 COPY --from=build-stage /usr/src/app/packages/app/nginx.conf.template /etc/nginx/conf.d/default.conf.template
+COPY --from=build-stage /usr/src/app/packages/app/nginx.conf.subpath.template /etc/nginx/conf.d/subpath.conf.template
 COPY --from=build-stage /usr/src/app/packages/app/dist /usr/share/nginx/html
 
 RUN cp /usr/share/nginx/html/index.html /usr/share/nginx/html/index.html.tpl
 
-CMD envsubst '$PORT $CSP_REPORT_ONLY' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf \
+# BASE_PATH (e.g. "/explorer") serves the app under a subpath for
+# prefix-preserving reverse proxies. When unset, behavior is unchanged.
+# nginx needs the prefix without a trailing slash, the <base> tag (filled
+# by gomplate from BASE_PATH) needs it with one.
+CMD BP="${BASE_PATH#/}" && BP="${BP%/}" \
+  && if [ -n "$BP" ]; then \
+       export BASE_PATH="/$BP" \
+       && envsubst '$PORT $CSP_REPORT_ONLY $BASE_PATH' < /etc/nginx/conf.d/subpath.conf.template > /etc/nginx/conf.d/default.conf \
+       && export BASE_PATH="/$BP/"; \
+     else \
+       export BASE_PATH="/" \
+       && envsubst '$PORT $CSP_REPORT_ONLY' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf; \
+     fi \
   && gomplate -f /usr/share/nginx/html/index.html.tpl -o /usr/share/nginx/html/index.html \
   && exec nginx -g 'daemon off;'

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -46,8 +46,11 @@ RUN cp /usr/share/nginx/html/index.html /usr/share/nginx/html/index.html.tpl
 # BASE_PATH (e.g. "/explorer") serves the app under a subpath for
 # prefix-preserving reverse proxies. When unset, behavior is unchanged.
 # nginx needs the prefix without a trailing slash, the <base> tag (filled
-# by gomplate from BASE_PATH) needs it with one.
+# by gomplate from BASE_PATH) needs it with one. The charset check fails
+# fast on values that would be unsafe to interpolate into the nginx
+# location/rewrite rules (see nginx.conf.subpath.template).
 CMD BP="${BASE_PATH#/}" && BP="${BP%/}" \
+  && case "$BP" in *[!a-zA-Z0-9_/-]*) echo "Invalid BASE_PATH: only letters, digits, '-', '_' and '/' are allowed" >&2 && exit 1;; esac \
   && if [ -n "$BP" ]; then \
        export BASE_PATH="/$BP" \
        && envsubst '$PORT $CSP_REPORT_ONLY $BASE_PATH' < /etc/nginx/conf.d/subpath.conf.template > /etc/nginx/conf.d/default.conf \

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -47,6 +47,14 @@ settlement chains:
 
 For a complete example of network configuration including settlement chains, refer to [`production.config.json`](./src/configs/production.config.json).
 
+### Serving the app from a subpath
+By default the app is served from the root of the domain (e.g. `https://explorer.example.com/`). To serve it from a subpath (e.g. `https://example.com/explorer/`), there are two options:
+
+- **Build time**: set the `VITE_BASE_PATH` env variable when building (e.g. `VITE_BASE_PATH=/explorer/ npm run build`). This bakes the base path into the build output. It also works for the dev server: `VITE_BASE_PATH=/explorer/ npm run dev`.
+- **Container runtime**: the published Docker image is built with a relative base, so the base path can be configured at container start by setting the `BASE_PATH` env variable (e.g. `docker run -e BASE_PATH=/explorer ...`). This injects a `<base>` tag into `index.html` and configures nginx to serve the app under the prefix. No rebuild is needed. `BASE_PATH` must be a plain path prefix consisting of URL path segments (letters, digits, `-`, `_`, `/`), since it is interpolated into an nginx location and rewrite rule.
+
+When the app sits behind a reverse proxy that forwards the subpath prefix to the container (prefix-preserving, e.g. `proxy.example.com/explorer/*` -> `container/explorer/*`), set `BASE_PATH` to that prefix. If the proxy strips the prefix before forwarding, leave `BASE_PATH` unset and note that the app would then generate root-relative URLs which will not work under the proxied subpath, so prefix-preserving proxying is the supported setup.
+
 ### Compile and Hot-Reload for Development
 
 ```sh

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -55,6 +55,8 @@ By default the app is served from the root of the domain (e.g. `https://explorer
 
 When the app sits behind a reverse proxy that forwards the subpath prefix to the container (prefix-preserving, e.g. `proxy.example.com/explorer/*` -> `container/explorer/*`), set `BASE_PATH` to that prefix. If the proxy strips the prefix before forwarding, leave `BASE_PATH` unset and note that the app would then generate root-relative URLs which will not work under the proxied subpath, so prefix-preserving proxying is the supported setup.
 
+For contributors: when referencing files from `public/` (e.g. `/images/...`) or building full-page redirect URLs in app code, resolve them through the helpers in [`src/utils/basePath.ts`](./src/utils/basePath.ts) (`publicAsset`, `appUrl`, etc.) instead of hardcoding root-absolute paths. Hardcoded `/...` URLs work at the domain root but silently break subpath deployments.
+
 ### Compile and Hot-Reload for Development
 
 ```sh

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <base href='{{ getenv "BASE_PATH" | default "/" }}' />
     <title>{{ getenv "VITE_BRAND_NAME" | default "ZKsync" }} Block Explorer</title>
     <meta charset="UTF-8" />
     <meta name="description" content='{{ getenv "VITE_BRAND_NAME" | default "ZKsync" }} Block Explorer provides all the information to deep dive into transactions, blocks, contracts, and much more. Deep dive into {{ getenv "VITE_BRAND_NAME" | default "ZKsync" }} and explore the network.' />
@@ -13,12 +14,12 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content='{{ getenv "VITE_BRAND_NAME" | default "ZKsync" }} Block Explorer' />
 
-    <link rel="alternate icon" type='{{ getenv "VITE_ALT_FAVICON_IMAGE_TYPE" | default "image/x-icon" }}' href='{{ getenv "VITE_ALT_FAVICON_IMAGE_URL" | default "/favicon.ico" }}' />
-    <link rel="icon" type='{{ getenv "VITE_FAVICON_IMAGE_TYPE" | default "image/svg+xml" }}' href='{{ getenv "VITE_FAVICON_IMAGE_URL" | default "/favicon.svg" }}' />
+    <link rel="alternate icon" type='{{ getenv "VITE_ALT_FAVICON_IMAGE_TYPE" | default "image/x-icon" }}' href='{{ getenv "VITE_ALT_FAVICON_IMAGE_URL" | default "favicon.ico" }}' />
+    <link rel="icon" type='{{ getenv "VITE_FAVICON_IMAGE_TYPE" | default "image/svg+xml" }}' href='{{ getenv "VITE_FAVICON_IMAGE_URL" | default "favicon.svg" }}' />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="true" />
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
-    <script src="/config.js"></script>
+    <script src="config.js"></script>
     
   </head>
   <body>

--- a/packages/app/nginx.conf.subpath.template
+++ b/packages/app/nginx.conf.subpath.template
@@ -1,0 +1,51 @@
+# Used instead of nginx.conf.template when the BASE_PATH env var is set
+# (see the Dockerfile CMD). Serves the app under the ${BASE_PATH} prefix
+# for prefix-preserving reverse proxies. BASE_PATH must have a leading
+# slash and no trailing slash (e.g. /explorer); the Dockerfile normalizes it.
+server {
+    listen   ${PORT};
+    listen   [::]:${PORT} default;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    server_name _; # all hostnames
+
+    # Emit relative Location headers so redirects survive https-terminating
+    # reverse proxies in front of this container.
+    absolute_redirect off;
+
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 256;
+    gzip_proxied any;
+    gzip_vary on;
+
+    # Redirect the bare prefix to its trailing-slash form so relative
+    # asset URLs resolve correctly.
+    location = ${BASE_PATH} {
+        return 301 ${BASE_PATH}/;
+    }
+
+    location ${BASE_PATH}/ {
+        # Static files live at the filesystem root, strip the prefix.
+        rewrite ^${BASE_PATH}/(.*)$ /$1 break;
+        # "=404" makes "/index.html" a file check (SPA fallback) instead of an
+        # internal redirect, which would re-match "location /" and return 404.
+        try_files $uri /index.html =404;
+        # Add headers to all responses
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Referrer-Policy "no-referrer, strict-origin-when-cross-origin" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Content-Security-Policy-Report-Only "${CSP_REPORT_ONLY}" always;
+    }
+
+    # Anything outside the prefix is not served.
+    location / {
+        return 404;
+    }
+
+    # TODO: add cache for static files, avoid caching config.js, index.html etc.
+}

--- a/packages/app/nginx.conf.subpath.template
+++ b/packages/app/nginx.conf.subpath.template
@@ -22,9 +22,10 @@ server {
     gzip_vary on;
 
     # Redirect the bare prefix to its trailing-slash form so relative
-    # asset URLs resolve correctly.
+    # asset URLs resolve correctly. $is_args$args preserves the query string
+    # (e.g. ?network=...); envsubst leaves both untouched, like $uri below.
     location = ${BASE_PATH} {
-        return 301 ${BASE_PATH}/;
+        return 301 ${BASE_PATH}/$is_args$args;
     }
 
     location ${BASE_PATH}/ {

--- a/packages/app/nginx.conf.template
+++ b/packages/app/nginx.conf.template
@@ -1,3 +1,6 @@
+# NOTE: keep gzip and header settings in sync with nginx.conf.subpath.template,
+# which is used instead of this file when the BASE_PATH env var is set
+# (see the Dockerfile CMD).
 server {
     listen   ${PORT};
     listen   [::]:${PORT} default;

--- a/packages/app/src/App.vue
+++ b/packages/app/src/App.vue
@@ -4,7 +4,7 @@
     v-if="isPrividiumAuthChecking"
     class="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-slate-50 via-white to-blue-50 px-4 py-12 sm:px-6 lg:px-8"
   >
-    <img src="/images/prividium_logo.svg" alt="Prividium Logo" class="mb-6 h-16 w-auto" />
+    <img :src="publicAsset('/images/prividium_logo.svg')" alt="Prividium Logo" class="mb-6 h-16 w-auto" />
     <div class="text-center">
       <h1 class="mb-4 text-2xl font-semibold text-gray-900">Checking permissions...</h1>
       <div class="mx-auto h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
@@ -46,6 +46,7 @@ import useLocalization from "@/composables/useLocalization";
 import useLogin from "@/composables/useLogin";
 import useRouteTitle from "@/composables/useRouteTitle";
 
+import { publicAsset } from "@/utils/basePath";
 import MaintenanceView from "@/views/MaintenanceView.vue";
 
 const { setup } = useLocalization();

--- a/packages/app/src/components/Account.vue
+++ b/packages/app/src/components/Account.vue
@@ -16,7 +16,7 @@
             <EmptyState>
               <template #image>
                 <div class="balances-empty-icon">
-                  <img src="/images/empty-state/empty_balance.svg" alt="empty_balance" />
+                  <img :src="publicAsset('/images/empty-state/empty_balance.svg')" alt="empty_balance" />
                 </div>
               </template>
               <template #title>
@@ -41,7 +41,7 @@
             <EmptyState>
               <template #image>
                 <div class="balances-empty-icon">
-                  <img src="/images/empty-state/error_balance.svg" alt="empty_balance" />
+                  <img :src="publicAsset('/images/empty-state/error_balance.svg')" alt="empty_balance" />
                 </div>
               </template>
               <template #title>
@@ -91,6 +91,7 @@ import useRuntimeConfig from "@/composables/useRuntimeConfig";
 import type { BreadcrumbItem } from "@/components/common/Breadcrumbs.vue";
 import type { Account } from "@/composables/useAddress";
 
+import { publicAsset } from "@/utils/basePath";
 import { shortValue } from "@/utils/formatters";
 
 const runtimeConfig = useRuntimeConfig();

--- a/packages/app/src/components/ConnectMetamaskButton.vue
+++ b/packages/app/src/components/ConnectMetamaskButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="metamask-button" :class="{ disabled: buttonDisabled }">
-    <img src="/images/metamask.svg" class="metamask-image" />
+    <img :src="publicAsset('/images/metamask.svg')" class="metamask-image" />
     <button v-if="!address" :disabled="buttonDisabled" class="login-button" @click="connect">
       {{ buttonText }}
     </button>
@@ -35,6 +35,8 @@ import HashLabel from "@/components/common/HashLabel.vue";
 
 import useContext from "@/composables/useContext";
 import { default as useWallet } from "@/composables/useWallet";
+
+import { publicAsset } from "@/utils/basePath";
 
 const { t } = useI18n();
 

--- a/packages/app/src/components/Contract.vue
+++ b/packages/app/src/components/Contract.vue
@@ -22,7 +22,7 @@
             <EmptyState>
               <template #image>
                 <div class="balances-empty-icon">
-                  <img src="/images/empty-state/empty_balance.svg" alt="empty_balance" />
+                  <img :src="publicAsset('/images/empty-state/empty_balance.svg')" alt="empty_balance" />
                 </div>
               </template>
               <template #title>
@@ -45,7 +45,7 @@
             <EmptyState>
               <template #image>
                 <div class="balances-empty-icon">
-                  <img src="/images/empty-state/error_balance.svg" alt="empty_balance" />
+                  <img :src="publicAsset('/images/empty-state/error_balance.svg')" alt="empty_balance" />
                 </div>
               </template>
               <template #title>
@@ -110,6 +110,7 @@ import useRuntimeConfig from "@/composables/useRuntimeConfig";
 import type { BreadcrumbItem } from "@/components/common/Breadcrumbs.vue";
 import type { Contract } from "@/composables/useAddress";
 
+import { publicAsset } from "@/utils/basePath";
 import { shortValue } from "@/utils/formatters";
 
 const { t } = useI18n();

--- a/packages/app/src/components/NetworkSwitch.vue
+++ b/packages/app/src/components/NetworkSwitch.vue
@@ -2,7 +2,7 @@
   <Listbox as="div" :model-value="selected" class="network-switch">
     <ListboxButton class="toggle-button">
       <span class="network-item">
-        <img :src="currentNetwork.icon" alt="ZKsync arrows logo" class="network-item-img" />
+        <img :src="publicAsset(currentNetwork.icon)" alt="ZKsync arrows logo" class="network-item-img" />
         <span class="network-item-label">{{ currentNetwork.l2NetworkName }}</span>
       </span>
       <span class="toggle-button-icon-wrapper">
@@ -26,7 +26,7 @@
               :class="{ selected }"
             >
               <span class="network-item">
-                <img :src="network.icon" :alt="`${network.l2NetworkName} logo`" class="network-item-img" />
+                <img :src="publicAsset(network.icon)" :alt="`${network.l2NetworkName} logo`" class="network-item-img" />
                 <span class="network-item-label network-list-item-label">{{ network.l2NetworkName }} </span>
               </span>
               <MinusCircleIcon v-if="network.maintenance" class="maintenance-icon" aria-hidden="true" />
@@ -50,6 +50,7 @@ import useContext from "@/composables/useContext";
 
 import type { NetworkConfig } from "@/configs";
 
+import { basePathPrefix, publicAsset } from "@/utils/basePath";
 import { getWindowLocation } from "@/utils/helpers";
 
 const { networks: allNetworks, currentNetwork } = useContext();
@@ -65,7 +66,7 @@ const getNetworkUrl = (network: NetworkConfig) => {
   const hostname = getWindowLocation().hostname;
 
   if (hostname === "localhost" || hostname.endsWith("web.app") || !network.hostnames?.length) {
-    return `${route.path}?network=${network.name}`;
+    return `${basePathPrefix()}${route.path}?network=${network.name}`;
   }
   return network.hostnames[0] + route.path;
 };

--- a/packages/app/src/components/Token.vue
+++ b/packages/app/src/components/Token.vue
@@ -8,7 +8,7 @@
       <img
         v-if="contract?.address && !pending && tokenInfo"
         class="token-img"
-        :src="tokenInfo.iconURL || '/images/currencies/customToken.svg'"
+        :src="publicAsset(tokenInfo.iconURL || '/images/currencies/customToken.svg')"
         :alt="tokenInfo.symbol || t('balances.table.unknownSymbol')"
       />
     </div>
@@ -88,6 +88,7 @@ import useTokenOverview from "@/composables/useTokenOverview";
 import type { BreadcrumbItem } from "@/components/common/Breadcrumbs.vue";
 import type { Contract } from "@/composables/useAddress";
 
+import { publicAsset } from "@/utils/basePath";
 import { shortValue } from "@/utils/formatters";
 
 const { t } = useI18n();

--- a/packages/app/src/components/TokenIconLabel.vue
+++ b/packages/app/src/components/TokenIconLabel.vue
@@ -60,6 +60,8 @@ import useRuntimeConfig from "@/composables/useRuntimeConfig";
 
 import type { Hash } from "@/types";
 
+import { publicAsset } from "@/utils/basePath";
+
 export type IconSize = "sm" | "md" | "lg" | "xl";
 
 const { t } = useI18n();
@@ -97,7 +99,7 @@ const props = defineProps({
 });
 
 const imgSource = computed(() => {
-  return props.iconUrl || "/images/currencies/customToken.svg";
+  return publicAsset(props.iconUrl || "/images/currencies/customToken.svg");
 });
 const { isReady: isImageLoaded } = useImage({ src: imgSource.value });
 </script>

--- a/packages/app/src/components/header/TheHeader.vue
+++ b/packages/app/src/components/header/TheHeader.vue
@@ -5,7 +5,7 @@
         <div class="logo-container">
           <router-link :to="{ name: 'home' }">
             <span class="sr-only">ZKsync</span>
-            <img v-if="currentNetwork.logoUrl" :src="currentNetwork.logoUrl" />
+            <img v-if="currentNetwork.logoUrl" :src="publicAsset(currentNetwork.logoUrl)" />
             <zk-sync-era v-else-if="currentNetwork.groupId === 'era'" />
             <zk-sync-arrows-logo v-else />
           </router-link>
@@ -56,7 +56,11 @@
       class="hero-banner-container"
       :class="[`${currentNetwork.name}`, { 'home-banner': route.path === '/' }]"
     >
-      <img v-if="currentNetwork.heroBannerImageUrl" class="hero-image" :src="currentNetwork.heroBannerImageUrl" />
+      <img
+        v-if="currentNetwork.heroBannerImageUrl"
+        class="hero-image"
+        :src="publicAsset(currentNetwork.heroBannerImageUrl)"
+      />
       <hero-arrows v-else class="hero-image" />
     </div>
     <transition
@@ -72,7 +76,7 @@
           <div class="mobile-header-container">
             <div class="mobile-popover-navigation">
               <div class="popover-zksync-logo">
-                <img v-if="currentNetwork.logoInverseUrl" :src="currentNetwork.logoInverseUrl" />
+                <img v-if="currentNetwork.logoInverseUrl" :src="publicAsset(currentNetwork.logoInverseUrl)" />
                 <zk-sync v-else class="logo" />
               </div>
               <div class="-mr-2">
@@ -159,6 +163,7 @@ import useContext from "@/composables/useContext";
 import useLocalization from "@/composables/useLocalization";
 import useRuntimeConfig from "@/composables/useRuntimeConfig";
 
+import { publicAsset } from "@/utils/basePath";
 import { isAddress, isBlockNumber, isTransactionHash } from "@/utils/validators";
 const { changeLanguage } = useLocalization();
 const { t, locale } = useI18n({ useScope: "global" });

--- a/packages/app/src/components/prividium/NetworkIndicator.vue
+++ b/packages/app/src/components/prividium/NetworkIndicator.vue
@@ -6,7 +6,7 @@
     <template v-else>
       <span class="network-item">
         <img
-          :src="context.currentNetwork.value.icon"
+          :src="publicAsset(context.currentNetwork.value.icon)"
           :alt="`${context.currentNetwork.value.l2NetworkName} logo`"
           class="network-item-img"
         />
@@ -21,6 +21,8 @@ import { computed } from "vue";
 
 import useContext from "@/composables/useContext";
 import useWallet from "@/composables/useWallet";
+
+import { publicAsset } from "@/utils/basePath";
 
 const context = useContext();
 const { isConnectedWrongNetwork } = useWallet({

--- a/packages/app/src/components/prividium/WalletButton.vue
+++ b/packages/app/src/components/prividium/WalletButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="wallet-button" :class="{ disabled: buttonDisabled }" @click="openModalConditionally">
-    <img src="/images/metamask.svg" class="wallet-image" />
+    <img :src="publicAsset('/images/metamask.svg')" class="wallet-image" />
     <button v-if="!displayAddress" :disabled="buttonDisabled" class="login-button" @click="handleLogin">
       {{ buttonText }}
     </button>
@@ -39,6 +39,7 @@ import useEnvironmentConfig from "@/composables/useEnvironmentConfig";
 import useLogin from "@/composables/useLogin";
 import { isAuthenticated, default as useWallet } from "@/composables/useWallet";
 
+import { publicAsset } from "@/utils/basePath";
 import { formatShortAddress } from "@/utils/formatters";
 import logger from "@/utils/logger";
 

--- a/packages/app/src/components/prividium/WalletInfoModal.vue
+++ b/packages/app/src/components/prividium/WalletInfoModal.vue
@@ -54,6 +54,8 @@ import Popup from "@/components/common/Popup.vue";
 import useContext from "@/composables/useContext";
 import useLogin from "@/composables/useLogin";
 
+import { appUrl } from "@/utils/basePath";
+
 const props = defineProps({
   opened: {
     type: Boolean,
@@ -92,7 +94,7 @@ const handleWalletSwitch = async (newAddress: string) => {
   try {
     isSwitching.value = true;
     await switchWallet(newAddress);
-    window.location.href = "/"; // Triggers full reload of the page
+    window.location.href = appUrl(); // Triggers full reload of the page
     emit("close");
   } catch (error) {
     console.error("Failed to switch wallet:", error);

--- a/packages/app/src/composables/useFetchInstance.ts
+++ b/packages/app/src/composables/useFetchInstance.ts
@@ -1,6 +1,7 @@
 import { $fetch } from "ohmyfetch";
 
 import useContext from "./useContext";
+import { appUrl, currentAppPath } from "../utils/basePath";
 
 import type { Context } from "./useContext";
 import type { FetchOptions, FetchResponse } from "ohmyfetch";
@@ -18,7 +19,7 @@ export class FetchInstance {
 
       // API invalidated the session
       context.user.value = { loggedIn: false };
-      window.location.href = `/login?redirect=${encodeURIComponent(window.location.pathname)}`;
+      window.location.href = `${appUrl("login")}?redirect=${encodeURIComponent(currentAppPath())}`;
     });
   }
 

--- a/packages/app/src/composables/useLogin.ts
+++ b/packages/app/src/composables/useLogin.ts
@@ -7,6 +7,7 @@ import { FetchInstance } from "./useFetchInstance";
 import type { Context } from "./useContext";
 
 import { PrividiumAuth } from "@/lib/prividium-auth";
+import { appUrl } from "@/utils/basePath";
 
 type LoginState = {
   isLoginPending: boolean;
@@ -37,7 +38,7 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
     if (!prividiumAuth) {
       prividiumAuth = new PrividiumAuth({
         clientId: "block-explorer",
-        redirectUri: new URL("auth/callback", window.location.origin).toString(),
+        redirectUri: appUrl("auth/callback"),
         userPanelUrl: context.currentNetwork.value.userPanelUrl!,
       });
     }

--- a/packages/app/src/composables/useNotFound.ts
+++ b/packages/app/src/composables/useNotFound.ts
@@ -1,6 +1,8 @@
 import { type Ref, watch } from "vue";
 import { useRouter } from "vue-router";
 
+import { basePathPrefix } from "@/utils/basePath";
+
 export default () => {
   const router = useRouter();
   const notFoundRoute = router.resolve({ name: "not-found" });
@@ -8,7 +10,9 @@ export default () => {
   async function setNotFoundView() {
     const fullPath = router.currentRoute.value.fullPath;
     await router.replace(notFoundRoute);
-    history.replaceState({}, notFoundRoute.meta.title as string, fullPath);
+    // fullPath is router-relative, so prepend the base path to keep the
+    // restored URL inside the app prefix when served from a subpath.
+    history.replaceState({}, notFoundRoute.meta.title as string, basePathPrefix() + fullPath);
   }
 
   async function useNotFoundView(...refs: Ref[]) {

--- a/packages/app/src/composables/useWallet.ts
+++ b/packages/app/src/composables/useWallet.ts
@@ -9,6 +9,7 @@ import defaultLogger from "./../utils/logger";
 import type { BaseProvider } from "@metamask/providers";
 import type { AbstractSigner, JsonRpcProvider } from "ethers";
 
+import { appRootUrl } from "@/utils/basePath";
 import { numberToHexString } from "@/utils/formatters";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -280,7 +281,7 @@ export default (
               decimals: 18,
             },
             rpcUrls: [rpcUrl],
-            blockExplorerUrls: [window.location.origin],
+            blockExplorerUrls: [appRootUrl()],
             iconUrls: ["https://zksync.io/favicon.ico"],
           },
         ],

--- a/packages/app/src/lib/prividium-auth/index.ts
+++ b/packages/app/src/lib/prividium-auth/index.ts
@@ -1,5 +1,7 @@
 import { AUTH_ERRORS, PRIVIDIUM_AUTH_CONSTANTS } from "./constants";
 
+import { appRootUrl } from "@/utils/basePath";
+
 export interface PrividiumAuthConfig {
   clientId: string;
   redirectUri: string;
@@ -117,7 +119,7 @@ export class PrividiumAuth {
     if (this.userPanelUrl) {
       window.location.href = `${this.userPanelUrl}${
         PRIVIDIUM_AUTH_CONSTANTS.AUTH_ENDPOINTS.LOGOUT
-      }?post_logout_redirect_uri=${encodeURIComponent(window.location.origin)}`;
+      }?post_logout_redirect_uri=${encodeURIComponent(appRootUrl())}`;
     }
   }
 

--- a/packages/app/src/router/index.ts
+++ b/packages/app/src/router/index.ts
@@ -6,7 +6,9 @@ import useContext from "@/composables/useContext";
 import useRuntimeConfig from "@/composables/useRuntimeConfig";
 
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  // With no base argument vue-router reads the <base> tag, which covers both
+  // build-time (VITE_BASE_PATH) and runtime (BASE_PATH env var) configuration.
+  history: createWebHistory(),
   routes,
 });
 

--- a/packages/app/src/utils/basePath.ts
+++ b/packages/app/src/utils/basePath.ts
@@ -1,0 +1,90 @@
+/**
+ * Helpers for resolving URLs when the app is served from a subpath (e.g. /explorer/).
+ *
+ * The base path can be set either at build time (VITE_BASE_PATH, see vite.config.ts)
+ * or at container start (BASE_PATH env var injected as a <base> tag in index.html,
+ * see Dockerfile). Reading the live <base> tag covers both cases.
+ */
+
+function ensureTrailingSlash(path: string): string {
+  return path.endsWith("/") ? path : `${path}/`;
+}
+
+/**
+ * Returns the base path the app is served from, with leading and trailing slashes.
+ * Defaults to "/" when no base is configured (current behavior).
+ */
+export function getBasePath(): string {
+  if (typeof document !== "undefined") {
+    const baseHref = document.querySelector("base")?.getAttribute("href");
+    if (baseHref) {
+      const url = new URL(baseHref, window.location.origin);
+      return ensureTrailingSlash(url.pathname);
+    }
+  }
+  const buildTimeBase = import.meta.env.BASE_URL || "/";
+  if (buildTimeBase === "./" || buildTimeBase === ".") {
+    return "/";
+  }
+  return ensureTrailingSlash(buildTimeBase);
+}
+
+/**
+ * Returns the base path without the trailing slash ("" for root, "/explorer" for
+ * a subpath), for prepending to router-relative paths.
+ */
+export function basePathPrefix(): string {
+  return getBasePath().replace(/\/$/, "");
+}
+
+/**
+ * Resolves a public asset path (e.g. "/images/metamask.svg") against the app base path.
+ * Fully qualified, protocol-relative and data: URLs are returned unchanged so that
+ * external icon/logo URLs from network configs keep working.
+ */
+export function publicAsset(path: string): string;
+export function publicAsset(path: string | null | undefined): string | undefined;
+export function publicAsset(path: string | null | undefined): string | undefined {
+  if (path == null || path === "") {
+    return path ?? undefined;
+  }
+  if (/^[a-z][a-z0-9+.-]*:/i.test(path) || path.startsWith("//")) {
+    return path;
+  }
+  return getBasePath() + path.replace(/^\//, "");
+}
+
+/**
+ * Builds an absolute app URL (origin + base path + app path), e.g. for full-page
+ * redirects and OAuth redirect URIs.
+ */
+export function appUrl(path = ""): string {
+  return new URL(getBasePath() + path.replace(/^\//, ""), window.location.origin).toString();
+}
+
+/**
+ * Returns an absolute URL to the app root without a trailing slash beyond the
+ * origin (e.g. "https://host" or "https://host/explorer"), preserving the
+ * pre-base-path format expected by external consumers (MetaMask, OAuth
+ * redirect allowlists).
+ */
+export function appRootUrl(): string {
+  return window.location.origin + basePathPrefix();
+}
+
+/**
+ * Returns the current router-relative path (window.location.pathname with the base
+ * path stripped), suitable for use as a redirect target for router.push().
+ */
+export function currentAppPath(): string {
+  const base = getBasePath();
+  const { pathname } = window.location;
+  if (base === "/") {
+    return pathname;
+  }
+  // Bare prefix without the trailing slash (e.g. "/explorer").
+  if (pathname === basePathPrefix()) {
+    return "/";
+  }
+  return pathname.startsWith(base) ? pathname.slice(base.length - 1) : pathname;
+}

--- a/packages/app/src/views/AuthCallbackView.vue
+++ b/packages/app/src/views/AuthCallbackView.vue
@@ -2,7 +2,11 @@
   <div
     class="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-slate-50 via-white to-blue-50 px-4 py-12 sm:px-6 lg:px-8"
   >
-    <img :src="currentNetwork.logoUrl || '/images/prividium_logo.svg'" alt="Logo" class="mb-6 h-16 w-auto" />
+    <img
+      :src="publicAsset(currentNetwork.logoUrl || '/images/prividium_logo.svg')"
+      alt="Logo"
+      class="mb-6 h-16 w-auto"
+    />
 
     <!-- Loading state (no card) -->
     <div v-if="!error" class="text-center">
@@ -35,6 +39,8 @@ import { FetchError } from "ohmyfetch";
 
 import useContext from "@/composables/useContext";
 import useLogin from "@/composables/useLogin";
+
+import { publicAsset } from "@/utils/basePath";
 
 const { t } = useI18n();
 

--- a/packages/app/src/views/LoginView.vue
+++ b/packages/app/src/views/LoginView.vue
@@ -3,7 +3,11 @@
     class="flex min-h-screen flex-col justify-center bg-gradient-to-br from-slate-50 via-white to-blue-50 px-4 py-12 sm:px-6 lg:px-8"
   >
     <div class="mb-6 text-center sm:mx-auto sm:w-full sm:max-w-md">
-      <img :src="currentNetwork.logoUrl || '/images/prividium_logo.svg'" alt="Logo" class="mx-auto mb-4 h-16 w-auto" />
+      <img
+        :src="publicAsset(currentNetwork.logoUrl || '/images/prividium_logo.svg')"
+        alt="Logo"
+        class="mx-auto mb-4 h-16 w-auto"
+      />
       <h1 class="mb-2 bg-gradient-to-r from-blue-600 to-blue-800 bg-clip-text text-4xl font-bold text-transparent">
         {{ t("loginView.explorerTitle") }}
       </h1>
@@ -37,6 +41,8 @@ import { FetchError } from "ohmyfetch";
 import useContext from "@/composables/useContext";
 import useLogin from "@/composables/useLogin";
 import useRuntimeConfig from "@/composables/useRuntimeConfig";
+
+import { publicAsset } from "@/utils/basePath";
 
 const { t } = useI18n();
 const { brandName } = useRuntimeConfig();

--- a/packages/app/src/views/NotAuthorizedView.vue
+++ b/packages/app/src/views/NotAuthorizedView.vue
@@ -2,7 +2,11 @@
   <div
     class="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-slate-50 via-white to-blue-50 px-4 py-12"
   >
-    <img :src="currentNetwork.logoUrl || '/images/prividium_logo.svg'" alt="Logo" class="mb-6 h-16 w-auto" />
+    <img
+      :src="publicAsset(currentNetwork.logoUrl || '/images/prividium_logo.svg')"
+      alt="Logo"
+      class="mb-6 h-16 w-auto"
+    />
 
     <div class="sm:mx-auto sm:w-full sm:max-w-md">
       <div class="rounded-2xl border border-gray-200 bg-white px-6 py-10 text-center shadow-xl sm:px-12">
@@ -31,6 +35,8 @@ import { useRouter } from "vue-router";
 import { LockClosedIcon } from "@heroicons/vue/outline";
 
 import useContext from "@/composables/useContext";
+
+import { publicAsset } from "@/utils/basePath";
 
 const { t } = useI18n();
 const router = useRouter();

--- a/packages/app/tests/composables/useNotFound.spec.ts
+++ b/packages/app/tests/composables/useNotFound.spec.ts
@@ -9,7 +9,7 @@ const router = {
   resolve: vi.fn(() => notFoundRoute),
   replace: vi.fn(),
   currentRoute: {
-    value: {},
+    value: { fullPath: "/" },
   },
 };
 
@@ -26,9 +26,39 @@ describe("UseNotFound:", () => {
   });
 
   it("sets not found view", async () => {
-    composable.setNotFoundView();
+    await composable.setNotFoundView();
     expect(router.replace).toHaveBeenCalledWith(notFoundRoute);
     router.replace.mockReset();
+  });
+
+  it("restores the original URL after replacing the route", async () => {
+    const replaceStateSpy = vi.spyOn(history, "replaceState").mockImplementation(() => undefined);
+    router.currentRoute.value = { fullPath: "/address/0x123" };
+    try {
+      await composable.setNotFoundView();
+      expect(replaceStateSpy).toHaveBeenCalledWith({}, "404 Not Found", "/address/0x123");
+    } finally {
+      replaceStateSpy.mockRestore();
+      router.currentRoute.value = { fullPath: "/" };
+      router.replace.mockReset();
+    }
+  });
+
+  it("prepends the base path to the restored URL when served from a subpath", async () => {
+    const base = document.createElement("base");
+    base.setAttribute("href", "/explorer/");
+    document.head.appendChild(base);
+    const replaceStateSpy = vi.spyOn(history, "replaceState").mockImplementation(() => undefined);
+    router.currentRoute.value = { fullPath: "/address/0x123?network=mainnet" };
+    try {
+      await composable.setNotFoundView();
+      expect(replaceStateSpy).toHaveBeenCalledWith({}, "404 Not Found", "/explorer/address/0x123?network=mainnet");
+    } finally {
+      replaceStateSpy.mockRestore();
+      base.remove();
+      router.currentRoute.value = { fullPath: "/" };
+      router.replace.mockReset();
+    }
   });
 
   it("sets not found view when passed refs are all falsy", async () => {

--- a/packages/app/tests/utils/basePath.spec.ts
+++ b/packages/app/tests/utils/basePath.spec.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { appRootUrl, appUrl, basePathPrefix, currentAppPath, getBasePath, publicAsset } from "@/utils/basePath";
+
+const setBaseTag = (href: string) => {
+  const base = document.createElement("base");
+  base.setAttribute("href", href);
+  document.head.appendChild(base);
+};
+
+const removeBaseTag = () => {
+  document.querySelector("base")?.remove();
+};
+
+describe("basePath:", () => {
+  afterEach(() => {
+    removeBaseTag();
+  });
+
+  describe("getBasePath", () => {
+    it("returns '/' when no base tag is present", () => {
+      expect(getBasePath()).toBe("/");
+    });
+
+    it("returns '/' for a root base tag", () => {
+      setBaseTag("/");
+      expect(getBasePath()).toBe("/");
+    });
+
+    it("returns the subpath from the base tag", () => {
+      setBaseTag("/explorer/");
+      expect(getBasePath()).toBe("/explorer/");
+    });
+
+    it("adds a trailing slash when the base tag has none", () => {
+      setBaseTag("/explorer");
+      // Per URL resolution rules "/explorer" resolves to the "/" directory,
+      // so an explicitly configured base must include the trailing slash.
+      // getBasePath still normalizes its own output to end with "/".
+      expect(getBasePath().endsWith("/")).toBe(true);
+    });
+
+    it("resolves an absolute base tag href to its pathname", () => {
+      setBaseTag("https://example.com/explorer/");
+      expect(getBasePath()).toBe("/explorer/");
+    });
+  });
+
+  describe("publicAsset", () => {
+    it("keeps root-absolute paths unchanged without a base tag", () => {
+      expect(publicAsset("/images/metamask.svg")).toBe("/images/metamask.svg");
+    });
+
+    it("prefixes root-absolute paths with the base path", () => {
+      setBaseTag("/explorer/");
+      expect(publicAsset("/images/metamask.svg")).toBe("/explorer/images/metamask.svg");
+    });
+
+    it("prefixes bare paths with the base path", () => {
+      setBaseTag("/explorer/");
+      expect(publicAsset("images/metamask.svg")).toBe("/explorer/images/metamask.svg");
+    });
+
+    it("keeps fully qualified urls unchanged", () => {
+      setBaseTag("/explorer/");
+      expect(publicAsset("https://example.com/icon.svg")).toBe("https://example.com/icon.svg");
+      expect(publicAsset("http://example.com/icon.svg")).toBe("http://example.com/icon.svg");
+    });
+
+    it("keeps protocol-relative urls unchanged", () => {
+      setBaseTag("/explorer/");
+      expect(publicAsset("//example.com/icon.svg")).toBe("//example.com/icon.svg");
+    });
+
+    it("keeps data urls unchanged", () => {
+      setBaseTag("/explorer/");
+      expect(publicAsset("data:image/svg+xml;base64,abc")).toBe("data:image/svg+xml;base64,abc");
+    });
+
+    it("passes through nullish and empty values unchanged", () => {
+      setBaseTag("/explorer/");
+      expect(publicAsset(undefined)).toBe(undefined);
+      expect(publicAsset(null)).toBe(undefined);
+      expect(publicAsset("")).toBe("");
+    });
+  });
+
+  describe("appUrl", () => {
+    it("returns the origin root url without a base tag", () => {
+      expect(appUrl()).toBe(`${window.location.origin}/`);
+    });
+
+    it("appends the app path to origin without a base tag", () => {
+      expect(appUrl("login")).toBe(`${window.location.origin}/login`);
+      expect(appUrl("/login")).toBe(`${window.location.origin}/login`);
+    });
+
+    it("includes the base path", () => {
+      setBaseTag("/explorer/");
+      expect(appUrl()).toBe(`${window.location.origin}/explorer/`);
+      expect(appUrl("auth/callback")).toBe(`${window.location.origin}/explorer/auth/callback`);
+    });
+  });
+
+  describe("basePathPrefix", () => {
+    it("returns an empty string without a base tag", () => {
+      expect(basePathPrefix()).toBe("");
+    });
+
+    it("returns the base path without a trailing slash", () => {
+      setBaseTag("/explorer/");
+      expect(basePathPrefix()).toBe("/explorer");
+    });
+  });
+
+  describe("appRootUrl", () => {
+    it("returns the bare origin without a base tag", () => {
+      expect(appRootUrl()).toBe(window.location.origin);
+    });
+
+    it("returns origin plus prefix without a trailing slash", () => {
+      setBaseTag("/explorer/");
+      expect(appRootUrl()).toBe(`${window.location.origin}/explorer`);
+    });
+  });
+
+  describe("currentAppPath", () => {
+    it("returns the pathname unchanged without a base tag", () => {
+      expect(currentAppPath()).toBe(window.location.pathname);
+    });
+
+    it("strips the base path from the pathname", () => {
+      setBaseTag("/explorer/");
+      history.replaceState(null, "", "/explorer/blocks");
+      try {
+        expect(currentAppPath()).toBe("/blocks");
+      } finally {
+        history.replaceState(null, "", "/");
+      }
+    });
+
+    it("returns '/' for the bare prefix without a trailing slash", () => {
+      setBaseTag("/explorer/");
+      history.replaceState(null, "", "/explorer");
+      try {
+        expect(currentAppPath()).toBe("/");
+      } finally {
+        history.replaceState(null, "", "/");
+      }
+    });
+
+    it("returns the pathname unchanged when it does not start with the base path", () => {
+      setBaseTag("/explorer/");
+      history.replaceState(null, "", "/blocks");
+      try {
+        expect(currentAppPath()).toBe("/blocks");
+      } finally {
+        history.replaceState(null, "", "/");
+      }
+    });
+  });
+});

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -3,8 +3,29 @@ import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import { fileURLToPath, URL } from "url";
 
+// Base public path the app is served from.
+// - VITE_BASE_PATH: explicit base path (e.g. "/explorer/") baked in at build time.
+// - Docker builds (DOCKER_BUILD=true) use a relative base so the same image can be
+//   served from any subpath, configured at container start via the BASE_PATH env var
+//   (injected as a <base> tag in index.html, see Dockerfile and index.html).
+// - Local dev/builds keep the default root base.
+function resolveBase(): string {
+  if (process.env.VITE_BASE_PATH) {
+    const trimmed = process.env.VITE_BASE_PATH.replace(/^\/+|\/+$/g, "");
+    return trimmed ? `/${trimmed}/` : "/";
+  }
+  return process.env.DOCKER_BUILD === "true" ? "./" : "/";
+}
+
+// Keep the <base> tag in index.html (filled from BASE_PATH by the html-transform
+// plugin below) in sync with the build-time base for non-Docker dev/builds.
+if (!process.env.BASE_PATH && process.env.VITE_BASE_PATH) {
+  process.env.BASE_PATH = resolveBase();
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: resolveBase(),
   server: {
     port: 3010,
   },


### PR DESCRIPTION
## What

Adds support for serving the explorer frontend from a configurable URL base path (e.g. `https://example.com/explorer/`) instead of only at the domain root. Motivated by a partner reverse-proxying `x.xx/explorer` to their hosted explorer instance, which currently breaks because all assets, the runtime `config.js`, and several JS redirects assume the app lives at `/`.

## How

Two configuration knobs, both backward compatible (defaults reproduce current behavior exactly):

- **Build time**: `VITE_BASE_PATH=/explorer/ npm run build` (also works for `npm run dev`). Sets the Vite `base` and keeps the injected `<base>` tag in sync.
- **Container runtime** (no rebuild): the Docker image is now built with a relative Vite base, and `docker run -e BASE_PATH=/explorer ...` configures everything at container start. This fits the existing pattern where `index.html` is templated with gomplate on startup, so the stock published image can serve any subpath.

Mechanism:

- `index.html` gets a `<base href>` tag templated from `BASE_PATH` (default `/`). Built asset URLs are emitted relative in Docker builds and resolve against it. `config.js` and the favicon defaults are now base-relative.
- `vue-router` uses `createWebHistory()` with no argument, which reads the `<base>` tag, covering both build-time and runtime configuration.
- New `src/utils/basePath.ts` helpers (`getBasePath`, `basePathPrefix`, `publicAsset`, `appUrl`, `appRootUrl`, `currentAppPath`) with unit tests. All root-absolute `/images/...` references, the 401 login redirect, the wallet-switch reload, the Prividium OAuth `redirect_uri` / `post_logout_redirect_uri`, and MetaMask `blockExplorerUrls` resolve through them. For root deployments every helper returns the exact same strings as before (including `https://host` without a trailing slash where external allowlists may do exact matching).
- New `nginx.conf.subpath.template` used only when `BASE_PATH` is set: serves the app under the prefix (with a `301` from the bare prefix, relative redirects for proxy friendliness, and the same security headers). When `BASE_PATH` is unset, the existing template is used unchanged and the rendered nginx config is byte-identical to today.
- Dockerfile: `VITE_BASE_PATH` build arg, and the CMD normalizes `BASE_PATH` and picks the right template at startup. Idempotent across container restarts (index.html is always regenerated from the `.tpl`).

`release.yml` is intentionally untouched: the published image stays a single artifact, configurable per deployment via `BASE_PATH`.

## Verification

- Full unit test suite passes (777 tests), plus new tests for the base-path helpers. Lint and `vue-tsc` clean.
- Built and served the app three ways against a real nginx (1.29) using the rendered configs from both templates:
  - root, no `BASE_PATH`: rendered nginx config identical to current, app loads, deep links work, browser console clean.
  - `BASE_PATH=/explorer` direct: `/explorer` 301s to `/explorer/`, `config.js`, JS/CSS chunks, images, and deep links (`/explorer/tx/0x...`) all 200, client-side navigation keeps the prefix, zero failed requests in a headless-browser run.
  - behind a prefix-preserving reverse proxy (simulating the partner setup): same results.
- Dockerfile CMD normalization exercised for all `BASE_PATH` input forms (``, `/`, `/explorer`, `/explorer/`, `explorer`, `explorer/`).
- Code review and security review performed; review findings (MetaMask/OAuth trailing-slash parity at root, bare-prefix redirect edge case, duplicated slash-trimming) were addressed in this PR. The security review found no newly introduced vulnerabilities: OAuth redirect URIs remain pinned to `window.location.origin`, and the nginx prefix rewrite is applied after nginx's standard URI normalization, so no traversal is possible.

Note: container-level smoke testing of the actual Docker image (`docker build` + `docker run` with and without `BASE_PATH`) was not run in this environment (no Docker available); the rendered nginx configs and the startup shell logic were tested directly against a real nginx binary instead. Worth a quick staging check on the built image.

## Deployment notes

- For the partner case: deploy the stock image with `BASE_PATH=/explorer` and have their proxy forward `/explorer/*` to the container without stripping the prefix.
- If a proxy strips the prefix instead, leave `BASE_PATH` unset (root mode), but the app will emit root-relative URLs, so prefix-preserving proxying is the supported setup.
- `BASE_PATH` must be a plain path prefix (letters, digits, `-`, `_`, `/`), as it is interpolated into an nginx `location`/`rewrite`.
