### PR TITLE
feat: support custom assets storage and custom base

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,14 +53,63 @@ jobs:
             VITE_APP_ENVIRONMENT=production \
               npx semantic-release
 
+  # Publish the app's assets + public images to the R2 bucket before the App image is pushed so the files are already in place when it goes live.
+  publishStaticAssetsToR2:
+    name: Publish app static assets to R2
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: createReleaseVersion
+    if: ${{ github.ref == 'refs/heads/main' && needs.createReleaseVersion.outputs.releaseVersion != '' && vars.STATIC_ASSETS_UPLOAD_FOLDER != '' }}
+    steps:
+      - name: Download Dist package
+        uses: dsaltares/fetch-gh-release-asset@master
+        with:
+          version: "tags/v${{ needs.createReleaseVersion.outputs.releaseVersion }}"
+          file: "dist.zip"
+          target: "dist.zip"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Unzip Dist package
+        run: |
+          unzip dist.zip -d packages/app
+
+      - name: Publish to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.STATIC_ASSETS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.STATIC_ASSETS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          set -e
+          APP_DIST=packages/app/dist
+          ASSETS_DEST="s3://${{ vars.STATIC_ASSETS_UPLOAD_FOLDER }}"
+          ASSETS_S3_ENDPOINT="${{ vars.STATIC_ASSETS_S3_ENDPOINT }}"
+          VERSION="${{ needs.createReleaseVersion.outputs.releaseVersion }}"
+
+          aws s3 sync "$APP_DIST/assets" "$ASSETS_DEST/$VERSION/assets" --endpoint-url "$ASSETS_S3_ENDPOINT" \
+            --cache-control "public, max-age=31536000, immutable" --exclude "*.map"
+          aws s3 sync "$APP_DIST/images" "$ASSETS_DEST/$VERSION/images" --endpoint-url "$ASSETS_S3_ENDPOINT" \
+            --cache-control "public, max-age=31536000, immutable"
+
+          # Retention: keep only the newest 50 version folders, delete the rest.
+          KEEP=50
+          STALE=$(aws s3 ls "$ASSETS_DEST/" --endpoint-url "$ASSETS_S3_ENDPOINT" \
+            | awk '/ PRE / {print $2}' | sed 's#/$##' | grep -E '^[0-9]' | sort -V | head -n "-$KEEP" || true)
+          for v in $STALE; do
+            echo "Pruning old asset version: $v"
+            aws s3 rm "$ASSETS_DEST/$v/" --recursive --endpoint-url "$ASSETS_S3_ENDPOINT"
+          done
+
   deployBackendToStaging:
     name: Deploy Block Explorer backend to staging
     runs-on: [matterlabs-ci-runner]
     permissions:
       contents: read
       packages: write
-    needs: createReleaseVersion
-    if: ${{ github.ref == 'refs/heads/main' && needs.createReleaseVersion.outputs.releaseVersion != '' }}
+    needs: [createReleaseVersion, publishStaticAssetsToR2]
+    # always() so a skipped R2 job (bucket not configured) doesn't skip this one; but a real R2
+    # failure does block the image push (assets must be live first).
+    if: ${{ always() && github.ref == 'refs/heads/main' && needs.createReleaseVersion.outputs.releaseVersion != '' && needs.publishStaticAssetsToR2.result != 'failure' && needs.publishStaticAssetsToR2.result != 'cancelled' }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' && needs.createReleaseVersion.outputs.releaseVersion != '' && vars.STATIC_ASSETS_UPLOAD_FOLDER != '' }}
     steps:
       - name: Download Dist package
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # 1.1.2
         with:
           version: "tags/v${{ needs.createReleaseVersion.outputs.releaseVersion }}"
           file: "dist.zip"
@@ -232,7 +232,7 @@ jobs:
           npm install -g firebase-tools
 
       - name: Download Dist package
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # 1.1.2
         with:
           version: "tags/v${{ needs.createReleaseVersion.outputs.releaseVersion }}"
           file: "dist.zip"
@@ -248,7 +248,7 @@ jobs:
           echo "window[\"##runtimeConfig\"] = { appEnvironment: \"staging\", sentryDSN: \"${{ vars.SENTRY_DSN }}\"  };" > packages/app/dist/config.js
 
       - name: Download Storybook package
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # 1.1.2
         with:
           version: "tags/v${{ needs.createReleaseVersion.outputs.releaseVersion }}"
           file: "storybook-static.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,14 @@ jobs:
     permissions:
       contents: read
     needs: createReleaseVersion
-    if: ${{ github.ref == 'refs/heads/main' && needs.createReleaseVersion.outputs.releaseVersion != '' && vars.STATIC_ASSETS_UPLOAD_FOLDER != '' }}
+    if: ${{ github.ref == 'refs/heads/main' && needs.createReleaseVersion.outputs.releaseVersion != '' }}
+    # STATIC_ASSETS_UPLOAD_FOLDER is a secret, and secrets can't be referenced in `if:` — so mirror it
+    # into a job-level env and gate the steps on that (empty = R2 not configured -> steps skip).
+    env:
+      STATIC_ASSETS_UPLOAD_FOLDER: ${{ secrets.STATIC_ASSETS_UPLOAD_FOLDER }}
     steps:
       - name: Download Dist package
+        if: ${{ env.STATIC_ASSETS_UPLOAD_FOLDER != '' }}
         uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # 1.1.2
         with:
           version: "tags/v${{ needs.createReleaseVersion.outputs.releaseVersion }}"
@@ -71,19 +76,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Unzip Dist package
+        if: ${{ env.STATIC_ASSETS_UPLOAD_FOLDER != '' }}
         run: |
           unzip dist.zip -d packages/app
 
       - name: Publish to R2
+        if: ${{ env.STATIC_ASSETS_UPLOAD_FOLDER != '' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.STATIC_ASSETS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.STATIC_ASSETS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
+          ASSETS_S3_ENDPOINT: ${{ secrets.STATIC_ASSETS_S3_ENDPOINT }}
         run: |
           set -e
           APP_DIST=packages/app/dist
-          ASSETS_DEST="s3://${{ vars.STATIC_ASSETS_UPLOAD_FOLDER }}"
-          ASSETS_S3_ENDPOINT="${{ vars.STATIC_ASSETS_S3_ENDPOINT }}"
+          ASSETS_DEST="s3://${STATIC_ASSETS_UPLOAD_FOLDER}"
           VERSION="${{ needs.createReleaseVersion.outputs.releaseVersion }}"
 
           aws s3 sync "$APP_DIST/assets" "$ASSETS_DEST/$VERSION/assets" --endpoint-url "$ASSETS_S3_ENDPOINT" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,8 @@ jobs:
           aws s3 sync "$APP_DIST/images" "$ASSETS_DEST/$VERSION/images" --endpoint-url "$ASSETS_S3_ENDPOINT" \
             --cache-control "public, max-age=31536000, immutable"
 
-          # Retention: keep only the newest 50 version folders, delete the rest.
-          KEEP=50
+          # Retention: keep only the newest 100 version folders, delete the rest.
+          KEEP=100
           STALE=$(aws s3 ls "$ASSETS_DEST/" --endpoint-url "$ASSETS_S3_ENDPOINT" \
             | awk '/ PRE / {print $2}' | sed 's#/$##' | grep -E '^[0-9]' | sort -V | head -n "-$KEEP" || true)
           for v in $STALE; do

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "typescript": "4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0",
+        "node": ">=22.0.0",
         "npm": ">=9.0.0"
       }
     },
@@ -58890,7 +58890,7 @@
         "typescript": "4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0",
+        "node": ">=22.0.0",
         "npm": ">=9.0.0"
       }
     },
