### PR TITLE
fix: expose nonces only to admins own addresses in prividium mode

### DIFF
--- a/packages/api/src/address/address.controller.spec.ts
+++ b/packages/api/src/address/address.controller.spec.ts
@@ -285,7 +285,7 @@ describe("AddressController", () => {
       let user: MockProxy<UserWithPermissions>;
       const mockUser = "0xc0ffee254729296a45a3885639AC7E10F9d54979";
       beforeEach(() => {
-        user = mock<UserWithPermissions>({ address: mockUser, hasFullReadAccess: false });
+        user = mock<UserWithPermissions>({ address: mockUser, wallets: [mockUser], hasFullReadAccess: false });
       });
 
       it("throws if address is an account and is not own address", async () => {
@@ -422,6 +422,56 @@ describe("AddressController", () => {
         serviceMock.findOne.mockResolvedValue(mock<Address>({ address: mockUser, bytecode: "0x" }));
         await controller.getAddress(mockUser, user);
         expect(balanceServiceMock.getBalances).toHaveBeenCalledTimes(1);
+      });
+
+      it("includes nonces if address is an account and is self", async () => {
+        serviceMock.findOne.mockResolvedValue(mock<Address>({ address: mockUser, bytecode: "0x" }));
+        (transactionServiceMock.getAccountNonce as jest.Mock).mockResolvedValueOnce(5).mockResolvedValueOnce(3);
+        const result = await controller.getAddress(mockUser, user);
+        expect(result["sealedNonce"]).toBe(5);
+        expect(result["verifiedNonce"]).toBe(3);
+      });
+
+      it("allows access and includes nonces for any wallet of the user", async () => {
+        user = mock<UserWithPermissions>({
+          address: mockUser,
+          wallets: [mockUser, blockchainAddress],
+          hasFullReadAccess: false,
+          hasAdminRead: false,
+        });
+        serviceMock.findOne.mockResolvedValue(mock<Address>({ address: blockchainAddress, bytecode: "0x" }));
+        (transactionServiceMock.getAccountNonce as jest.Mock).mockResolvedValueOnce(5).mockResolvedValueOnce(3);
+        const result = await controller.getAddress(blockchainAddress, user);
+        expect(result["sealedNonce"]).toBe(5);
+        expect(result["verifiedNonce"]).toBe(3);
+      });
+
+      it("does not include nonces if user is not the account owner and is not an admin", async () => {
+        user = mock<UserWithPermissions>({
+          address: mockUser,
+          wallets: [mockUser],
+          hasFullReadAccess: true,
+          hasAdminRead: false,
+        });
+        serviceMock.findOne.mockResolvedValue(mock<Address>({ address: blockchainAddress, bytecode: "0x" }));
+        const result = await controller.getAddress(blockchainAddress, user);
+        expect(transactionServiceMock.getAccountNonce).not.toHaveBeenCalled();
+        expect(result).not.toHaveProperty("sealedNonce");
+        expect(result).not.toHaveProperty("verifiedNonce");
+      });
+
+      it("includes nonces if user is an admin and is not the account owner", async () => {
+        user = mock<UserWithPermissions>({
+          address: mockUser,
+          wallets: [mockUser],
+          hasFullReadAccess: true,
+          hasAdminRead: true,
+        });
+        serviceMock.findOne.mockResolvedValue(mock<Address>({ address: blockchainAddress, bytecode: "0x" }));
+        (transactionServiceMock.getAccountNonce as jest.Mock).mockResolvedValueOnce(5).mockResolvedValueOnce(3);
+        const result = await controller.getAddress(blockchainAddress, user);
+        expect(result["sealedNonce"]).toBe(5);
+        expect(result["verifiedNonce"]).toBe(3);
       });
     });
   });

