### PR TITLE
fix: calculate nonce for accounts without any balance

### DIFF
--- a/packages/api/src/address/address.controller.spec.ts
+++ b/packages/api/src/address/address.controller.spec.ts
@@ -247,6 +247,7 @@ describe("AddressController", () => {
       beforeEach(() => {
         (serviceMock.findOne as jest.Mock).mockResolvedValueOnce(null);
         (blockServiceMock.getLastBlockNumber as jest.Mock).mockResolvedValueOnce(blockNumber);
+        (transactionServiceMock.getAccountNonce as jest.Mock).mockResolvedValueOnce(0).mockResolvedValueOnce(0);
         (balanceServiceMock.getBalances as jest.Mock).mockResolvedValue({
           blockNumber: 0,
           balances: {},
@@ -262,6 +263,20 @@ describe("AddressController", () => {
           balances: {},
           sealedNonce: 0,
           verifiedNonce: 0,
+        });
+      });
+
+      it("still resolves the nonce from account transactions (gasless chains)", async () => {
+        (transactionServiceMock.getAccountNonce as jest.Mock).mockReset();
+        (transactionServiceMock.getAccountNonce as jest.Mock).mockResolvedValueOnce(5).mockResolvedValueOnce(3);
+        const result = await controller.getAddress(blockchainAddress, null);
+        expect(result).toStrictEqual({
+          type: AddressType.Account,
+          address: normalizedAddress,
+          blockNumber,
+          balances: {},
+          sealedNonce: 5,
+          verifiedNonce: 3,
         });
       });
     });

--- a/packages/api/src/address/address.controller.ts
+++ b/packages/api/src/address/address.controller.ts
@@ -110,29 +110,18 @@ export class AddressController {
       };
     }
 
-    if (addressBalance.blockNumber) {
-      const [sealedNonce, verifiedNonce] = await Promise.all([
-        this.transactionService.getAccountNonce({ accountAddress: address }),
-        this.transactionService.getAccountNonce({ accountAddress: address, isVerified: true }),
-      ]);
-
-      return {
-        type: AddressType.Account,
-        address: ethersGetAddress(address),
-        blockNumber: addressBalance.blockNumber,
-        balances: addressBalance.balances,
-        sealedNonce,
-        verifiedNonce,
-      };
-    }
+    const [sealedNonce, verifiedNonce] = await Promise.all([
+      this.transactionService.getAccountNonce({ accountAddress: address }),
+      this.transactionService.getAccountNonce({ accountAddress: address, isVerified: true }),
+    ]);
 
     return {
       type: AddressType.Account,
       address: ethersGetAddress(address),
-      blockNumber: await this.blockService.getLastBlockNumber(),
-      balances: {},
-      sealedNonce: 0,
-      verifiedNonce: 0,
+      blockNumber: addressBalance.blockNumber || (await this.blockService.getLastBlockNumber()),
+      balances: addressBalance.balances,
+      sealedNonce,
+      verifiedNonce,
     };
   }
 


### PR DESCRIPTION
For gassless chains even account which never had any balance can send transactions