### PR TITLE
ci: repoint storybook hosting to recreated -2 site

### DIFF
--- a/packages/app/.firebaserc
+++ b/packages/app/.firebaserc
@@ -19,7 +19,7 @@
           "staging-scan-v2-zksyncos"
         ],
         "storybook": [
-          "staging-storybook-scan-v2-zksyncos"
+          "staging-storybook-scan-v2-zksyncos-2"
         ]
       }
     }


### PR DESCRIPTION
The `staging-storybook-scan-v2-zksyncos` Firebase Hosting site was deleted and is reservation-locked by Firebase, so channel deploys 404 (e.g. PR #627 feature-branch deploy). Recreated the site as `staging-storybook-scan-v2-zksyncos-2` and repoint the `.firebaserc` storybook target to it. Same project, so the existing deploy runner identity already has access - no SA/secret change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)