### PR TITLE
feat(prividium): serve Swagger /docs publicly

### DIFF
--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -8,7 +8,7 @@ import { getLogger } from "./logger";
 import { AppModule } from "./app.module";
 import { AppMetricsModule } from "./appMetrics.module";
 import { prividium } from "./config/featureFlags";
-import { applyPrividiumExpressConfig, applySwaggerAuthMiddleware } from "./prividium";
+import { applyPrividiumExpressConfig } from "./prividium";
 
 const BODY_PARSER_SIZE_LIMIT = "10mb";
 
@@ -34,8 +34,7 @@ async function bootstrap() {
   metricsApp.enableShutdownHooks();
 
   if (prividium) {
-    // Prividium config includes strict CORS configuration
-    // Must be applied before Swagger setup so session is available for auth check
+    // Prividium config includes strict CORS configuration.
     applyPrividiumExpressConfig(app, {
       sessionSecret: configService.get<string>("prividium.sessionSecret"),
       appUrl: configService.get<string>("prividium.appUrl"),
@@ -43,7 +42,6 @@ async function bootstrap() {
       sessionSameSite: configService.get<"none" | "strict" | "lax">("prividium.sessionSameSite"),
       corsOrigins: configService.get<string[]>("prividium.corsOrigins"),
     });
-    applySwaggerAuthMiddleware(app, configService);
   } else {
     app.enableCors();
   }

--- a/packages/api/src/prividium.spec.ts
+++ b/packages/api/src/prividium.spec.ts
@@ -1,15 +1,12 @@
 import request from "supertest";
 import express from "express";
-import cookieSession from "cookie-session";
-import { applyPrividiumExpressConfig, applyPrividiumMiddlewares, applySwaggerAuthMiddleware } from "./prividium";
+import { applyPrividiumExpressConfig, applyPrividiumMiddlewares } from "./prividium";
 import { NestExpressApplication } from "@nestjs/platform-express";
 import { mock } from "jest-mock-extended";
 import { MiddlewareConsumer } from "@nestjs/common";
-import { ConfigService } from "@nestjs/config";
 import { MiddlewareConfigProxy } from "@nestjs/common/interfaces/middleware/middleware-config-proxy.interface";
 import { AuthMiddleware } from "./middlewares/auth.middleware";
 import { NoCacheMiddleware } from "./middlewares/no-cache.middleware";
-import { AddUserRolesPipe } from "./api/pipes/addUserRoles.pipe";
 
 describe("applyPrividiumExpressConfig", () => {
   it("allows to set cookies", async () => {
@@ -74,102 +71,5 @@ describe("applyPrividiumMiddlewares", () => {
     expect(consumer.apply).toHaveBeenCalledTimes(2);
     expect(consumer.apply).toHaveBeenCalledWith(AuthMiddleware);
     expect(consumer.apply).toHaveBeenCalledWith(NoCacheMiddleware);
-  });
-});
-
-describe("applySwaggerAuthMiddleware", () => {
-  let app: express.Express;
-  let configService: ConfigService;
-  let transformSpy: jest.SpyInstance;
-
-  beforeEach(() => {
-    app = express();
-    app.use(
-      cookieSession({
-        name: "_auth",
-        secret: "test-secret",
-        maxAge: 1000,
-      })
-    );
-    configService = mock<ConfigService>();
-    transformSpy = jest.spyOn(AddUserRolesPipe.prototype, "transform");
-  });
-
-  afterEach(() => {
-    transformSpy.mockRestore();
-  });
-
-  it("returns 401 for unauthenticated requests without session", async () => {
-    applySwaggerAuthMiddleware(app as unknown as NestExpressApplication, configService);
-    app.get("/docs", (_req, res) => res.send("docs"));
-
-    const res = await request(app).get("/docs");
-    expect(res.status).toBe(401);
-    expect(res.body).toEqual({ message: "Unauthorized" });
-  });
-
-  it("returns 401 for requests with incomplete session (missing token)", async () => {
-    app.use((req, _res, next) => {
-      req.session = { address: "0x123" } as any;
-      next();
-    });
-    applySwaggerAuthMiddleware(app as unknown as NestExpressApplication, configService);
-    app.get("/docs", (_req, res) => res.send("docs"));
-
-    const res = await request(app).get("/docs");
-    expect(res.status).toBe(401);
-    expect(res.body).toEqual({ message: "Unauthorized" });
-  });
-
-  it("returns 403 for authenticated non-admin users", async () => {
-    app.use((req, _res, next) => {
-      req.session = { address: "0x123", token: "valid-token" } as any;
-      next();
-    });
-    transformSpy.mockResolvedValue({
-      address: "0x123",
-      token: "valid-token",
-      roles: ["user"],
-      hasFullReadAccess: false,
-    });
-    applySwaggerAuthMiddleware(app as unknown as NestExpressApplication, configService);
-    app.get("/docs", (_req, res) => res.send("docs"));
-
-    const res = await request(app).get("/docs");
-    expect(res.status).toBe(403);
-    expect(res.body).toEqual({ message: "Forbidden" });
-  });
-
-  it("allows admin users to access /docs", async () => {
-    app.use((req, _res, next) => {
-      req.session = { address: "0x123", token: "valid-token" } as any;
-      next();
-    });
-    transformSpy.mockResolvedValue({
-      address: "0x123",
-      token: "valid-token",
-      roles: ["admin"],
-      hasFullReadAccess: true,
-    });
-    applySwaggerAuthMiddleware(app as unknown as NestExpressApplication, configService);
-    app.get("/docs", (_req, res) => res.send("docs"));
-
-    const res = await request(app).get("/docs");
-    expect(res.status).toBe(200);
-    expect(res.text).toBe("docs");
-  });
-
-  it("returns 401 when AddUserRolesPipe throws an error", async () => {
-    app.use((req, _res, next) => {
-      req.session = { address: "0x123", token: "invalid-token" } as any;
-      next();
-    });
-    transformSpy.mockRejectedValue(new Error("Authentication failed"));
-    applySwaggerAuthMiddleware(app as unknown as NestExpressApplication, configService);
-    app.get("/docs", (_req, res) => res.send("docs"));
-
-    const res = await request(app).get("/docs");
-    expect(res.status).toBe(401);
-    expect(res.body).toEqual({ message: "Unauthorized" });
   });
 });

--- a/packages/api/src/prividium.ts
+++ b/packages/api/src/prividium.ts
@@ -1,13 +1,10 @@
 import { MiddlewareConsumer } from "@nestjs/common";
-import { ConfigService } from "@nestjs/config";
 import { AuthMiddleware } from "./middlewares/auth.middleware";
 import { AuthModule } from "./auth/auth.module";
 import { AuthController } from "./auth/auth.controller";
 import { NoCacheMiddleware } from "./middlewares/no-cache.middleware";
-import { AddUserRolesPipe } from "./api/pipes/addUserRoles.pipe";
 import cookieSession from "cookie-session";
 import { NestExpressApplication } from "@nestjs/platform-express";
-import { Request, Response, NextFunction } from "express";
 
 export function applyPrividiumExpressConfig(
   app: NestExpressApplication,
@@ -40,32 +37,6 @@ export function applyPrividiumExpressConfig(
   app.enableCors({
     origin: corsOrigins ?? appUrl,
     credentials: true,
-  });
-}
-
-export function applySwaggerAuthMiddleware(app: NestExpressApplication, configService: ConfigService) {
-  app.use("/docs", async (req: Request, res: Response, next: NextFunction) => {
-    if (!req.session?.address || !req.session?.token) {
-      res.status(401).json({ message: "Unauthorized" });
-      return;
-    }
-
-    const addUserRolesPipe = new AddUserRolesPipe(configService);
-    try {
-      const userWithRoles = await addUserRolesPipe.transform({
-        address: req.session.address,
-        token: req.session.token,
-      });
-      if (!userWithRoles?.hasAdminRead && !userWithRoles?.hasFullReadAccess) {
-        res.status(403).json({ message: "Forbidden" });
-        return;
-      }
-    } catch {
-      res.status(401).json({ message: "Unauthorized" });
-      return;
-    }
-
-    next();
   });
 }
 

--- a/packages/api/test/prividium-api.e2e-spec.ts
+++ b/packages/api/test/prividium-api.e2e-spec.ts
@@ -16,7 +16,7 @@ import { AddressTransaction } from "../src/transaction/entities/addressTransacti
 import { Transaction } from "../src/transaction/entities/transaction.entity";
 import { BlockDetails } from "../src/block/blockDetails.entity";
 import { IndexerState } from "../src/indexerState/indexerState.entity";
-import { applyPrividiumExpressConfig, applySwaggerAuthMiddleware } from "../src/prividium";
+import { applyPrividiumExpressConfig } from "../src/prividium";
 import { ConfigService } from "@nestjs/config";
 import { NestExpressApplication } from "@nestjs/platform-express";
 import { SwaggerModule, DocumentBuilder } from "@nestjs/swagger";
@@ -46,9 +46,6 @@ describe("Prividium API (e2e)", () => {
       sessionMaxAge: configService.get<number>("prividium.sessionMaxAge"),
       sessionSameSite: configService.get<"none" | "strict" | "lax">("prividium.sessionSameSite"),
     });
-
-    // Set up Swagger auth middleware before Swagger setup
-    applySwaggerAuthMiddleware(app as NestExpressApplication, configService);
 
     // Set up Swagger docs
     const swaggerConfig = new DocumentBuilder()
@@ -233,84 +230,9 @@ describe("Prividium API (e2e)", () => {
     });
   });
 
-  describe("Swagger Docs Access Control", () => {
-    let fetchSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-      fetchSpy = jest.spyOn(global, "fetch");
-    });
-
-    afterEach(() => {
-      fetchSpy.mockRestore();
-    });
-
-    it("returns 401 for unauthenticated users accessing /docs", async () => {
-      await agent.get("/docs").expect(401);
-    });
-
-    it("returns 403 for authenticated non-admin users accessing /docs", async () => {
-      // Login as non-admin user
-      fetchSpy
-        .mockResolvedValueOnce({
-          status: 200,
-          json: jest.fn().mockResolvedValue({ wallets: [mockWalletAddress] }),
-        })
-        .mockResolvedValueOnce({
-          status: 200,
-          json: jest.fn().mockResolvedValue({
-            type: "user",
-            expiresAt: new Date(2100, 0, 0).toISOString(),
-          }),
-        })
-        .mockResolvedValueOnce({
-          status: 200,
-          json: jest.fn().mockResolvedValue({ roles: [{ roleName: "user" }] }),
-        });
-
-      await agent.post("/auth/login").send({ token: mockToken }).expect(201);
-
-      // Mock the roles check for /docs access (non-admin)
-      fetchSpy.mockResolvedValueOnce({
-        status: 200,
-        json: jest.fn().mockResolvedValue({ roles: [{ roleName: "user" }] }),
-      });
-
-      await agent.get("/docs").expect(403);
-    });
-
-    it("allows admin users to access /docs", async () => {
-      // Login as admin user
-      fetchSpy
-        .mockResolvedValueOnce({
-          status: 200,
-          json: jest.fn().mockResolvedValue({ wallets: [mockWalletAddress] }),
-        })
-        .mockResolvedValueOnce({
-          status: 200,
-          json: jest.fn().mockResolvedValue({
-            type: "user",
-            expiresAt: new Date(2100, 0, 0).toISOString(),
-          }),
-        })
-        .mockResolvedValueOnce({
-          status: 200,
-          json: jest.fn().mockResolvedValue({
-            roles: [{ roleName: "admin", systemPermissions: ["full_read_access"] }],
-          }),
-        });
-
-      await agent.post("/auth/login").send({ token: mockToken }).expect(201);
-
-      // Mock the roles check for /docs access (admin)
-      fetchSpy.mockResolvedValueOnce({
-        status: 200,
-        json: jest.fn().mockResolvedValue({
-          roles: [{ roleName: "admin", systemPermissions: ["full_read_access"] }],
-        }),
-      });
-
+  describe("Swagger Docs", () => {
+    it("serves /docs publicly to unauthenticated callers", async () => {
       const response = await agent.get("/docs");
-      // Swagger returns 200 with HTML content
       expect(response.status).toBe(200);
       expect(response.text).toContain("swagger");
     });


### PR DESCRIPTION
# What ❔

Removes the auth gate (`applySwaggerAuthMiddleware`) that was returning 401 on `/docs` in Prividium mode. The `/docs` route is now reachable without a session, matching the Permissions API's public-docs behavior.

## Why ❔

- Block-explorer `/docs` returned 401 in Prividium mode because the middleware required a session and an admin role.
- Align block explorer docs with permission api docs for access without auth 

Related to matter-labs/zksync-prividium#1019.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.