### PR TITLE
feat: security hardening, pin workflows to commit hashes

### DIFF
--- a/.github/workflows/api-e2e.yml
+++ b/.github/workflows/api-e2e.yml
@@ -23,7 +23,7 @@ jobs:
         working-directory: ./packages/api
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
           docker compose -f "docker-compose.e2e.yaml" up -d --build
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -47,7 +47,7 @@ jobs:
           npm run test:e2e-prividium
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        uses: EnricoMi/publish-unit-test-result-action/composite@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         if: always()
         with:
           files: "packages/api/e2e-junit.xml"
@@ -56,7 +56,7 @@ jobs:
           check_name: API E2E Test Results
 
       - name: Publish Prividium Test Results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        uses: EnricoMi/publish-unit-test-result-action/composite@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         if: always()
         with:
           files: "packages/api/prividium-e2e-junit.xml"

--- a/.github/workflows/app-deploy-feature-branch.yml
+++ b/.github/workflows/app-deploy-feature-branch.yml
@@ -18,12 +18,12 @@ jobs:
       CHANNEL_NAME: pr-${{ github.event.number }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -81,7 +81,7 @@ jobs:
 
       - name: Publish preview url
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           comment_tag: preview_url
           message: |

--- a/.github/workflows/app-deploy-preview.yml
+++ b/.github/workflows/app-deploy-preview.yml
@@ -19,12 +19,12 @@ jobs:
       CHANNEL_NAME: ${{ github.event.inputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
 
@@ -33,7 +33,7 @@ jobs:
           npm install -g firebase-tools
 
       - name: Download Dist package
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # 1.1.2
         with:
           version: "tags/${{ github.event.inputs.version }}"
           file: "dist.zip"
@@ -45,7 +45,7 @@ jobs:
           unzip dist.zip -d packages/app
 
       - name: Download Storybook package
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # 1.1.2
         with:
           version: "tags/${{ github.event.inputs.version }}"
           file: "storybook-static.zip"

--- a/.github/workflows/app-deploy-prod.yml
+++ b/.github/workflows/app-deploy-prod.yml
@@ -15,11 +15,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 
@@ -28,7 +28,7 @@ jobs:
           npm install -g firebase-tools
 
       - name: Download Dist package
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # 1.1.2
         with:
           version: "tags/${{ github.event.inputs.version }}"
           file: "dist.zip"
@@ -44,7 +44,7 @@ jobs:
           echo "window[\"##runtimeConfig\"] = { sentryDSN: \"${{ vars.SENTRY_DSN }}\"  };" > packages/app/dist/config.js
 
       - name: Download Storybook package
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # 1.1.2
         with:
           version: "tags/${{ github.event.inputs.version }}"
           file: "storybook-static.zip"

--- a/.github/workflows/app-e2e.yml
+++ b/.github/workflows/app-e2e.yml
@@ -65,19 +65,19 @@ jobs:
       image: mcr.microsoft.com/playwright:v1.54.1-noble
       options: --user 1001
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
 
       - name: Cache node modules
         id: cache-nodemodules
-        uses: actions/cache@v3
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         env:
           cache-name: cache-node-modules
           # Workaround for bug https://github.com/typicode/husky/issues/991
@@ -122,7 +122,7 @@ jobs:
 
       - name: Save artifacts to Git
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.tags }}-allure-results
           path: packages/app/allure-results
@@ -138,7 +138,7 @@ jobs:
 
       - if: failure()
         name: Save artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: portal_e2e_${{ github.run_number }}_${{ matrix.tags }}_artifacts
           path: packages/app/tests/e2e/artifacts/*

--- a/.github/workflows/nodejs-license.yaml
+++ b/.github/workflows/nodejs-license.yaml
@@ -36,7 +36,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - run: |
           DIRS=$(find -not \( -path \*node_modules -prune \) -type f -name package.json  | xargs dirname | awk -v RS='' -v OFS='","' 'NF { $1 = $1; print "\"" $0 "\"" }')
           echo "matrix=[${DIRS}]" >> $GITHUB_OUTPUT
@@ -52,10 +52,10 @@ jobs:
         dir: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 

--- a/.github/workflows/prividium-e2e.yml
+++ b/.github/workflows/prividium-e2e.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload allure results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: prividium-e2e-results
           path: packages/app/allure-results/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ jobs:
       releaseVersion: ${{ steps.release.outputs.releaseVersion }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -63,19 +63,19 @@ jobs:
     env:
       STATIC_ASSETS_UPLOAD_FOLDER: ${{ secrets.STATIC_ASSETS_UPLOAD_FOLDER }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Build
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -93,7 +93,7 @@ jobs:
           gcloud auth configure-docker us-docker.pkg.dev -q 
 
       - name: Build and push Docker image for API
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: true
           tags: |
@@ -110,7 +110,7 @@ jobs:
           no-cache: true
 
       - name: Build and push Docker image for Worker
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: true
           tags: |
@@ -127,7 +127,7 @@ jobs:
           no-cache: true
 
       - name: Build and push Docker image for Data Fetcher
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: true
           tags: |
@@ -144,7 +144,7 @@ jobs:
           no-cache: true
 
       - name: Build Docker image for App
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: false
           load: ${{ env.STATIC_ASSETS_UPLOAD_FOLDER != '' }}
@@ -194,7 +194,7 @@ jobs:
 
       # Publish the App image from the gha cache
       - name: Push Docker image for App
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: true
           build-args: |
@@ -233,11 +233,11 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' && needs.createReleaseVersion.outputs.releaseVersion != '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 

--- a/.github/workflows/sbom-analysis-reusable.yml
+++ b/.github/workflows/sbom-analysis-reusable.yml
@@ -49,7 +49,7 @@ jobs:
           upload-release-assets: 'false'
 
       - name: Upload CycloneDX file to Dependency Track
-        uses: DependencyTrack/gh-upload-sbom@b717d6595efa77a7ff1b18b57ac28597afc75d77 # v4.0.0
+        uses: DependencyTrack/gh-upload-sbom@95c2b5a810450509ef8a67e4f854b42d2ddf7fbf # v4.1.0
         with:
           serverhostname: ${{ vars.DEPENDENCY_TRACK_SERVER_HOSTNAME }}
           apikey: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
@@ -84,7 +84,7 @@ jobs:
           upload-release-assets: 'false'
 
       - name: Upload CycloneDX file to Dependency Track
-        uses: DependencyTrack/gh-upload-sbom@b717d6595efa77a7ff1b18b57ac28597afc75d77 # v4.0.0
+        uses: DependencyTrack/gh-upload-sbom@95c2b5a810450509ef8a67e4f854b42d2ddf7fbf # v4.1.0
         with:
           serverhostname: ${{ vars.DEPENDENCY_TRACK_SERVER_HOSTNAME }}
           apikey: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}

--- a/.github/workflows/secrets_scanner.yaml
+++ b/.github/workflows/secrets_scanner.yaml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@0c66d30c1f4075cee1aada2e1ab46dabb1b0071a
+        uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         with:
           subjectPattern: ^(?![A-Z]).+$
         env:
@@ -31,12 +31,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -59,7 +59,7 @@ jobs:
           npm run test:ci
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        uses: EnricoMi/publish-unit-test-result-action/composite@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         if: always()
         with:
           files: |


### PR DESCRIPTION
# What ❔

Pins all GitHub Actions in `.github/workflows/` to full commit SHAs of their latest releases, with a trailing version comment (e.g. `actions/checkout@9c091bb… # v7.0.0`).

Covers 11 workflow files and 14 distinct actions. Several were bumped across major versions in the process:

- `actions/checkout` → v7.0.0
- `actions/setup-node` → v6.4.0
- `actions/cache` → v6.1.0
- `actions/upload-artifact` → v7.0.1
- `EnricoMi/publish-unit-test-result-action` → v2.24.0
- `thollander/actions-comment-pull-request` → v3.0.1
- `dsaltares/fetch-gh-release-asset` → 1.1.2
- `docker/setup-buildx-action` → v4.2.0
- `docker/login-action` → v4.4.0
- `docker/build-push-action` → v7.3.0
- `anchore/sbom-action` → v0.24.0
- `DependencyTrack/gh-upload-sbom` → v4.1.0
- `amannn/action-semantic-pull-request` → v6.1.1
- `trufflesecurity/trufflehog` → v3.95.8

Local reusable-workflow calls (`uses: ./.github/workflows/...`) and commented-out lines are left untouched.

## Why ❔

Referencing actions by mutable tags (`@v3`, `@master`) means the code executed in CI can change without any change on our side — a supply-chain risk, since a compromised or force-pushed tag would silently run in our pipelines. Pinning to an immutable commit SHA guarantees the exact code that runs is the code that was reviewed, while the version comment keeps the reference human-readable and Dependabot-updatable.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.