### PR TITLE
fix: hero banner cover image no longer stretches on wide screens

### DIFF
--- a/packages/app/src/components/header/TheHeader.vue
+++ b/packages/app/src/components/header/TheHeader.vue
@@ -340,7 +340,7 @@ const hasContent = computed(() => {
       @apply h-5/6 w-auto;
 
       &.hero-image-cover {
-        @apply h-full w-full object-cover;
+        @apply h-full;
       }
     }
   }


### PR DESCRIPTION
## What

Removes `w-full object-cover` from the `hero-image-cover` style so the banner image renders at full banner height with its natural aspect ratio instead of scaling to the full viewport width.

## Why

With `heroBannerCover: true` (added in #637), the banner image gets `width: 100%` and `object-cover`. On wide screens the image scales to the viewport width and gets cropped vertically, which looks excessively stretched/zoomed. Reported by the partner, who asked for the `width: 100%` to be removed from `.hero-image.hero-image-cover`.

## Notes

- The image stays right-aligned in the banner strip, matching the default (non-cover) behavior.
- Existing `TheHeader` tests for `heroBannerCover` pass unchanged (they assert the class, not the CSS).