### PR TITLE
feat: add statusBadgeIconUrl config option for transaction status badge icon

### DIFF
--- a/packages/app/src/components/transactions/Table.vue
+++ b/packages/app/src/components/transactions/Table.vue
@@ -45,11 +45,10 @@
           <template #default>
             {{ te(`transactions.status.${item.status}`) ? t(`transactions.status.${item.status}`) : item.status
             }}<img
-              v-if="currentNetwork.statusBadgeIconUrl && !statusBadgeIconFailed"
+              v-if="currentNetwork.txStatusBadgeIconUrl"
               class="status-badge-icon"
-              :src="resolveAsset(currentNetwork.statusBadgeIconUrl)"
+              :src="resolveAsset(currentNetwork.txStatusBadgeIconUrl)"
               alt=""
-              @error="statusBadgeIconFailed = true"
             /><component :is="item.statusIcon" v-else />
           </template>
         </Badge>
@@ -248,8 +247,6 @@ import { resolveAsset } from "@/utils/appBase";
 import { getContractDisplayName, isContractDeployerAddress, utcStringFromISOString } from "@/utils/helpers";
 
 const { currentNetwork } = useContext();
-
-const statusBadgeIconFailed = ref(false);
 
 const { t, te } = useI18n();
 

--- a/packages/app/src/components/transactions/Table.vue
+++ b/packages/app/src/components/transactions/Table.vue
@@ -44,12 +44,7 @@
         <Badge :color="item.statusColor" :data-testid="$testId.statusBadge">
           <template #default>
             {{ te(`transactions.status.${item.status}`) ? t(`transactions.status.${item.status}`) : item.status
-            }}<img
-              v-if="currentNetwork.txStatusBadgeIconUrl"
-              class="status-badge-icon"
-              :src="resolveAsset(currentNetwork.txStatusBadgeIconUrl)"
-              alt=""
-            /><component :is="item.statusIcon" v-else />
+            }}<component :is="item.statusIcon" />
           </template>
         </Badge>
       </TableBodyColumn>
@@ -232,6 +227,7 @@ import ZkSyncIcon from "@/components/icons/ZkSync.vue";
 import TokenAmountPriceTableCell from "@/components/transactions/TokenAmountPriceTableCell.vue";
 import TransactionDirectionTableCell from "@/components/transactions/TransactionDirectionTableCell.vue";
 import TransactionNetworkSquareBlock from "@/components/transactions/TransactionNetworkSquareBlock.vue";
+import TxStatusBadgeIcon from "@/components/transactions/TxStatusBadgeIcon.vue";
 
 import useContext from "@/composables/useContext";
 import { fetchMethodNames } from "@/composables/useOpenChain";
@@ -243,7 +239,6 @@ import type { Direction } from "@/components/transactions/TransactionDirectionTa
 import type { AbiFragment } from "@/composables/useAddress";
 
 import { type NetworkOrigin, TimeFormat } from "@/types";
-import { resolveAsset } from "@/utils/appBase";
 import { getContractDisplayName, isContractDeployerAddress, utcStringFromISOString } from "@/utils/helpers";
 
 const { currentNetwork } = useContext();
