### PR TITLE
fix: upload assets to R2 from the built docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,70 +52,16 @@ jobs:
         run: |
             npx semantic-release
 
-  # Publish the app's assets + public images to the R2 bucket before the App image is pushed so the files are already in place when it goes live.
-  publishStaticAssetsToR2:
-    name: Publish app static assets to R2
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    needs: createReleaseVersion
-    if: ${{ github.ref == 'refs/heads/main' && needs.createReleaseVersion.outputs.releaseVersion != '' }}
-    # STATIC_ASSETS_UPLOAD_FOLDER is a secret, and secrets can't be referenced in `if:` — so mirror it
-    # into a job-level env and gate the steps on that (empty = R2 not configured -> steps skip).
-    env:
-      STATIC_ASSETS_UPLOAD_FOLDER: ${{ secrets.STATIC_ASSETS_UPLOAD_FOLDER }}
-    steps:
-      - name: Download Dist package
-        if: ${{ env.STATIC_ASSETS_UPLOAD_FOLDER != '' }}
-        uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # 1.1.2
-        with:
-          version: "tags/v${{ needs.createReleaseVersion.outputs.releaseVersion }}"
-          file: "dist.zip"
-          target: "dist.zip"
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Unzip Dist package
-        if: ${{ env.STATIC_ASSETS_UPLOAD_FOLDER != '' }}
-        run: |
-          unzip dist.zip
-
-      - name: Publish to R2
-        if: ${{ env.STATIC_ASSETS_UPLOAD_FOLDER != '' }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.STATIC_ASSETS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.STATIC_ASSETS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-          ASSETS_S3_ENDPOINT: ${{ secrets.STATIC_ASSETS_S3_ENDPOINT }}
-        run: |
-          set -e
-          APP_DIST=dist
-          ASSETS_DEST="s3://${STATIC_ASSETS_UPLOAD_FOLDER}"
-          VERSION="${{ needs.createReleaseVersion.outputs.releaseVersion }}"
-
-          aws s3 sync "$APP_DIST/assets" "$ASSETS_DEST/$VERSION/assets" --endpoint-url "$ASSETS_S3_ENDPOINT" \
-            --cache-control "public, max-age=31536000, immutable" --exclude "*.map"
-          aws s3 sync "$APP_DIST/images" "$ASSETS_DEST/$VERSION/images" --endpoint-url "$ASSETS_S3_ENDPOINT" \
-            --cache-control "public, max-age=31536000, immutable"
-
-          # Retention: keep only the newest 100 version folders, delete the rest.
-          KEEP=100
-          STALE=$(aws s3 ls "$ASSETS_DEST/" --endpoint-url "$ASSETS_S3_ENDPOINT" \
-            | awk '/ PRE / {print $2}' | sed 's#/$##' | grep -E '^[0-9]' | sort -V | head -n "-$KEEP" || true)
-          for v in $STALE; do
-            echo "Pruning old asset version: $v"
-            aws s3 rm "$ASSETS_DEST/$v/" --recursive --endpoint-url "$ASSETS_S3_ENDPOINT"
-          done
-
   deployBackendToStaging:
     name: Deploy Block Explorer backend to staging
     runs-on: [matterlabs-ci-runner]
     permissions:
       contents: read
       packages: write
-    needs: [createReleaseVersion, publishStaticAssetsToR2]
-    # always() so a skipped R2 job (bucket not configured) doesn't skip this one; but a real R2
-    # failure does block the image push (assets must be live first).
-    if: ${{ always() && github.ref == 'refs/heads/main' && needs.createReleaseVersion.outputs.releaseVersion != '' && needs.publishStaticAssetsToR2.result != 'failure' && needs.publishStaticAssetsToR2.result != 'cancelled' }}
+    needs: [createReleaseVersion]
+    if: ${{ github.ref == 'refs/heads/main' && needs.createReleaseVersion.outputs.releaseVersion != '' }}
+    env:
+      STATIC_ASSETS_UPLOAD_FOLDER: ${{ secrets.STATIC_ASSETS_UPLOAD_FOLDER }}
     steps:
       - uses: actions/checkout@v3
 
@@ -197,7 +143,53 @@ jobs:
           file: packages/data-fetcher/Dockerfile
           no-cache: true
 
-      - name: Build and push Docker image for App
+      - name: Build Docker image for App
+        uses: docker/build-push-action@v4
+        with:
+          push: false
+          load: ${{ env.STATIC_ASSETS_UPLOAD_FOLDER != '' }}
+          build-args: |
+              VITE_VERSION=${{ needs.createReleaseVersion.outputs.releaseVersion }}
+          tags: "block-explorer-app:ci"
+          file: packages/app/Dockerfile
+          cache-to: type=gha,mode=max,scope=app
+          cache-from: type=gha,scope=app
+
+      # Extract the built static assets (JS/CSS + /images) from the loaded image and upload to R2, so
+      # they are byte-identical to what the published image's index.html references.
+      - name: Upload static assets to R2
+        if: ${{ env.STATIC_ASSETS_UPLOAD_FOLDER != '' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.STATIC_ASSETS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.STATIC_ASSETS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          ASSETS_S3_ENDPOINT: ${{ secrets.STATIC_ASSETS_S3_ENDPOINT }}
+        run: |
+          set -e
+          VERSION="${{ needs.createReleaseVersion.outputs.releaseVersion }}"
+          cid="$(docker create block-explorer-app:ci)"
+          mkdir -p dist
+          docker cp "$cid":/usr/share/nginx/html/assets dist/assets
+          docker cp "$cid":/usr/share/nginx/html/images dist/images
+          docker rm "$cid"
+
+          ASSETS_DEST="s3://${STATIC_ASSETS_UPLOAD_FOLDER}"
+          aws s3 sync dist/assets "$ASSETS_DEST/$VERSION/assets" --endpoint-url "$ASSETS_S3_ENDPOINT" \
+            --cache-control "public, max-age=31536000, immutable" --exclude "*.map"
+          aws s3 sync dist/images "$ASSETS_DEST/$VERSION/images" --endpoint-url "$ASSETS_S3_ENDPOINT" \
+            --cache-control "public, max-age=31536000, immutable"
+
+          # Retention: keep only the newest 100 version folders, delete the rest.
+          KEEP=100
+          STALE=$(aws s3 ls "$ASSETS_DEST/" --endpoint-url "$ASSETS_S3_ENDPOINT" \
+            | awk '/ PRE / {print $2}' | sed 's#/$##' | grep -E '^[0-9]' | sort -V | head -n "-$KEEP" || true)
+          for v in $STALE; do
+            echo "Pruning old asset version: $v"
+            aws s3 rm "$ASSETS_DEST/$v/" --recursive --endpoint-url "$ASSETS_S3_ENDPOINT"
+          done
+
+      # Publish the App image from the gha cache
+      - name: Push Docker image for App
         uses: docker/build-push-action@v4
         with:
           push: true
@@ -214,7 +206,7 @@ jobs:
               "us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/block-explorer-app:v${{ needs.createReleaseVersion.outputs.releaseVersion }}"
               "us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/block-explorer-app:${{ steps.setVersionForFlux.outputs.imageTag }}"
           file: packages/app/Dockerfile
-          no-cache: true
+          cache-from: type=gha,scope=app
 
   sbom-generation:
     name: SBOM


### PR DESCRIPTION
upload assets to R2 from the built docker image (which guarantees exactly the same files) instead of release artifact