### PR TITLE
chore: bump postgres to 18 in dev/CI

### DIFF
--- a/.github/workflows/prividium-e2e.yml
+++ b/.github/workflows/prividium-e2e.yml
@@ -16,7 +16,7 @@ jobs:
       options: --user 1001
     services:
       postgres:
-        image: postgres:15
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/docker-compose-cli.yaml
+++ b/docker-compose-cli.yaml
@@ -55,7 +55,7 @@ services:
     restart: unless-stopped
 
   postgres:
-    image: "postgres:14"
+    image: "postgres:18"
     logging:
       driver: none 
     volumes:

--- a/docker-compose-prividium.yaml
+++ b/docker-compose-prividium.yaml
@@ -73,7 +73,7 @@ services:
     restart: on-failure
 
   postgres:
-    image: "postgres:14"
+    image: "postgres:18"
     logging:
       driver: none
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,7 +64,7 @@ services:
     restart: unless-stopped
 
   postgres:
-    image: "postgres:14"
+    image: "postgres:18"
     logging:
       driver: none
     volumes:

--- a/packages/api/docker-compose.e2e.yaml
+++ b/packages/api/docker-compose.e2e.yaml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: "postgres"
+    image: "postgres:18"
     ports:
       - "5432:5432"
     healthcheck:


### PR DESCRIPTION
Bumps Postgres images to 18 across local compose files (were `14`/untagged) and the prividium-e2e workflow (was `15`).

Dev/CI only. No persistence guarantees - existing local setups need recreating (postgres:18 also moves default PGDATA).