@@ -58961,6 +58961,7 @@
         "eslint-plugin-storybook": "^0.5.7",
         "eslint-plugin-vue": "^8.2.0",
         "jsdom": "19.0.0",
+        "magic-string": "^0.30.8",
         "playwright": "1.54.1",
         "postcss": "^8.4.12",
         "prettier-plugin-tailwindcss": "^0.2.2",
@@ -59052,7 +59053,7 @@
         "typescript": "4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0",
+        "node": ">=22.0.0",
         "npm": ">=9.0.0"
       }
     },
@@ -59151,7 +59152,7 @@
         "typescript": "4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0",
+        "node": ">=22.0.0",
         "npm": ">=9.0.0"
       }
     },

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -1,4 +1,7 @@
 DOCKER_BUILD=false
+APP_BASE=/
+STATIC_ASSETS_URL=
+STATIC_ASSETS_VERSIONED=true # When STATIC_ASSETS_URL is set, assets served from /<VITE_VERSION>/ folder; set false to serve them flat.
 VITE_APP_ENVIRONMENT=default
 VITE_BRAND_NAME=ZKsync
 VITE_VERSION=dev

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -28,6 +28,11 @@ RUN npm run build
 
 FROM nginx:1.30.2-alpine AS production-stage
 ENV PORT=3010
+ENV APP_BASE=/
+ENV STATIC_ASSETS_URL=
+ENV STATIC_ASSETS_VERSIONED=true
+ARG VITE_VERSION=
+ENV VITE_VERSION=$VITE_VERSION
 ENV CSP_REPORT_ONLY="default-src 'self'; child-src 'self' blob:; script-src 'self' 'unsafe-eval' blob:; connect-src https://*.ingest.sentry.io https://*.zkscan.io https://*.zksync.io https://*.zksync.dev https://storage.googleapis.com; style-src 'self' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; img-src 'self' https://assets.coingecko.com blob: data: https://firebasestorage.googleapis.com/v0/b/token-library.appspot.com/o/;"
 
 RUN apk add --no-cache gomplate
@@ -37,6 +42,26 @@ COPY --from=build-stage /usr/src/app/packages/app/dist /usr/share/nginx/html
 
 RUN cp /usr/share/nginx/html/index.html /usr/share/nginx/html/index.html.tpl
 
-CMD envsubst '$PORT $CSP_REPORT_ONLY' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf \
-  && gomplate -f /usr/share/nginx/html/index.html.tpl -o /usr/share/nginx/html/index.html \
-  && exec nginx -g 'daemon off;'
+# Pick where the asset sentinel resolves (STATIC_ASSETS_URL if set, else APP_BASE),
+# allow that origin in the CSP, and render index.html. Only index.html carries the sentinel
+# (in its entry/preload/stylesheet URLs); the JS reads window.__ASSETS_BASE__ at runtime
+# (set in index.html by gomplate), so the bundle itself is never edited -> sourcemaps stay valid.
+CMD set -e; \
+  if [ -n "$STATIC_ASSETS_URL" ]; then \
+    ASSET_TARGET="${STATIC_ASSETS_URL%/}/"; \
+    if [ "$STATIC_ASSETS_VERSIONED" != "false" ] && [ -n "$VITE_VERSION" ]; then \
+      ASSET_TARGET="${ASSET_TARGET}${VITE_VERSION}/"; \
+    fi; \
+    case "$STATIC_ASSETS_URL" in http://*|https://*) \
+      ORIGIN=$(printf '%s' "$STATIC_ASSETS_URL" | sed -E 's#^(https?://[^/]+).*#\1#'); \
+      for d in script-src style-src font-src img-src connect-src; do \
+        CSP_REPORT_ONLY=$(printf '%s' "$CSP_REPORT_ONLY" | sed "s#$d #$d $ORIGIN #"); \
+      done ;; \
+    esac; \
+  else \
+    ASSET_TARGET="${APP_BASE%/}/"; \
+  fi; \
+  envsubst '$PORT $CSP_REPORT_ONLY' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf; \
+  gomplate -f /usr/share/nginx/html/index.html.tpl -o /usr/share/nginx/html/index.html; \
+  sed -i "s#/__ASSET_BASE__/#$ASSET_TARGET#g" /usr/share/nginx/html/index.html; \
+  exec nginx -g 'daemon off;'

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22.22.3-alpine AS base-stage
 ENV NODE_ENV=production
 
 WORKDIR /usr/src/app