--- a/packages/api/src/address/address.controller.spec.ts
+++ b/packages/api/src/address/address.controller.spec.ts
@@ -320,6 +320,8 @@ describe("AddressController", () => {
           expect(result["bytecode"]).toEqual("");
           expect(result["creatorAddress"]).toEqual("");
           expect(result["creatorTxHash"]).toEqual("");
+          expect(result).not.toHaveProperty("totalTransactions");
+          expect(transactionServiceMock.count).not.toHaveBeenCalled();
         });
 
         it("does not include additional information if user is not owner (ownerTopic is undefined)", async () => {
@@ -399,6 +401,7 @@ describe("AddressController", () => {
           expect(result["bytecode"]).not.toEqual("");
           expect(result["creatorAddress"]).not.toEqual("");
           expect(result["creatorTxHash"]).not.toEqual("");
+          expect(result["totalTransactions"]).toBeDefined();
         });
 
         it("does not include additional information if logService throws an error", async () => {

--- a/packages/api/src/address/address.controller.ts
+++ b/packages/api/src/address/address.controller.ts
@@ -74,6 +74,7 @@ export class AddressController {
     let includeBytecode = true;
     let includeCreatorAddress = true;
     let includeCreatorTxHash = true;
+    let includeTotalTransactions = true;
 
     const isOwnAddress = !!user && user.wallets.some((wallet) => isAddressEqual(wallet, address));
 
@@ -89,6 +90,7 @@ export class AddressController {
         includeBytecode = false;
         includeCreatorAddress = false;
         includeCreatorTxHash = false;
+        includeTotalTransactions = false;
       }
     }
 
@@ -97,7 +99,9 @@ export class AddressController {
       : { blockNumber: 0, balances: {} };
 
     if (addressType === AddressType.Contract) {
-      const totalTransactions = await this.transactionService.count({ "from|to": formatHexAddress(address) });
+      const totalTransactions = includeTotalTransactions
+        ? await this.transactionService.count({ "from|to": formatHexAddress(address) })
+        : undefined;
       return {
         type: AddressType.Contract,
         ...addressRecord,
@@ -105,7 +109,7 @@ export class AddressController {
         balances: addressBalance.balances,
         createdInBlockNumber: addressRecord.createdInBlockNumber,
         creatorTxHash: includeCreatorTxHash ? addressRecord.creatorTxHash : "",
-        totalTransactions,
+        ...(includeTotalTransactions && { totalTransactions }),
         creatorAddress: includeCreatorAddress ? addressRecord.creatorAddress : "",
         isEvmLike: addressRecord.isEvmLike,
         bytecode: includeBytecode ? addressRecord.bytecode : "",

--- a/packages/api/src/address/address.controller.ts
+++ b/packages/api/src/address/address.controller.ts
@@ -75,14 +75,16 @@ export class AddressController {
     let includeCreatorAddress = true;
     let includeCreatorTxHash = true;
 
+    const isOwnAddress = !!user && user.wallets.some((wallet) => isAddressEqual(wallet, address));
+
     if (user && !user.hasFullReadAccess) {
       // If address is an account and is not own address, forbid access
-      if (addressType === AddressType.Account && !isAddressEqual(user.address, address)) {
+      if (addressType === AddressType.Account && !isOwnAddress) {
         throw new ForbiddenException();
       }
 
       // If address is a contract and user is not owner, don't include additional information
-      if (addressType === AddressType.Contract && !(await this.isUserOwnerOfContract(address, user.address))) {
+      if (addressType === AddressType.Contract && !(await this.isUserOwnerOfContract(address, user.wallets))) {
         includeBalances = false;
         includeBytecode = false;
         includeCreatorAddress = false;
@@ -110,18 +112,21 @@ export class AddressController {
       };
     }
 
-    const [sealedNonce, verifiedNonce] = await Promise.all([
-      this.transactionService.getAccountNonce({ accountAddress: address }),
-      this.transactionService.getAccountNonce({ accountAddress: address, isVerified: true }),
-    ]);
+    // In prividium mode account nonces are only visible to the account owner or an admin
+    const includeNonces = !user || user.hasAdminRead || isOwnAddress;
+    const [sealedNonce, verifiedNonce] = includeNonces
+      ? await Promise.all([
+          this.transactionService.getAccountNonce({ accountAddress: address }),
+          this.transactionService.getAccountNonce({ accountAddress: address, isVerified: true }),
+        ])
+      : [undefined, undefined];
 
     return {
       type: AddressType.Account,
       address: ethersGetAddress(address),
       blockNumber: addressBalance.blockNumber || (await this.blockService.getLastBlockNumber()),
       balances: addressBalance.balances,
-      sealedNonce,
-      verifiedNonce,
+      ...(includeNonces && { sealedNonce, verifiedNonce }),
     };
   }
 
@@ -209,10 +214,10 @@ export class AddressController {
    * the OpenZeppelin Ownable pattern.
    *
    * @param contractAddress - The contract address to check
-   * @param accountAddress - The account address to verify ownership for
-   * @returns Promise<boolean> - True if the account is the contract owner
+   * @param accountAddresses - The user account addresses to verify ownership for
+   * @returns Promise<boolean> - True if any of the accounts is the contract owner
    */
-  private async isUserOwnerOfContract(contractAddress: string, accountAddress: string): Promise<boolean> {
+  private async isUserOwnerOfContract(contractAddress: string, accountAddresses: string[]): Promise<boolean> {
     try {
       const OWNERSHIP_TRANSFERRED_TOPIC = "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0";
       const logs = await this.logService.findMany({
@@ -235,7 +240,7 @@ export class AddressController {
       // Topic is 32 bytes log, so we need to convert it to an address
       // by removing the first 12 bytes and 0x prefix
       const owner = `0x${ownerTopic.slice(2 + 12 * 2)}`;
-      return isAddressEqual(owner, accountAddress);
+      return accountAddresses.some((accountAddress) => isAddressEqual(owner, accountAddress));
     } catch (err) {
       this.logger.error("Failed to check if user is owner of contract", err.stack);
       return false;

--- a/packages/api/src/address/dtos/account.dto.ts
+++ b/packages/api/src/address/dtos/account.dto.ts
@@ -12,13 +12,15 @@ export class AccountDto extends BaseAddressDto {
     type: Number,
     description: "The nonce for the account in sealed blocks",
     example: 12345,
+    required: false,
   })
-  public readonly sealedNonce: number;
+  public readonly sealedNonce?: number;
 
   @ApiProperty({
     type: Number,
     description: "The nonce for the account in verified blocks",
     example: 12345,
+    required: false,
   })
-  public readonly verifiedNonce: number;
+  public readonly verifiedNonce?: number;
 }

--- a/packages/api/src/address/dtos/contract.dto.ts
+++ b/packages/api/src/address/dtos/contract.dto.ts
@@ -33,8 +33,9 @@ export class ContractDto extends BaseAddressDto {
     type: Number,
     description: "The total number of transactions for the contract",
     example: 12345,
+    required: false,
   })
-  public readonly totalTransactions: number;
+  public readonly totalTransactions?: number;
 
   @ApiProperty({
     type: String,

--- a/packages/api/src/api/pipes/addUserRoles.pipe.spec.ts
+++ b/packages/api/src/api/pipes/addUserRoles.pipe.spec.ts
@@ -33,7 +33,7 @@ describe("AddUserRolesPipe", () => {
       }),
     });
 
-    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    const user = await pipe.transform({ address: "0x01", wallets: ["0x01"], token: "token1" });
     expect(user.hasFullReadAccess).toBe(false);
   });
 
@@ -45,7 +45,7 @@ describe("AddUserRolesPipe", () => {
       }),
     });
 
-    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    const user = await pipe.transform({ address: "0x01", wallets: ["0x01"], token: "token1" });
     expect(user.hasFullReadAccess).toBe(false);
   });
 
@@ -57,7 +57,7 @@ describe("AddUserRolesPipe", () => {
       }),
     });
 
-    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    const user = await pipe.transform({ address: "0x01", wallets: ["0x01"], token: "token1" });
     expect(user.hasFullReadAccess).toBe(false);
   });
 
@@ -69,7 +69,7 @@ describe("AddUserRolesPipe", () => {
       }),
     });
 
-    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    const user = await pipe.transform({ address: "0x01", wallets: ["0x01"], token: "token1" });
     expect(user.hasFullReadAccess).toBe(true);
   });
 
@@ -81,7 +81,7 @@ describe("AddUserRolesPipe", () => {
       }),
     });
 