@@ -359,7 +354,7 @@ const transactions = computed<TransactionListItemMapped[] | undefined>(() => {
       statusColor: transaction.status === "failed" ? "danger" : "dark-success",
       // replace finality status with execution status here
       status: ["verified", "proved", "committed"].includes(transaction.status) ? "included" : transaction.status,
-      statusIcon: ZkSyncIcon,
+      statusIcon: currentNetwork.value.txStatusBadgeIconUrl ? TxStatusBadgeIcon : ZkSyncIcon,
       displayedTxReceiver,
       displayedTxReceiverName: isContractDeploymentTx
         ? t("contract.contractCreated")
@@ -520,10 +515,6 @@ const toggleAgeTimestamp = () => {
 
     svg {
       @apply ml-1;
-    }
-
-    .status-badge-icon {
-      @apply ml-1 h-5 w-5 object-contain;
     }
   }
   .badge-container.type-label {

--- a/packages/app/src/components/transactions/Table.vue
+++ b/packages/app/src/components/transactions/Table.vue
@@ -44,7 +44,13 @@
         <Badge :color="item.statusColor" :data-testid="$testId.statusBadge">
           <template #default>
             {{ te(`transactions.status.${item.status}`) ? t(`transactions.status.${item.status}`) : item.status
-            }}<component :is="item.statusIcon" />
+            }}<img
+              v-if="currentNetwork.statusBadgeIconUrl && !statusBadgeIconFailed"
+              class="status-badge-icon"
+              :src="resolveAsset(currentNetwork.statusBadgeIconUrl)"
+              alt=""
+              @error="statusBadgeIconFailed = true"
+            /><component :is="item.statusIcon" v-else />
           </template>
         </Badge>
       </TableBodyColumn>
@@ -238,9 +244,12 @@ import type { Direction } from "@/components/transactions/TransactionDirectionTa
 import type { AbiFragment } from "@/composables/useAddress";
 
 import { type NetworkOrigin, TimeFormat } from "@/types";
+import { resolveAsset } from "@/utils/appBase";
 import { getContractDisplayName, isContractDeployerAddress, utcStringFromISOString } from "@/utils/helpers";
 
 const { currentNetwork } = useContext();
+
+const statusBadgeIconFailed = ref(false);
 
 const { t, te } = useI18n();
 
@@ -514,6 +523,10 @@ const toggleAgeTimestamp = () => {
 
     svg {
       @apply ml-1;
+    }
+
+    .status-badge-icon {
+      @apply ml-1 h-5 w-5 object-contain;
     }
   }
   .badge-container.type-label {

--- a/packages/app/src/components/transactions/TxStatusBadgeIcon.vue
+++ b/packages/app/src/components/transactions/TxStatusBadgeIcon.vue
@@ -1,0 +1,17 @@
+<template>
+  <img class="status-badge-icon" :src="resolveAsset(currentNetwork.txStatusBadgeIconUrl ?? '')" alt="" />
+</template>
+
+<script lang="ts" setup>
+import useContext from "@/composables/useContext";
+
+import { resolveAsset } from "@/utils/appBase";
+
+const { currentNetwork } = useContext();
+</script>
+
+<style lang="scss" scoped>
+.status-badge-icon {
+  @apply ml-1 h-5 w-5 object-contain;
+}
+</style>

--- a/packages/app/src/configs/index.ts
+++ b/packages/app/src/configs/index.ts
@@ -6,6 +6,7 @@ export type NetworkConfig = {
   logoInverseUrl?: string;
   heroBannerImageUrl?: string;
   heroBannerCover?: boolean;
+  statusBadgeIconUrl?: string;
   verificationApiUrl?: string;
   apiUrl: string;
   rpcUrl: string;

--- a/packages/app/src/configs/index.ts
+++ b/packages/app/src/configs/index.ts
@@ -6,7 +6,7 @@ export type NetworkConfig = {
   logoInverseUrl?: string;
   heroBannerImageUrl?: string;
   heroBannerCover?: boolean;
-  statusBadgeIconUrl?: string;
+  txStatusBadgeIconUrl?: string;
   verificationApiUrl?: string;
   apiUrl: string;
   rpcUrl: string;

--- a/packages/app/tests/components/transactions/Table.spec.ts
+++ b/packages/app/tests/components/transactions/Table.spec.ts
@@ -3,10 +3,10 @@ import { createI18n } from "vue-i18n";
 
 import { afterEach, beforeEach, describe, expect, it, type SpyInstance, vi } from "vitest";
 
-import { render, type RenderResult } from "@testing-library/vue";
+import { fireEvent, render, type RenderResult } from "@testing-library/vue";
 import { RouterLinkStub } from "@vue/test-utils";
 
-import { ETH_TOKEN_MOCK, useContextMock, useTransactionsMock } from "../../mocks";
+import { ETH_TOKEN_MOCK, TESTNET_NETWORK, useContextMock, useTransactionsMock } from "../../mocks";
 
 import Table from "@/components/transactions/Table.vue";
 
@@ -208,6 +208,48 @@ describe("Transfers:", () => {
 
     it("renders status column", () => {
       expect(renderResult!.getByTestId(elements.statusBadge).textContent).toEqual("Processed on");
+    });
+
+    it("renders the default status icon when statusBadgeIconUrl is not configured", () => {
+      expect(renderResult!.container.querySelector(".status-badge-icon")).toBeNull();
+      expect(renderResult!.container.querySelector(".badge-content svg")).toBeTruthy();
+    });
+
+    describe("when statusBadgeIconUrl is configured", () => {
+      let renderResult: RenderResult | null;
+      const iconUrl = "https://cdn.example.com/status-icon.svg";
+
+      beforeEach(() => {
+        mockContext?.mockRestore();
+        mockContext = useContextMock({
+          currentNetwork: computed(() => ({ ...TESTNET_NETWORK, statusBadgeIconUrl: iconUrl })),
+        });
+        renderResult = render(Table, {
+          props: {},
+          global: {
+            plugins: [i18n, $testId],
+            stubs: { RouterLink: RouterLinkStub },
+          },
+        });
+      });
+
+      afterEach(() => {
+        renderResult?.unmount();
+      });
+
+      it("renders the configured icon instead of the default status icon", () => {
+        const icon = renderResult!.container.querySelector(".status-badge-icon") as HTMLImageElement | null;
+        expect(icon).toBeTruthy();
+        expect(icon!.getAttribute("src")).toEqual(iconUrl);
+        expect(renderResult!.container.querySelector(".badge-content svg")).toBeNull();
+      });
+
+      it("falls back to the default status icon when the configured icon fails to load", async () => {
+        const icon = renderResult!.container.querySelector(".status-badge-icon") as HTMLImageElement;
+        await fireEvent(icon, new Event("error"));
+        expect(renderResult!.container.querySelector(".status-badge-icon")).toBeNull();
+        expect(renderResult!.container.querySelector(".badge-content svg")).toBeTruthy();
+      });
     });
 
     it("renders transaction hash column", () => {

--- a/packages/app/tests/components/transactions/Table.spec.ts
+++ b/packages/app/tests/components/transactions/Table.spec.ts
@@ -3,7 +3,7 @@ import { createI18n } from "vue-i18n";
 
 import { afterEach, beforeEach, describe, expect, it, type SpyInstance, vi } from "vitest";
 
-import { fireEvent, render, type RenderResult } from "@testing-library/vue";
+import { render, type RenderResult } from "@testing-library/vue";
 import { RouterLinkStub } from "@vue/test-utils";
 
 import { ETH_TOKEN_MOCK, TESTNET_NETWORK, useContextMock, useTransactionsMock } from "../../mocks";
@@ -210,19 +210,19 @@ describe("Transfers:", () => {
       expect(renderResult!.getByTestId(elements.statusBadge).textContent).toEqual("Processed on");
     });
 
-    it("renders the default status icon when statusBadgeIconUrl is not configured", () => {
+    it("renders the default status icon when txStatusBadgeIconUrl is not configured", () => {
       expect(renderResult!.container.querySelector(".status-badge-icon")).toBeNull();
       expect(renderResult!.container.querySelector(".badge-content svg")).toBeTruthy();
     });
 
-    describe("when statusBadgeIconUrl is configured", () => {
+    describe("when txStatusBadgeIconUrl is configured", () => {
       let renderResult: RenderResult | null;
       const iconUrl = "https://cdn.example.com/status-icon.svg";
 
       beforeEach(() => {
         mockContext?.mockRestore();
         mockContext = useContextMock({
-          currentNetwork: computed(() => ({ ...TESTNET_NETWORK, statusBadgeIconUrl: iconUrl })),
+          currentNetwork: computed(() => ({ ...TESTNET_NETWORK, txStatusBadgeIconUrl: iconUrl })),
         });
         renderResult = render(Table, {
           props: {},
@@ -242,13 +242,6 @@ describe("Transfers:", () => {
         expect(icon).toBeTruthy();
         expect(icon!.getAttribute("src")).toEqual(iconUrl);
         expect(renderResult!.container.querySelector(".badge-content svg")).toBeNull();
-      });
-
-      it("falls back to the default status icon when the configured icon fails to load", async () => {
-        const icon = renderResult!.container.querySelector(".status-badge-icon") as HTMLImageElement;
-        await fireEvent(icon, new Event("error"));
-        expect(renderResult!.container.querySelector(".status-badge-icon")).toBeNull();
-        expect(renderResult!.container.querySelector(".badge-content svg")).toBeTruthy();
       });
     });
 


### PR DESCRIPTION
# What ❔

Adds an optional `statusBadgeIconUrl` field to `NetworkConfig`. When set, the transactions table status badge renders the configured image instead of the default ZKsync arrows icon. If the configured image fails to load (404, CDN outage, blocked request), the badge falls back to the default icon via an `@error` handler instead of showing a broken-image glyph.

## Why ❔

Hyperchain operators customizing the explorer (logo, hero banner, theme) currently have no way to replace the ZKsync brand icon inside the transaction status badge. This extends the existing per-network branding options with the same pattern used by `logoUrl` and `heroBannerImageUrl` (optional config field, resolved through `resolveAsset`).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.