### PR TITLE
feat: add heroBannerCover config option for full-cover hero banner

### DIFF
--- a/packages/app/src/components/header/TheHeader.vue
+++ b/packages/app/src/components/header/TheHeader.vue
@@ -59,6 +59,7 @@
       <img
         v-if="currentNetwork.heroBannerImageUrl"
         class="hero-image"
+        :class="{ 'hero-image-cover': currentNetwork.heroBannerCover }"
         :src="resolveAsset(currentNetwork.heroBannerImageUrl)"
       />
       <hero-arrows v-else class="hero-image" />
@@ -337,6 +338,10 @@ const hasContent = computed(() => {
 
     .hero-image {
       @apply h-5/6 w-auto;
+
+      &.hero-image-cover {
+        @apply h-full w-full object-cover;
+      }
     }
   }
 

--- a/packages/app/src/configs/index.ts
+++ b/packages/app/src/configs/index.ts
@@ -5,6 +5,7 @@ export type NetworkConfig = {
   logoUrl?: string;
   logoInverseUrl?: string;
   heroBannerImageUrl?: string;
+  heroBannerCover?: boolean;
   verificationApiUrl?: string;
   apiUrl: string;
   rpcUrl: string;

--- a/packages/app/tests/components/TheHeader.spec.ts
+++ b/packages/app/tests/components/TheHeader.spec.ts
@@ -18,6 +18,7 @@ vi.mock("vue-router", () => ({
 }));
 
 const maintenanceMock = vi.fn(() => false);
+const networkOverridesMock = vi.fn(() => ({}));
 vi.mock("@/composables/useContext", () => {
   return {
     default: () => ({
@@ -25,6 +26,7 @@ vi.mock("@/composables/useContext", () => {
         maintenance: maintenanceMock(),
         bridgeUrl: "https://bridge.zksync.io/",
         apiUrl: "https://api-url",
+        ...networkOverridesMock(),
       })),
       networks: computed(() => []),
       user: computed(() => ({ loggedIn: false })),
@@ -95,6 +97,39 @@ describe("TheHeader:", () => {
     });
 
     expect(wrapper.find(".hero-banner-container").exists()).toBe(true);
+  });
+  it("renders hero banner image without cover class by default", async () => {
+    const mockNetwork = networkOverridesMock.mockReturnValue({
+      heroBannerImageUrl: "https://example.com/banner.webp",
+    });
+    const wrapper = mount(TheHeader, {
+      global: {
+        stubs: ["router-link"],
+        plugins: [i18n],
+      },
+    });
+
+    const heroImage = wrapper.find(".hero-image");
+    expect(heroImage.attributes("src")).toBe("https://example.com/banner.webp");
+    expect(heroImage.classes()).not.toContain("hero-image-cover");
+    mockNetwork.mockRestore();
+  });
+  it("renders hero banner image with cover class if heroBannerCover is true", async () => {
+    const mockNetwork = networkOverridesMock.mockReturnValue({
+      heroBannerImageUrl: "https://example.com/banner.webp",
+      heroBannerCover: true,
+    });
+    const wrapper = mount(TheHeader, {
+      global: {
+        stubs: ["router-link"],
+        plugins: [i18n],
+      },
+    });
+
+    const heroImage = wrapper.find(".hero-image");
+    expect(heroImage.attributes("src")).toBe("https://example.com/banner.webp");
+    expect(heroImage.classes()).toContain("hero-image-cover");
+    mockNetwork.mockRestore();
   });
   it("doesn't render hero banner for not-found route", async () => {
     const mockRoute = routeMock.mockReturnValue({ name: "not-found", params: {} });


### PR DESCRIPTION
## What

Adds an optional `heroBannerCover` boolean to `NetworkConfig`. When set together with `heroBannerImageUrl`, the hero banner image fills the entire banner strip edge to edge (`object-cover`) instead of rendering as a right-positioned image over the solid background color.

## Why

A partner asked whether the explorer header could use a full-width banner image (similar to X or LinkedIn cover banners) rather than a plain color with a logo to the right. The existing `heroBannerImageUrl` renders the image at 5/6 height pinned to the bottom-right, so a cover-style banner was not achievable via config alone.

## How

- `configs/index.ts`: new optional `heroBannerCover?: boolean` field on `NetworkConfig`, alongside the existing branding fields
- `TheHeader.vue`: when the flag is set, the banner `<img>` gets a `hero-image-cover` class applying `h-full w-full object-cover`
- CSS-only change, no new dependencies, no runtime logic

The image approach (rather than a CSS `background-image`) means the cover automatically tracks the per-view banner height overrides (e.g. the contract verification view's responsive heights).

## Backward compatibility

Fully opt-in:
- networks setting only `heroBannerImageUrl` keep the existing right-positioned rendering
- networks without a banner image keep the default fallback arrows

## Testing

- Added two unit tests to `TheHeader.spec.ts` covering the default (no cover class) and opt-in (cover class applied) cases
- `vue-tsc` typecheck and eslint clean
- Verified locally with a partner banner image in a hyperchain config