-    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    const user = await pipe.transform({ address: "0x01", wallets: ["0x01"], token: "token1" });
     expect(user.hasFullReadAccess).toBe(true);
   });
 
@@ -93,7 +93,7 @@ describe("AddUserRolesPipe", () => {
       }),
     });
 
-    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    const user = await pipe.transform({ address: "0x01", wallets: ["0x01"], token: "token1" });
     expect(user.hasAdminRead).toBe(false);
   });
 
@@ -105,7 +105,7 @@ describe("AddUserRolesPipe", () => {
       }),
     });
 
-    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    const user = await pipe.transform({ address: "0x01", wallets: ["0x01"], token: "token1" });
     expect(user.hasAdminRead).toBe(true);
   });
 
@@ -117,7 +117,7 @@ describe("AddUserRolesPipe", () => {
       }),
     });
 
-    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    const user = await pipe.transform({ address: "0x01", wallets: ["0x01"], token: "token1" });
     expect(user.hasFullReadAccess).toBe(true);
     expect(user.hasAdminRead).toBe(false);
   });
@@ -133,7 +133,7 @@ describe("AddUserRolesPipe", () => {
       }),
     });
 
-    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    const user = await pipe.transform({ address: "0x01", wallets: ["0x01"], token: "token1" });
     expect(user.hasFullReadAccess).toBe(true);
   });
 
