### PR TITLE
chore: allow cdn.mementoblockchain.com in img-src CSP

### DIFF
--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -33,7 +33,7 @@ ENV STATIC_ASSETS_URL=
 ENV STATIC_ASSETS_VERSIONED=true
 ARG VITE_VERSION=
 ENV VITE_VERSION=$VITE_VERSION
-ENV CSP_REPORT_ONLY="default-src 'self'; child-src 'self' blob:; script-src 'self' 'unsafe-eval' blob:; connect-src https://*.ingest.sentry.io https://*.zkscan.io https://*.zksync.io https://*.zksync.dev https://storage.googleapis.com; style-src 'self' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; img-src 'self' https://assets.coingecko.com blob: data: https://firebasestorage.googleapis.com/v0/b/token-library.appspot.com/o/;"
+ENV CSP_REPORT_ONLY="default-src 'self'; child-src 'self' blob:; script-src 'self' 'unsafe-eval' blob:; connect-src https://*.ingest.sentry.io https://*.zkscan.io https://*.zksync.io https://*.zksync.dev https://storage.googleapis.com; style-src 'self' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; img-src 'self' https://assets.coingecko.com https://cdn.mementoblockchain.com blob: data: https://firebasestorage.googleapis.com/v0/b/token-library.appspot.com/o/;"
 
 RUN apk add --no-cache gomplate
 

--- a/packages/app/firebase.json
+++ b/packages/app/firebase.json
@@ -36,7 +36,7 @@
             },
             {
               "key": "Content-Security-Policy-Report-Only",
-              "value": "default-src 'self'; child-src 'self' blob:; script-src 'self' 'unsafe-eval' blob:; connect-src https://*.ingest.sentry.io https://firestore.googleapis.com/ https://*.zkscan.io https://*.zksync.io https://*.zksync.dev https://storage.googleapis.com; style-src 'self' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; img-src 'self' https://assets.coingecko.com blob: data: https://firebasestorage.googleapis.com/v0/b/token-library.appspot.com/o/;"
+              "value": "default-src 'self'; child-src 'self' blob:; script-src 'self' 'unsafe-eval' blob:; connect-src https://*.ingest.sentry.io https://firestore.googleapis.com/ https://*.zkscan.io https://*.zksync.io https://*.zksync.dev https://storage.googleapis.com; style-src 'self' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; img-src 'self' https://assets.coingecko.com https://cdn.mementoblockchain.com blob: data: https://firebasestorage.googleapis.com/v0/b/token-library.appspot.com/o/;"
             }
           ]
         }


### PR DESCRIPTION
# What ❔

- Add `https://cdn.mementoblockchain.com` to the `img-src` directive in the block explorer CSP
- Applied in both the runtime nginx CSP (`packages/app/Dockerfile`) and the firebase-hosting CSP (`packages/app/firebase.json`) to keep them in sync

## Why ❔

- The memento explorer deployment repoints its favicon, hero banner, and logo images to `cdn.mementoblockchain.com` 
- Adding the origin keeps those image loads clean under the `Content-Security-Policy-Report-Only` policy

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.