-RUN apk add --update python3 make g++ && rm -rf /var/cache/apk/*
+RUN apk add --update python3 py3-setuptools make g++ && rm -rf /var/cache/apk/*
 
 COPY --chown=node:node .npmrc .npmrc
 COPY --chown=node:node lerna.json ./

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -77,10 +77,34 @@ npm run test:e2e
 npm run lint
 ```
 
+## Runtime base path & serving assets from a CDN
+
+The Docker image is built once and configured at container start (via env vars), so a single image can
+be served under any base path and optionally load its hashed assets from a separate origin.
+
+### Runtime env vars (container)
+
+| Var | Default | Purpose |
+| --- | --- | --- |
+| `APP_BASE` | `/` | Base path the app is served under (leading + trailing slash, e.g. `/explorer/`). Applies to routing, `config.js`, favicon, and locally-served assets. |
+| `STATIC_ASSETS_URL` | _(empty)_ | If set, hashed assets and `/images` load from this origin instead of the app (e.g. `https://static.example.com/explorer`). Empty = serve everything from the app at `APP_BASE`. |
+| `STATIC_ASSETS_VERSIONED` | `true` | When `STATIC_ASSETS_URL` is set, assets are read from a `/<VITE_VERSION>/` sub-folder. Set `false` to read them flat (requires assets uploaded flat — the release pipeline always uploads versioned). |
+
+`config.js` and the favicon are always served by the app at `APP_BASE` (never the CDN). Only the
+content-hashed bundle and `/images` move to `STATIC_ASSETS_URL`.
+
+### Publishing assets to the CDN (CI)
+
+When the release workflow runs, the `publishStaticAssetsToR2` job uploads the released `dist`'s
+`assets/` and `images/` to the bucket under `<version>/`, then prunes to the newest 50 versions. It runs
+only when `STATIC_ASSETS_UPLOAD_FOLDER` is configured, and **before** the app image is pushed.
+
+The uploaded files are byte-identical to what the image serves (same content hashes), so Sentry source
+maps match either way.
+
 ## Production links
  - [Web Application](https://explorer.zksync.io)
  - [Storybook](https://storybook-scan-v2.zksync.dev)
-
 
 ## Verify Block Explorer UI test results in GitHub Actions
 GitHub Actions test results are available in:

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -96,7 +96,7 @@ content-hashed bundle and `/images` move to `STATIC_ASSETS_URL`.
 ### Publishing assets to the CDN (CI)
 
 When the release workflow runs, the `publishStaticAssetsToR2` job uploads the released `dist`'s
-`assets/` and `images/` to the bucket under `<version>/`, then prunes to the newest 50 versions. It runs
+`assets/` and `images/` to the bucket under `<version>/`, then prunes to the newest 100 versions. It runs
 only when `STATIC_ASSETS_UPLOAD_FOLDER` is configured, and **before** the app image is pushed.
 
 The uploaded files are byte-identical to what the image serves (same content hashes), so Sentry source

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -13,12 +13,22 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content='{{ getenv "VITE_BRAND_NAME" | default "ZKsync" }} Block Explorer' />
 
-    <link rel="alternate icon" type='{{ getenv "VITE_ALT_FAVICON_IMAGE_TYPE" | default "image/x-icon" }}' href='{{ getenv "VITE_ALT_FAVICON_IMAGE_URL" | default "/favicon.ico" }}' />
-    <link rel="icon" type='{{ getenv "VITE_FAVICON_IMAGE_TYPE" | default "image/svg+xml" }}' href='{{ getenv "VITE_FAVICON_IMAGE_URL" | default "/favicon.svg" }}' />
+    <link rel="alternate icon" type='{{ getenv "VITE_ALT_FAVICON_IMAGE_TYPE" | default "image/x-icon" }}' href='{{ getenv "VITE_ALT_FAVICON_IMAGE_URL" | default (print (getenv "APP_BASE" "/") "favicon.ico") }}' />
+    <link rel="icon" type='{{ getenv "VITE_FAVICON_IMAGE_TYPE" | default "image/svg+xml" }}' href='{{ getenv "VITE_FAVICON_IMAGE_URL" | default (print (getenv "APP_BASE" "/") "favicon.svg") }}' />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="true" />
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
-    <script src="/config.js"></script>
+    <script>
+      window.__APP_BASE__ = '{{ getenv "APP_BASE" | default "/" }}';
+      window.__ASSETS_BASE__ = (function () {
+        var url = '{{ getenv "STATIC_ASSETS_URL" }}';
+        var version = '{{ getenv "VITE_VERSION" }}';
+        var versioned = '{{ getenv "STATIC_ASSETS_VERSIONED" | default "true" }}' !== 'false';
+        var base = (url || window.__APP_BASE__).replace(/\/?$/, '/');
+        return url && versioned && version ? base + version + '/' : base;
+      })();
+    </script>
+    <script src='{{ getenv "APP_BASE" | default "/" }}config.js'></script>
     
   </head>
   <body>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -88,6 +88,7 @@
     "eslint-plugin-storybook": "^0.5.7",
     "eslint-plugin-vue": "^8.2.0",
     "jsdom": "19.0.0",
+    "magic-string": "^0.30.8",
     "playwright": "1.54.1",
     "postcss": "^8.4.12",
     "prettier-plugin-tailwindcss": "^0.2.2",

--- a/packages/app/src/App.vue
+++ b/packages/app/src/App.vue
@@ -4,7 +4,7 @@
     v-if="isPrividiumAuthChecking"
     class="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-slate-50 via-white to-blue-50 px-4 py-12 sm:px-6 lg:px-8"
   >
-    <img src="/images/prividium_logo.svg" alt="Prividium Logo" class="mb-6 h-16 w-auto" />
+    <img :src="resolveAsset('/images/prividium_logo.svg')" alt="Prividium Logo" class="mb-6 h-16 w-auto" />
     <div class="text-center">
       <h1 class="mb-4 text-2xl font-semibold text-gray-900">Checking permissions...</h1>
       <div class="mx-auto h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
@@ -46,6 +46,7 @@ import useLocalization from "@/composables/useLocalization";
 import useLogin from "@/composables/useLogin";
 import useRouteTitle from "@/composables/useRouteTitle";
 
+import { resolveAsset, resolveBase } from "@/utils/appBase";
 import MaintenanceView from "@/views/MaintenanceView.vue";
 
 const { setup } = useLocalization();
@@ -81,7 +82,7 @@ onBeforeMount(async () => {
     return;
   }
 
-  return router.push({ name: "login", query: { redirect: route.fullPath } });
+  return router.push({ name: "login", query: { redirect: resolveBase(route.fullPath) } });
 });
 </script>
 

--- a/packages/app/src/components/Account.vue
+++ b/packages/app/src/components/Account.vue
@@ -16,7 +16,7 @@
             <EmptyState>
               <template #image>
                 <div class="balances-empty-icon">
-                  <img src="/images/empty-state/empty_balance.svg" alt="empty_balance" />
+                  <img :src="resolveAsset('/images/empty-state/empty_balance.svg')" alt="empty_balance" />
                 </div>
               </template>
               <template #title>
@@ -41,7 +41,7 @@
             <EmptyState>
               <template #image>
                 <div class="balances-empty-icon">
-                  <img src="/images/empty-state/error_balance.svg" alt="empty_balance" />
+                  <img :src="resolveAsset('/images/empty-state/error_balance.svg')" alt="empty_balance" />
                 </div>
               </template>
               <template #title>
@@ -91,6 +91,7 @@ import useRuntimeConfig from "@/composables/useRuntimeConfig";
 import type { BreadcrumbItem } from "@/components/common/Breadcrumbs.vue";
 import type { Account } from "@/composables/useAddress";
 
+import { resolveAsset } from "@/utils/appBase";
 import { shortValue } from "@/utils/formatters";
 
 const runtimeConfig = useRuntimeConfig();

--- a/packages/app/src/components/ConnectMetamaskButton.vue
+++ b/packages/app/src/components/ConnectMetamaskButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="metamask-button" :class="{ disabled: buttonDisabled }">
-    <img src="/images/metamask.svg" class="metamask-image" />
+    <img :src="resolveAsset('/images/metamask.svg')" class="metamask-image" />
     <button v-if="!address" :disabled="buttonDisabled" class="login-button" @click="connect">
       {{ buttonText }}
     </button>
@@ -35,6 +35,8 @@ import HashLabel from "@/components/common/HashLabel.vue";
 
 import useContext from "@/composables/useContext";
 import { default as useWallet } from "@/composables/useWallet";
+
+import { resolveAsset } from "@/utils/appBase";
 
 const { t } = useI18n();
 

--- a/packages/app/src/components/Contract.vue
+++ b/packages/app/src/components/Contract.vue
@@ -22,7 +22,7 @@
             <EmptyState>
               <template #image>
                 <div class="balances-empty-icon">
-                  <img src="/images/empty-state/empty_balance.svg" alt="empty_balance" />
+                  <img :src="resolveAsset('/images/empty-state/empty_balance.svg')" alt="empty_balance" />
                 </div>
               </template>
               <template #title>
@@ -45,7 +45,7 @@
             <EmptyState>
               <template #image>
                 <div class="balances-empty-icon">
-                  <img src="/images/empty-state/error_balance.svg" alt="empty_balance" />
+                  <img :src="resolveAsset('/images/empty-state/error_balance.svg')" alt="empty_balance" />
                 </div>
               </template>
               <template #title>
@@ -110,6 +110,7 @@ import useRuntimeConfig from "@/composables/useRuntimeConfig";
 import type { BreadcrumbItem } from "@/components/common/Breadcrumbs.vue";
 import type { Contract } from "@/composables/useAddress";
 
+import { resolveAsset } from "@/utils/appBase";
 import { shortValue } from "@/utils/formatters";
 
 const { t } = useI18n();

--- a/packages/app/src/components/NetworkSwitch.vue
+++ b/packages/app/src/components/NetworkSwitch.vue
@@ -2,7 +2,7 @@
   <Listbox as="div" :model-value="selected" class="network-switch">
     <ListboxButton class="toggle-button">
       <span class="network-item">
-        <img :src="currentNetwork.icon" alt="ZKsync arrows logo" class="network-item-img" />
+        <img :src="resolveAsset(currentNetwork.icon)" alt="ZKsync arrows logo" class="network-item-img" />
         <span class="network-item-label">{{ currentNetwork.l2NetworkName }}</span>
       </span>
       <span class="toggle-button-icon-wrapper">
@@ -26,7 +26,11 @@
               :class="{ selected }"
             >
               <span class="network-item">
-                <img :src="network.icon" :alt="`${network.l2NetworkName} logo`" class="network-item-img" />
+                <img
+                  :src="resolveAsset(network.icon)"
+                  :alt="`${network.l2NetworkName} logo`"
+                  class="network-item-img"
+                />
                 <span class="network-item-label network-list-item-label">{{ network.l2NetworkName }} </span>
               </span>
               <MinusCircleIcon v-if="network.maintenance" class="maintenance-icon" aria-hidden="true" />
@@ -50,6 +54,7 @@ import useContext from "@/composables/useContext";
 
 import type { NetworkConfig } from "@/configs";
 
+import { resolveAsset, resolveBase } from "@/utils/appBase";
 import { getWindowLocation } from "@/utils/helpers";
 
 const { networks: allNetworks, currentNetwork } = useContext();
@@ -65,7 +70,7 @@ const getNetworkUrl = (network: NetworkConfig) => {
   const hostname = getWindowLocation().hostname;
 
   if (hostname === "localhost" || hostname.endsWith("web.app") || !network.hostnames?.length) {
-    return `${route.path}?network=${network.name}`;
+    return `${resolveBase(route.path)}?network=${network.name}`;
   }
   return network.hostnames[0] + route.path;
 };

--- a/packages/app/src/components/Token.vue
+++ b/packages/app/src/components/Token.vue
@@ -8,7 +8,7 @@
       <img
         v-if="contract?.address && !pending && tokenInfo"
         class="token-img"
-        :src="tokenInfo.iconURL || '/images/currencies/customToken.svg'"
+        :src="resolveAsset(tokenInfo.iconURL || '/images/currencies/customToken.svg')"
         :alt="tokenInfo.symbol || t('balances.table.unknownSymbol')"
       />
     </div>
@@ -88,6 +88,7 @@ import useTokenOverview from "@/composables/useTokenOverview";
 import type { BreadcrumbItem } from "@/components/common/Breadcrumbs.vue";
 import type { Contract } from "@/composables/useAddress";
 
+import { resolveAsset } from "@/utils/appBase";
 import { shortValue } from "@/utils/formatters";
 
 const { t } = useI18n();

--- a/packages/app/src/components/TokenIconLabel.vue
+++ b/packages/app/src/components/TokenIconLabel.vue
@@ -60,6 +60,8 @@ import useRuntimeConfig from "@/composables/useRuntimeConfig";
 
 import type { Hash } from "@/types";
 
+import { resolveAsset } from "@/utils/appBase";
+
 export type IconSize = "sm" | "md" | "lg" | "xl";
 
 const { t } = useI18n();
@@ -97,7 +99,7 @@ const props = defineProps({
 });
 
 const imgSource = computed(() => {
-  return props.iconUrl || "/images/currencies/customToken.svg";
+  return resolveAsset(props.iconUrl || "/images/currencies/customToken.svg");
 });
 const { isReady: isImageLoaded } = useImage({ src: imgSource.value });
 </script>

--- a/packages/app/src/components/contract/ContractInfoTab.vue
+++ b/packages/app/src/components/contract/ContractInfoTab.vue
@@ -57,14 +57,14 @@
           <div class="proxy-implementation-link">
             <Alert v-if="contract.proxyInfo?.implementation.verificationInfo" class="w-fit" type="notification">
               <span>{{ t("contract.abiInteraction.contractImplementationFound") }}&nbsp;</span>
-              <a :href="`/address/${contract.proxyInfo?.implementation.address}#contract`">
+              <a :href="resolveBase(`/address/${contract.proxyInfo?.implementation.address}#contract`)">
                 <HashLabel :text="contract.proxyInfo?.implementation.address" /> </a
               >{{ "." }}
               <span>{{ t("contract.abiInteraction.proxyCautionMessage") }}</span>
             </Alert>
             <Alert v-else class="w-fit" type="warning">
               <span>{{ t("contract.abiInteraction.contractImplementationAt") }}&nbsp;</span>
-              <a :href="`/address/${contract.proxyInfo?.implementation.address}#contract`">
+              <a :href="resolveBase(`/address/${contract.proxyInfo?.implementation.address}#contract`)">
                 <HashLabel :text="contract.proxyInfo?.implementation.address" />
               </a>
               <span class="to-lowercase">&nbsp;{{ t("contract.abiInteraction.contractNotVerified") }}.</span>
@@ -98,14 +98,14 @@
           <div class="proxy-implementation-link">
             <Alert v-if="contract.proxyInfo?.implementation.verificationInfo" class="w-fit" type="notification">
               <span>{{ t("contract.abiInteraction.contractImplementationFound") }}&nbsp;</span>
-              <a :href="`/address/${contract.proxyInfo?.implementation.address}#contract`">
+              <a :href="resolveBase(`/address/${contract.proxyInfo?.implementation.address}#contract`)">
                 <HashLabel :text="contract.proxyInfo?.implementation.address" /> </a
               >{{ "." }}
               <span>{{ t("contract.abiInteraction.proxyCautionMessage") }}</span>
             </Alert>
             <Alert v-else class="w-fit" type="warning">
               <span>{{ t("contract.abiInteraction.contractImplementationAt") }}&nbsp;</span>
-              <a :href="`/address/${contract.proxyInfo?.implementation.address}#contract`">
+              <a :href="resolveBase(`/address/${contract.proxyInfo?.implementation.address}#contract`)">
                 <HashLabel :text="contract.proxyInfo?.implementation.address" />
               </a>
               <span class="to-lowercase">&nbsp;{{ t("contract.abiInteraction.contractNotVerified") }}.</span>
@@ -157,6 +157,8 @@ import useRuntimeConfig from "@/composables/useRuntimeConfig";
 
 import type { Contract } from "@/composables/useAddress";
 import type { PropType } from "vue";
+
+import { resolveBase } from "@/utils/appBase";
 
 const runtimeConfig = useRuntimeConfig();
 const props = defineProps({

--- a/packages/app/src/components/header/TheHeader.vue
+++ b/packages/app/src/components/header/TheHeader.vue
@@ -5,7 +5,7 @@
         <div class="logo-container">
           <router-link :to="{ name: 'home' }">
             <span class="sr-only">ZKsync</span>
-            <img v-if="currentNetwork.logoUrl" :src="currentNetwork.logoUrl" />
+            <img v-if="currentNetwork.logoUrl" :src="resolveAsset(currentNetwork.logoUrl)" />
             <zk-sync-era v-else-if="currentNetwork.groupId === 'era'" />
             <zk-sync-arrows-logo v-else />
           </router-link>
@@ -56,7 +56,11 @@
       class="hero-banner-container"
       :class="[`${currentNetwork.name}`, { 'home-banner': route.path === '/' }]"
     >
-      <img v-if="currentNetwork.heroBannerImageUrl" class="hero-image" :src="currentNetwork.heroBannerImageUrl" />
+      <img
+        v-if="currentNetwork.heroBannerImageUrl"
+        class="hero-image"
+        :src="resolveAsset(currentNetwork.heroBannerImageUrl)"
+      />
       <hero-arrows v-else class="hero-image" />
     </div>
     <transition
@@ -72,7 +76,7 @@
           <div class="mobile-header-container">
             <div class="mobile-popover-navigation">
               <div class="popover-zksync-logo">
-                <img v-if="currentNetwork.logoInverseUrl" :src="currentNetwork.logoInverseUrl" />
+                <img v-if="currentNetwork.logoInverseUrl" :src="resolveAsset(currentNetwork.logoInverseUrl)" />
                 <zk-sync v-else class="logo" />
               </div>
               <div class="-mr-2">
@@ -159,6 +163,7 @@ import useContext from "@/composables/useContext";
 import useLocalization from "@/composables/useLocalization";
 import useRuntimeConfig from "@/composables/useRuntimeConfig";
 
+import { resolveAsset } from "@/utils/appBase";
 import { isAddress, isBlockNumber, isTransactionHash } from "@/utils/validators";
 const { changeLanguage } = useLocalization();
 const { t, locale } = useI18n({ useScope: "global" });

--- a/packages/app/src/components/prividium/NetworkIndicator.vue
+++ b/packages/app/src/components/prividium/NetworkIndicator.vue
@@ -6,7 +6,7 @@
     <template v-else>
       <span class="network-item">
         <img
-          :src="context.currentNetwork.value.icon"
+          :src="resolveAsset(context.currentNetwork.value.icon)"
           :alt="`${context.currentNetwork.value.l2NetworkName} logo`"
           class="network-item-img"
         />
@@ -21,6 +21,8 @@ import { computed } from "vue";
 
 import useContext from "@/composables/useContext";
 import useWallet from "@/composables/useWallet";
+
+import { resolveAsset } from "@/utils/appBase";
 
 const context = useContext();
 const { isConnectedWrongNetwork } = useWallet({

--- a/packages/app/src/components/prividium/WalletButton.vue
+++ b/packages/app/src/components/prividium/WalletButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="wallet-button" :class="{ disabled: buttonDisabled }" @click="openModalConditionally">
-    <img src="/images/metamask.svg" class="wallet-image" />
+    <img :src="resolveAsset('/images/metamask.svg')" class="wallet-image" />
     <button v-if="!displayAddress" :disabled="buttonDisabled" class="login-button" @click="handleLogin">
       {{ buttonText }}
     </button>
@@ -39,6 +39,7 @@ import useEnvironmentConfig from "@/composables/useEnvironmentConfig";
 import useLogin from "@/composables/useLogin";
 import { isAuthenticated, default as useWallet } from "@/composables/useWallet";
 
+import { resolveAsset } from "@/utils/appBase";
 import { formatShortAddress } from "@/utils/formatters";
 import logger from "@/utils/logger";
 

--- a/packages/app/src/components/prividium/WalletInfoModal.vue
+++ b/packages/app/src/components/prividium/WalletInfoModal.vue
@@ -54,6 +54,8 @@ import Popup from "@/components/common/Popup.vue";
 import useContext from "@/composables/useContext";
 import useLogin from "@/composables/useLogin";
 
+import { resolveBase } from "@/utils/appBase";
+
 const props = defineProps({
   opened: {
     type: Boolean,
@@ -92,7 +94,7 @@ const handleWalletSwitch = async (newAddress: string) => {
   try {
     isSwitching.value = true;
     await switchWallet(newAddress);
-    window.location.href = "/"; // Triggers full reload of the page
+    window.location.href = resolveBase("/"); // Triggers full reload of the page
     emit("close");
   } catch (error) {
     console.error("Failed to switch wallet:", error);

--- a/packages/app/src/composables/useFetchInstance.ts
+++ b/packages/app/src/composables/useFetchInstance.ts
@@ -5,6 +5,8 @@ import useContext from "./useContext";
 import type { Context } from "./useContext";
 import type { FetchOptions, FetchResponse } from "ohmyfetch";
 
+import { resolveBase } from "@/utils/appBase";
+
 type OnResponse = (args: { response: FetchResponse<unknown> }) => void | Promise<void>;
 
 export class FetchInstance {
@@ -18,7 +20,7 @@ export class FetchInstance {
 
       // API invalidated the session
       context.user.value = { loggedIn: false };
-      window.location.href = `/login?redirect=${encodeURIComponent(window.location.pathname)}`;
+      window.location.href = `${resolveBase("/login")}?redirect=${encodeURIComponent(window.location.pathname)}`;
     });
   }
 

--- a/packages/app/src/composables/useLogin.ts
+++ b/packages/app/src/composables/useLogin.ts
@@ -7,6 +7,7 @@ import { FetchInstance } from "./useFetchInstance";
 import type { Context } from "./useContext";
 
 import { PrividiumAuth } from "@/lib/prividium-auth";
+import { resolveBase } from "@/utils/appBase";
 
 type LoginState = {
   isLoginPending: boolean;
@@ -37,7 +38,7 @@ export default (context: Context, _logger = defaultLogger): UseLogin => {
     if (!prividiumAuth) {
       prividiumAuth = new PrividiumAuth({
         clientId: "block-explorer",
-        redirectUri: new URL("auth/callback", window.location.origin).toString(),
+        redirectUri: new URL(resolveBase("/auth/callback"), window.location.origin).toString(),
         userPanelUrl: context.currentNetwork.value.userPanelUrl!,
       });
     }

--- a/packages/app/src/composables/useNotFound.ts
+++ b/packages/app/src/composables/useNotFound.ts
@@ -1,6 +1,8 @@
 import { type Ref, watch } from "vue";
 import { useRouter } from "vue-router";
 
+import { resolveBase } from "@/utils/appBase";
+
 export default () => {
   const router = useRouter();
   const notFoundRoute = router.resolve({ name: "not-found" });
@@ -8,7 +10,7 @@ export default () => {
   async function setNotFoundView() {
     const fullPath = router.currentRoute.value.fullPath;
     await router.replace(notFoundRoute);
-    history.replaceState({}, notFoundRoute.meta.title as string, fullPath);
+    history.replaceState({}, notFoundRoute.meta.title as string, resolveBase(fullPath));
   }
 
   async function useNotFoundView(...refs: Ref[]) {

--- a/packages/app/src/composables/useWallet.ts
+++ b/packages/app/src/composables/useWallet.ts
@@ -9,6 +9,7 @@ import defaultLogger from "./../utils/logger";
 import type { BaseProvider } from "@metamask/providers";
 import type { AbstractSigner, JsonRpcProvider } from "ethers";
 
+import { appPrefix } from "@/utils/appBase";
 import { numberToHexString } from "@/utils/formatters";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -280,7 +281,7 @@ export default (
               decimals: 18,
             },
             rpcUrls: [rpcUrl],
-            blockExplorerUrls: [window.location.origin],
+            blockExplorerUrls: [window.location.origin + appPrefix],
             iconUrls: ["https://zksync.io/favicon.ico"],
           },
         ],

--- a/packages/app/src/lib/prividium-auth/index.ts
+++ b/packages/app/src/lib/prividium-auth/index.ts
@@ -1,5 +1,7 @@
 import { AUTH_ERRORS, PRIVIDIUM_AUTH_CONSTANTS } from "./constants";
 
+import { appPrefix } from "@/utils/appBase";
+
 export interface PrividiumAuthConfig {
   clientId: string;
   redirectUri: string;
@@ -117,7 +119,7 @@ export class PrividiumAuth {
     if (this.userPanelUrl) {
       window.location.href = `${this.userPanelUrl}${
         PRIVIDIUM_AUTH_CONSTANTS.AUTH_ENDPOINTS.LOGOUT
-      }?post_logout_redirect_uri=${encodeURIComponent(window.location.origin)}`;
+      }?post_logout_redirect_uri=${encodeURIComponent(window.location.origin + appPrefix)}`;
     }
   }
 

--- a/packages/app/src/router/index.ts
+++ b/packages/app/src/router/index.ts
@@ -5,8 +5,12 @@ import routes from "./routes";
 import useContext from "@/composables/useContext";
 import useRuntimeConfig from "@/composables/useRuntimeConfig";
 
+import { appBase } from "@/utils/appBase";
+
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  // Not import.meta.env.BASE_URL: that is Vite's `base`, which is used as the asset placeholder.
+  // The router base must be the runtime app base (window.__APP_BASE__).
+  history: createWebHistory(appBase),
   routes,
 });
 

--- a/packages/app/src/utils/appBase.ts
+++ b/packages/app/src/utils/appBase.ts
@@ -1,0 +1,23 @@
+// Runtime app base and assets base, published on `window` by a script in index.html.
+declare global {
+  interface Window {
+    __APP_BASE__?: string;
+    __ASSETS_BASE__?: string;
+  }
+}
+
+export const appPrefix = ((typeof window !== "undefined" && window.__APP_BASE__) || "/").replace(/\/+$/, "");
+export const appBase = `${appPrefix}/`;
+
+const assetsBase = (typeof window !== "undefined" && window.__ASSETS_BASE__) || appBase;
+
+export function resolveAsset(path: string): string {
+  if (!path || /^[a-z][a-z0-9+.-]*:/i.test(path) || path.startsWith("//")) {
+    return path;
+  }
+  return assetsBase.replace(/\/$/, "") + "/" + path.replace(/^\//, "");
+}
+
+export function resolveBase(path: string): string {
+  return appPrefix + path;
+}

--- a/packages/app/src/views/AuthCallbackView.vue
+++ b/packages/app/src/views/AuthCallbackView.vue
@@ -2,7 +2,11 @@
   <div
     class="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-slate-50 via-white to-blue-50 px-4 py-12 sm:px-6 lg:px-8"
   >
-    <img :src="currentNetwork.logoUrl || '/images/prividium_logo.svg'" alt="Logo" class="mb-6 h-16 w-auto" />
+    <img
+      :src="resolveAsset(currentNetwork.logoUrl || '/images/prividium_logo.svg')"
+      alt="Logo"
+      class="mb-6 h-16 w-auto"
+    />
 
     <!-- Loading state (no card) -->
     <div v-if="!error" class="text-center">
@@ -36,6 +40,8 @@ import { FetchError } from "ohmyfetch";
 import useContext from "@/composables/useContext";
 import useLogin from "@/composables/useLogin";
 
+import { resolveAsset, resolveBase } from "@/utils/appBase";
+
 const { t } = useI18n();
 
 const router = useRouter();
@@ -61,7 +67,7 @@ const redirectToLogin = () => {
 onMounted(async () => {
   try {
     const { redirect } = await handlePrividiumCallback();
-    await router.push(isValidRedirectPath(redirect) ? redirect : "/");
+    window.location.href = isValidRedirectPath(redirect) ? redirect : resolveBase("/");
   } catch (err: unknown) {
     console.error("Auth callback failed:", err);
 

--- a/packages/app/src/views/LoginView.vue
+++ b/packages/app/src/views/LoginView.vue
@@ -3,7 +3,11 @@
     class="flex min-h-screen flex-col justify-center bg-gradient-to-br from-slate-50 via-white to-blue-50 px-4 py-12 sm:px-6 lg:px-8"
   >
     <div class="mb-6 text-center sm:mx-auto sm:w-full sm:max-w-md">
-      <img :src="currentNetwork.logoUrl || '/images/prividium_logo.svg'" alt="Logo" class="mx-auto mb-4 h-16 w-auto" />
+      <img
+        :src="resolveAsset(currentNetwork.logoUrl || '/images/prividium_logo.svg')"
+        alt="Logo"
+        class="mx-auto mb-4 h-16 w-auto"
+      />
       <h1 class="mb-2 bg-gradient-to-r from-blue-600 to-blue-800 bg-clip-text text-4xl font-bold text-transparent">
         {{ t("loginView.explorerTitle") }}
       </h1>
@@ -37,6 +41,8 @@ import { FetchError } from "ohmyfetch";
 import useContext from "@/composables/useContext";
 import useLogin from "@/composables/useLogin";
 import useRuntimeConfig from "@/composables/useRuntimeConfig";
+
+import { resolveAsset, resolveBase } from "@/utils/appBase";
 
 const { t } = useI18n();
 const { brandName } = useRuntimeConfig();
@@ -73,7 +79,7 @@ const isValidRedirectPath = (path: unknown): path is string => {
 watchEffect(() => {
   if (context.user.value.loggedIn) {
     const redirectPath = route.query.redirect;
-    router.push(isValidRedirectPath(redirectPath) ? redirectPath : "/");
+    window.location.href = isValidRedirectPath(redirectPath) ? redirectPath : resolveBase("/");
   }
 });
 </script>

--- a/packages/app/src/views/NotAuthorizedView.vue
+++ b/packages/app/src/views/NotAuthorizedView.vue
@@ -2,7 +2,11 @@
   <div
     class="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-slate-50 via-white to-blue-50 px-4 py-12"
   >
-    <img :src="currentNetwork.logoUrl || '/images/prividium_logo.svg'" alt="Logo" class="mb-6 h-16 w-auto" />
+    <img
+      :src="resolveAsset(currentNetwork.logoUrl || '/images/prividium_logo.svg')"
+      alt="Logo"
+      class="mb-6 h-16 w-auto"
+    />
 
     <div class="sm:mx-auto sm:w-full sm:max-w-md">
       <div class="rounded-2xl border border-gray-200 bg-white px-6 py-10 text-center shadow-xl sm:px-12">
@@ -31,6 +35,8 @@ import { useRouter } from "vue-router";
 import { LockClosedIcon } from "@heroicons/vue/outline";
 
 import useContext from "@/composables/useContext";
+
+import { resolveAsset } from "@/utils/appBase";
 
 const { t } = useI18n();
 const router = useRouter();

--- a/packages/app/tests/composables/useEventLog.spec.ts
+++ b/packages/app/tests/composables/useEventLog.spec.ts
@@ -58,6 +58,7 @@ describe("useEventLog:", () => {
   });
   it("returns raw logs in case account request failed", async () => {
     const mock = ($fetch as unknown as SpyInstance).mockRejectedValue(new Error("An error occurred"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const { collection, isDecodePending, isDecodeFailed, decodeEventLog } = useEventLog();
     const logWithNewAddress = [
       {
@@ -69,6 +70,8 @@ describe("useEventLog:", () => {
     expect(isDecodePending.value).toEqual(false);
     expect(isDecodeFailed.value).toEqual(true);
     expect(collection.value).toEqual(logWithNewAddress);
+    expect(errorSpy).toHaveBeenCalledWith("Error fetching event names:", expect.any(Error));
+    errorSpy.mockRestore();
     mock.mockRestore();
   });
   it("decodes logs successfully", async () => {

--- a/packages/app/tests/utils/appBase.spec.ts
+++ b/packages/app/tests/utils/appBase.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// appBase/appPrefix are module-level consts read from window at import time, so each scenario sets the
+// window globals, resets the module registry, and re-imports to get freshly-evaluated values.
+async function loadAppBase(appBase?: string, assetsBase?: string) {
+  vi.resetModules();
+  if (appBase === undefined) {
+    delete (window as unknown as { __APP_BASE__?: string }).__APP_BASE__;
+  } else {
+    (window as unknown as { __APP_BASE__?: string }).__APP_BASE__ = appBase;
+  }
+  if (assetsBase === undefined) {
+    delete (window as unknown as { __ASSETS_BASE__?: string }).__ASSETS_BASE__;
+  } else {
+    (window as unknown as { __ASSETS_BASE__?: string }).__ASSETS_BASE__ = assetsBase;
+  }
+  return import("@/utils/appBase");
+}
+
+afterEach(() => {
+  delete (window as unknown as { __APP_BASE__?: string }).__APP_BASE__;
+  delete (window as unknown as { __ASSETS_BASE__?: string }).__ASSETS_BASE__;
+  vi.resetModules();
+});
+
+describe("appBase / appPrefix", () => {
+  it("defaults to root when no base is configured", async () => {
+    const { appBase, appPrefix } = await loadAppBase();
+    expect(appPrefix).toBe("");
+    expect(appBase).toBe("/");
+  });
+
+  it("derives prefix and base from a subpath", async () => {
+    const { appBase, appPrefix } = await loadAppBase("/explorer/");
+    expect(appPrefix).toBe("/explorer");
+    expect(appBase).toBe("/explorer/");
+  });
+
+  it("normalizes a subpath without a trailing slash", async () => {
+    const { appBase, appPrefix } = await loadAppBase("/explorer");
+    expect(appPrefix).toBe("/explorer");
+    expect(appBase).toBe("/explorer/");
+  });
+});
+
+describe("resolveBase", () => {
+  it("returns the path unchanged at root", async () => {
+    const { resolveBase } = await loadAppBase();
+    expect(resolveBase("/login")).toBe("/login");
+    expect(resolveBase("/")).toBe("/");
+  });
+
+  it("prefixes the path with the base under a subpath", async () => {
+    const { resolveBase } = await loadAppBase("/explorer/");
+    expect(resolveBase("/login")).toBe("/explorer/login");
+    expect(resolveBase("/")).toBe("/explorer/");
+    expect(resolveBase("/tx/0xabc")).toBe("/explorer/tx/0xabc");
+  });
+});
+
+describe("resolveAsset", () => {
+  it("resolves against the app base when no assets base is set", async () => {
+    const root = await loadAppBase();
+    expect(root.resolveAsset("/images/x.svg")).toBe("/images/x.svg");
+
+    const sub = await loadAppBase("/explorer/");
+    expect(sub.resolveAsset("/images/x.svg")).toBe("/explorer/images/x.svg");
+    expect(sub.resolveAsset("images/x.svg")).toBe("/explorer/images/x.svg");
+  });
+
+  it("resolves against the assets base (CDN) when set, independent of the app base", async () => {
+    const { resolveAsset, resolveBase } = await loadAppBase("/explorer/", "https://cdn.example.com/123/");
+    expect(resolveAsset("/images/x.svg")).toBe("https://cdn.example.com/123/images/x.svg");
+    // resolveBase still uses the app base, not the CDN.
+    expect(resolveBase("/login")).toBe("/explorer/login");
+  });
+
+  it("passes through external, protocol-relative, data: and empty paths unchanged", async () => {
+    const { resolveAsset } = await loadAppBase("/explorer/", "https://cdn.example.com/");
+    expect(resolveAsset("https://other.example.com/icon.svg")).toBe("https://other.example.com/icon.svg");
+    expect(resolveAsset("http://other.example.com/icon.svg")).toBe("http://other.example.com/icon.svg");
+    expect(resolveAsset("//other.example.com/icon.svg")).toBe("//other.example.com/icon.svg");
+    expect(resolveAsset("data:image/svg+xml;base64,abc")).toBe("data:image/svg+xml;base64,abc");
+    expect(resolveAsset("")).toBe("");
+  });
+});

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig } from "vite";
 
 import vue from "@vitejs/plugin-vue";
+import MagicString from "magic-string";
 import { fileURLToPath, URL } from "url";
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
+  // Every build bakes the sentinel base, so the bundle is byte-identical for Docker and regular builds
+  // (the runtime-asset-base plugin then turns it into a window.__ASSETS_BASE__ read). A single set of
+  // chunk hashes means one Sentry sourcemap upload matches every deployment. The dev server serves its
+  // own bundle (no CDN, no build-only plugin), so it just mounts at the app base path.
+  base: command === "build" ? "/__ASSET_BASE__/" : process.env.APP_BASE || "/",
   server: {
     port: 3010,
   },
@@ -52,10 +58,47 @@ export default defineConfig({
     {
       name: "html-transform",
       transformIndexHtml(html) {
+        // Docker: leave the sentinel + {{ }} templates for gomplate/sed to resolve at container start.
         if (process.env.DOCKER_BUILD === "true") {
           return html;
         }
-        return replaceEnvVariables(html);
+        // Non-Docker: resolve the templates now and point the sentinel asset URLs at the
+        // serving base — the CDN origin if STATIC_ASSETS_URL is set at build time, else the app base
+        // The JS is untouched — it reads window.__ASSETS_BASE__.
+        return replaceEnvVariables(html).replace(
+          /\/__ASSET_BASE__\//g,
+          (process.env.STATIC_ASSETS_URL || process.env.APP_BASE || "/").replace(/\/?$/, "/")
+        );
+      },
+    },
+    {
+      // Every build bakes the asset base as the sentinel "/__ASSET_BASE__/". Rewrite the standalone
+      // preload-base constant into a runtime read of window.__ASSETS_BASE__ (set by index.html), so the
+      // served bundle resolves its lazy-chunk/CSS URLs at runtime and never has to be edited on disk —
+      // which keeps the sourcemaps aligned and the bundle identical across Docker and regular builds. Done
+      // with magic-string so the emitted .map tracks the edit. (Static image refs go through
+      // resolveAsset(), so the sentinel only appears here as a standalone quoted token; image literals
+      // like "/__ASSET_BASE__/images/x.svg" are intentionally not matched.)
+      name: "runtime-asset-base",
+      apply: "build",
+      enforce: "post",
+      renderChunk(code, chunk) {
+        const s = new MagicString(code);
+        // Narrow on purpose: only the standalone quoted token (the preload-base const), never a sentinel
+        // embedded in a longer asset literal — those stay intact and are caught by the guard below.
+        s.replaceAll(/(["'])\/__ASSET_BASE__\/\1/g, '(window.__ASSETS_BASE__||"/")');
+        // A surviving sentinel means an asset got bundled as "/__ASSET_BASE__/assets/…" (e.g. an
+        // `import x from "*.svg"`), which neither this plugin nor the runtime sed resolves — reference
+        // such assets by path through resolveAsset() instead.
+        if (s.toString().includes("/__ASSET_BASE__/")) {
+          throw new Error(
+            `Unresolved /__ASSET_BASE__/ left in ${chunk.fileName} — don't bundle asset imports; use resolveAsset() with a path.`
+          );
+        }
+        if (!s.hasChanged()) {
+          return null;
+        }
+        return { code: s.toString(), map: s.generateMap({ hires: true }) };
       },
     },
   ],
@@ -80,15 +123,25 @@ export default defineConfig({
     __VUE_I18N_LEGACY_API__: false,
     __INTLIFY_PROD_DEVTOOLS__: false,
   },
-});
+}));
 
 function replaceEnvVariables(template: string): string {
-  // Regex matches either:
-  // {{ getenv "VAR" | default "fallback" }}  OR  {{ getenv "VAR" }}
-  const regex = /\{\{\s*getenv\s*"([^"]+)"(?:\s*\|\s*default\s*"([^"]*)")?\s*\}\}/g;
+  // Resolves the gomplate-style placeholders used in index.html for the non-Docker (static) build.
+  // (For Docker builds DOCKER_BUILD=true skips this and gomplate resolves them at container start.)
+  // Supported forms:
+  //   {{ getenv "VAR" }}
+  //   {{ getenv "VAR" | default "fallback" }}
+  //   {{ getenv "VAR" | default (print (getenv "APP_BASE" "/") "defaultValue") }}   (base-prefixed default)
+  const regex =
+    /\{\{\s*getenv\s*"([^"]+)"(?:\s*\|\s*default\s+(?:"([^"]*)"|\(\s*print\s+\(\s*getenv\s+"([^"]+)"\s+"([^"]*)"\s*\)\s+"([^"]*)"\s*\)))?\s*\}\}/g;
 
-  return template.replace(regex, (_, varName, fallback) => {
-    // If env var exists, use it; else fallback if provided; else empty string
+  return template.replace(regex, (_match, varName, quotedFallback, baseVar, baseDefault, defaultValue) => {
+    let fallback = quotedFallback;
+    if (fallback === undefined && baseVar !== undefined) {
+      // default (print (getenv baseVar baseDefault) defaultValue)  ->  (APP_BASE || "/") + defaultValue
+      fallback = (process.env[baseVar] ?? baseDefault ?? "") + (defaultValue ?? "");
+    }
+    // If env var exists, use it
     return process.env[varName] ?? fallback ?? "";
   });
 }


### PR DESCRIPTION
# What ❔

- support custom custom base
- support serving assets from third-party url
- upload static assets to R2 

## Why ❔

- separate storage for static assets makes old assets accessible 

## How it works

Two independent runtime knobs, carried on `window` by a small inline script in `index.html` (filled by **gomplate** at container start for Docker, or `replaceEnvVariables` at build time for regular builds):

- **`window.__APP_BASE__`** — the app base path. Drives the router (`createWebHistory(appBase)`), `config.js`/favicon, same-origin navigations, and the fallback asset base.
- **`window.__ASSETS_BASE__`** — where hashed assets load from (the CDN origin, optionally a `/<version>/` sub-folder), else the app base.

### Asset base (the tricky part)

Vite 2.9 bakes `base` as a literal string into the bundle, with no runtime hook. To keep **one image** retargetable without rewriting JS on disk (which would desync sourcemaps):

- Every **build** bakes a sentinel base `"/__ASSET_BASE__/"`.
- A small Vite plugin (`runtime-asset-base`, using `magic-string`) rewrites the standalone preload-base constant to `(window.__ASSETS_BASE__||"/")` **at build time**, so the bundle reads the base at runtime and its `.map` stays aligned. A build-time guard throws if any sentinel survives (e.g. a future `import x from "*.svg"`).
- Dynamic `/images` references go through a runtime `resolveAsset()` helper; static `<img>` were converted to it too.
- Only `index.html`'s entry/preload/stylesheet URLs still carry the sentinel; the Docker `CMD` `sed`s those to the chosen base at startup (and injects the CDN origin into the CSP). `config.js` and favicon always stay on the app at `APP_BASE`.

Because the bundle is **byte-identical** across Docker and regular builds, a single Sentry sourcemap upload matches every deployment.

### App base path

`resolveBase()` / `appPrefix` prefix same-origin app paths; `resolveAsset()` handles assets. All base-sensitive spots that bypass the router were updated: the 401 login redirect (`useFetchInstance`), OAuth `redirect_uri` (`useLogin`), MetaMask `blockExplorerUrls` (`useWallet`), OAuth `post_logout_redirect_uri` (`prividium-auth`), logout reload (`WalletInfoModal`), not-found `history.replaceState` (`useNotFound`), the network-switch URL (`NetworkSwitch`), the login redirect query (`App.vue`), post-login navigation (`LoginView`/`AuthCallbackView`), and the header/network logos (`TheHeader` and friends).

## Runtime configuration (container env)

| Var | Default | Purpose |
| --- | --- | --- |
| `APP_BASE` | `/` | Base path the app is served under (e.g. `/explorer/`). |
| `STATIC_ASSETS_URL` | _(empty)_ | CDN/R2 origin to load hashed assets + `/images` from. Empty = serve from the app. |
| `STATIC_ASSETS_VERSIONED` | `true` | When the CDN is set, read assets from a `/<VITE_VERSION>/` sub-folder; `false` = flat. |

> Note: serving under a subpath assumes a **prefix-preserving reverse proxy** in front (nginx is intentionally left mounting at `/`).

## CI / publishing

New `publishStaticAssetsToR2` job (runs **before** the App image is pushed, only when configured): downloads the released `dist.zip` (byte-identical to the image), uploads `assets/` + `images/` to `<upload-folder>/<version>/`, and prunes to the newest **100** versions. The App image push is gated so a real upload failure blocks it, while an unconfigured/skipped upload doesn't.

GitHub configuration:

| Kind | Name | Example / notes |
| --- | --- | --- |
| var | `STATIC_ASSETS_UPLOAD_FOLDER` | `bucket/explorer` — S3 destination; also the on/off switch. Path must match `STATIC_ASSETS_URL`. |
| var | `STATIC_ASSETS_S3_ENDPOINT` | `https://<account>.r2.cloudflarestorage.com` |
| secret | `STATIC_ASSETS_ACCESS_KEY_ID` | R2 S3 API key id |
| secret | `STATIC_ASSETS_SECRET_ACCESS_KEY` | R2 S3 API secret |

## Operator notes

- **CORS**: the bundle's ES-module scripts are fetched cross-origin, so the CDN/R2 bucket **must** return `Access-Control-Allow-Origin` for the app origin(s), or the app won't load.
- The CDN URL must be the bucket's **public** URL (R2.dev or a custom domain), not the `…r2.cloudflarestorage.com` S3 endpoint (that's upload-only).
- `STATIC_ASSETS_UPLOAD_FOLDER` (CI) and `STATIC_ASSETS_URL` (runtime) must point at the same location.

## Testing

- Unit tests, `vue-tsc` typecheck, and ESLint all pass; added `tests/utils/appBase.spec.ts` covering `appBase`/`appPrefix`/`resolveBase`/`resolveAsset` at root, subpath, and CDN/versioned.
- Verified Docker and non-Docker builds produce identical chunk hashes; validated the gomplate + `sed` runtime substitution end-to-end for default / custom-base / CDN(±versioned) modes.
- Prividium auth e2e (`@prividium`) exercises the login/redirect paths touched here.