@@ -145,7 +145,7 @@ describe("AddUserRolesPipe", () => {
       }),
     });
 
-    const user = await pipe.transform({ address: "0x01", token: "token1" });
+    const user = await pipe.transform({ address: "0x01", wallets: ["0x01"], token: "token1" });
     expect(user.address).toEqual("0x01");
     expect(user.token).toEqual("token1");
   });
@@ -160,7 +160,9 @@ describe("AddUserRolesPipe", () => {
 
     const pipe = new AddUserRolesPipe(configServiceMock);
 
-    await expect(pipe.transform({ address: "0x01", token: "token1" })).rejects.toThrow(BadGatewayException);
+    await expect(pipe.transform({ address: "0x01", wallets: ["0x01"], token: "token1" })).rejects.toThrow(
+      BadGatewayException
+    );
   });
 
   it("throws PrividiumApiError if server returns 401", async () => {
@@ -173,7 +175,9 @@ describe("AddUserRolesPipe", () => {
 
     const pipe = new AddUserRolesPipe(configServiceMock);
 
-    await expect(pipe.transform({ address: "0x01", token: "token1" })).rejects.toThrow(PrividiumApiError);
+    await expect(pipe.transform({ address: "0x01", wallets: ["0x01"], token: "token1" })).rejects.toThrow(
+      PrividiumApiError
+    );
   });
 
   it("throws BadGatewayException if server returns a non-401 error status", async () => {
@@ -184,7 +188,9 @@ describe("AddUserRolesPipe", () => {
 
     const pipe = new AddUserRolesPipe(configServiceMock);
 
-    await expect(pipe.transform({ address: "0x01", token: "token1" })).rejects.toThrow(BadGatewayException);
+    await expect(pipe.transform({ address: "0x01", wallets: ["0x01"], token: "token1" })).rejects.toThrow(
+      BadGatewayException
+    );
   });
 
   it("throws if server returns non parseable json", async () => {
@@ -195,7 +201,9 @@ describe("AddUserRolesPipe", () => {
 
     const pipe = new AddUserRolesPipe(configServiceMock);
 
-    await expect(pipe.transform({ address: "0x01", token: "token1" })).rejects.toThrow(BadGatewayException);
+    await expect(pipe.transform({ address: "0x01", wallets: ["0x01"], token: "token1" })).rejects.toThrow(
+      BadGatewayException
+    );
   });
 
   it("throws if server do not complete request", async () => {
@@ -203,6 +211,8 @@ describe("AddUserRolesPipe", () => {
 
     const pipe = new AddUserRolesPipe(configServiceMock);
 
-    await expect(pipe.transform({ address: "0x01", token: "token1" })).rejects.toThrow(BadGatewayException);
+    await expect(pipe.transform({ address: "0x01", wallets: ["0x01"], token: "token1" })).rejects.toThrow(
+      BadGatewayException
+    );
   });
 });

--- a/packages/api/src/middlewares/auth.middleware.ts
+++ b/packages/api/src/middlewares/auth.middleware.ts
@@ -26,7 +26,7 @@ export class AuthMiddleware implements NestMiddleware {
         throw new UnauthorizedException({ message: "Unauthorized request" });
       }
       const addUserRolesPipe = new AddUserRolesPipe(this.configService);
-      const userWithRoles = await addUserRolesPipe.transform({ address: "", token });
+      const userWithRoles = await addUserRolesPipe.transform({ address: "", wallets: [], token });
       if (!userWithRoles.hasFullReadAccess) {
         // Only admin users can access the API for now
         throw new ForbiddenException({ message: "Forbidden request" });

--- a/packages/api/src/prividium.ts
+++ b/packages/api/src/prividium.ts
@@ -54,6 +54,7 @@ export function applySwaggerAuthMiddleware(app: NestExpressApplication, configSe
     try {
       const userWithRoles = await addUserRolesPipe.transform({
         address: req.session.address,
+        wallets: req.session.wallets ?? [req.session.address],
         token: req.session.token,
       });
       if (!userWithRoles?.hasAdminRead && !userWithRoles?.hasFullReadAccess) {

--- a/packages/api/src/transaction/transaction.service.spec.ts
+++ b/packages/api/src/transaction/transaction.service.spec.ts
@@ -769,7 +769,7 @@ describe("TransactionService", () => {
 
   describe("isTransactionVisibleByUser", () => {
     const userAddress = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
-    const user = { address: userAddress, token: "token" };
+    const user = { address: userAddress, wallets: [userAddress], token: "token" };
     const txHash = "0xabcdef1234567890";
 
     describe("when user is the sender", () => {

--- a/packages/api/src/user/user.decorator.spec.ts
+++ b/packages/api/src/user/user.decorator.spec.ts
@@ -19,13 +19,24 @@ describe("User Decorator", () => {
   it("returns user object with address when request session has address and token", () => {
     mockRequest.session = {
       address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      wallets: ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", "0xc0ffee254729296a45a3885639AC7E10F9d54979"],
       token: "jwt-token",
     };
     const result = userFactory(mockExecutionContext);
     expect(result).toEqual({
       address: mockRequest.session.address,
+      wallets: mockRequest.session.wallets,
       token: "jwt-token",
     });
+  });
+
+  it("defaults wallets to the session address when session has no wallets", () => {
+    mockRequest.session = {
+      address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      token: "jwt-token",
+    };
+    const result = userFactory(mockExecutionContext);
+    expect(result.wallets).toEqual([mockRequest.session.address]);
   });
 
   it("returns null when request session has no address", () => {

--- a/packages/api/src/user/user.decorator.ts
+++ b/packages/api/src/user/user.decorator.ts
@@ -3,6 +3,7 @@ import { Request } from "express";
 
 export type UserParam = {
   address: string;
+  wallets: string[];
   token: string;
 } | null;
 
@@ -17,5 +18,9 @@ export function userFactory(ctx: ExecutionContext): UserParam {
     return null;
   }
 
-  return { address: request.session.address, token: request.session.token };
+  return {
+    address: request.session.address,
+    wallets: request.session.wallets ?? [request.session.address],
+    token: request.session.token,
+  };
 }

--- a/packages/app/src/components/account/InfoTable.vue
+++ b/packages/app/src/components/account/InfoTable.vue
@@ -59,9 +59,14 @@ const tableInfoItems = computed(() => {
   };
   const tableItems: InfoTableItem[] = [
     { label: t("accountView.accountInfo.address"), value: { value: props.account.address }, component: CopyContent },
-    { label: t("accountView.accountInfo.sealedNonce"), value: props.account.sealedNonce },
-    { label: t("accountView.accountInfo.verifiedNonce"), value: props.account.verifiedNonce },
   ];
+  // Nonces are omitted by the API in prividium mode unless the user is the account owner or an admin
+  if (props.account.sealedNonce != null) {
+    tableItems.push({ label: t("accountView.accountInfo.sealedNonce"), value: props.account.sealedNonce });
+  }
+  if (props.account.verifiedNonce != null) {
+    tableItems.push({ label: t("accountView.accountInfo.verifiedNonce"), value: props.account.verifiedNonce });
+  }
   return tableItems;
 });
 </script>

--- a/packages/app/src/components/contract/InfoTable.vue
+++ b/packages/app/src/components/contract/InfoTable.vue
@@ -23,7 +23,7 @@
           </router-link>
         </table-body-column>
       </tr>
-      <tr>
+      <tr v-if="contract.totalTransactions != null">
         <table-body-column class="contract-info-field-label">
           {{ t("contract.table.transactions") }}
         </table-body-column>

--- a/packages/app/src/composables/common/Api.d.ts
+++ b/packages/app/src/composables/common/Api.d.ts
@@ -103,7 +103,7 @@ declare namespace Api {
       creatorAddress: string;
       creatorTxHash: string;
       createdInBlockNumber: number;
-      totalTransactions: number;
+      totalTransactions?: number;
       isEvmLike: boolean;
     };
   }

--- a/packages/app/src/composables/common/Api.d.ts
+++ b/packages/app/src/composables/common/Api.d.ts
@@ -90,8 +90,8 @@ declare namespace Api {
       address: string;
       blockNumber: number;
       balances: Balances;
-      sealedNonce: number;
-      verifiedNonce: number;
+      sealedNonce?: number;
+      verifiedNonce?: number;
     };
 
     type Contract = {

--- a/packages/app/tests/components/account/InfoTable.spec.ts
+++ b/packages/app/tests/components/account/InfoTable.spec.ts
@@ -45,6 +45,26 @@ describe("InfoTable:", () => {
     expect(verified[0].text()).toBe("Verified nonce");
     expect(verified[1].text()).toBe("1");
   });
+  it("hides nonce rows when nonces are not returned by the API", () => {
+    const wrapper = mount(InfoTable, {
+      global: {
+        plugins: [i18n],
+      },
+      props: {
+        account: <Account>{
+          address: "0x481e48ce19781c3ca573967216dee75fdcf70f54",
+          balances: {},
+        },
+        loading: false,
+      },
+    });
+
+    const rowArray = wrapper.findAll("tbody tr");
+    expect(rowArray.length).toBe(1);
+    const address = rowArray[0].findAll("td");
+    expect(address[0].text()).toBe("Address");
+    expect(address[1].text()).toBe("0x481e48ce19781c3ca573967216dee75fdcf70f54");
+  });
   it("renders loading state", () => {
     const wrapper = mount(InfoTable, {
       global: {


### PR DESCRIPTION
# What ❔

- expose nonces only to admins and own addresses in prividium mode
- expose contracts total transactions only to admins and contract owners
- check agains all user wallets instead of only the first one when exposing account/contract info

## Why ❔

- regular users shouldn't see other users nonces or contract total transactions count
- user should be able to see account/contract info owned by any of the wallets associated with the user

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [+] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [+] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
