### PR TITLE
feat: allow hiding docs and terms links via runtime config

### DIFF
--- a/packages/app/src/components/TheFooter.vue
+++ b/packages/app/src/components/TheFooter.vue
@@ -21,18 +21,13 @@ import useRuntimeConfig from "@/composables/useRuntimeConfig";
 const { t } = useI18n();
 const config = useRuntimeConfig();
 
-const navigation = computed(() => {
-  const items = [
+const navigation = computed(() =>
+  [
     { label: t("footer.nav.docs"), url: config.links.docsUrl },
     { label: t("footer.nav.terms"), url: config.links.termsOfServiceUrl },
-  ];
-
-  if (config.links.contactUsUrl) {
-    items.push({ label: t("footer.nav.contact"), url: config.links.contactUsUrl });
-  }
-
-  return items;
-});
+    { label: t("footer.nav.contact"), url: config.links.contactUsUrl },
+  ].filter((item): item is { label: string; url: string } => !!item.url)
+);
 </script>
 
 <style scoped lang="scss">

--- a/packages/app/src/components/header/TheHeader.vue
+++ b/packages/app/src/components/header/TheHeader.vue
@@ -176,12 +176,16 @@ const isPrividium = runtimeConfig.appEnvironment === "prividium";
 const hasAdminRead = computed(() => user.value.loggedIn && user.value.hasAdminRead);
 const showAdminLinks = computed(() => !isPrividium || hasAdminRead.value);
 
-const navigation = reactive([
-  {
-    label: computed(() => t("header.nav.documentation")),
-    url: runtimeConfig.links.docsUrl,
-  },
-]);
+const navigation = computed(() =>
+  runtimeConfig.links.docsUrl
+    ? [
+        {
+          label: t("header.nav.documentation"),
+          url: runtimeConfig.links.docsUrl,
+        },
+      ]
+    : []
+);
 
 const blockExplorerLinks = reactive([
   {

--- a/packages/app/src/composables/useRuntimeConfig.ts
+++ b/packages/app/src/composables/useRuntimeConfig.ts
@@ -19,6 +19,11 @@ export const DEFAULT_NETWORK: NetworkConfig = {
   baseTokenAddress: checksumAddress("0x000000000000000000000000000000000000800A"),
 };
 
+// An operator can hide a link by explicitly setting it to null or "" in the
+// runtime config. Only when the key is absent does the fallback URL apply.
+const resolveHideableLink = (configUrl: string | null | undefined, fallbackUrl: string | null): string | null =>
+  configUrl === undefined ? fallbackUrl : configUrl || null;
+
 export default (): RuntimeConfig => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -34,18 +39,18 @@ export default (): RuntimeConfig => {
     links: {
       discordUrl: runtimeConfig?.links?.discordUrl || import.meta.env?.VITE_DISCORD_URL || "https://join.zksync.dev",
       xUrl: runtimeConfig?.links?.xUrl || import.meta.env?.VITE_X_URL || "https://x.com/zksync",
-      docsUrl:
-        runtimeConfig?.links?.docsUrl ||
-        import.meta.env?.VITE_DOCS_URL ||
-        "https://docs.zksync.io/zksync-network/tooling/block-explorers",
-      termsOfServiceUrl:
-        runtimeConfig?.links?.termsOfServiceUrl ||
-        import.meta.env?.VITE_TERMS_OF_SERVICE_URL ||
-        "https://zksync.io/terms",
-      contactUsUrl:
-        runtimeConfig?.links?.contactUsUrl ||
-        import.meta.env?.VITE_CONTACT_US_URL ||
-        (appEnvironment === "prividium" ? null : "https://zksync.io/contact"),
+      docsUrl: resolveHideableLink(
+        runtimeConfig?.links?.docsUrl,
+        import.meta.env?.VITE_DOCS_URL || "https://docs.zksync.io/zksync-network/tooling/block-explorers"
+      ),
+      termsOfServiceUrl: resolveHideableLink(
+        runtimeConfig?.links?.termsOfServiceUrl,
+        import.meta.env?.VITE_TERMS_OF_SERVICE_URL || "https://zksync.io/terms"
+      ),
+      contactUsUrl: resolveHideableLink(
+        runtimeConfig?.links?.contactUsUrl,
+        import.meta.env?.VITE_CONTACT_US_URL || (appEnvironment === "prividium" ? null : "https://zksync.io/contact")
+      ),
     },
     environmentConfig: runtimeConfig?.environmentConfig,
     theme: runtimeConfig?.theme || JSON.parse(import.meta.env?.VITE_THEME_CONFIG || "{}"),

--- a/packages/app/src/configs/index.ts
+++ b/packages/app/src/configs/index.ts
@@ -66,8 +66,8 @@ export type RuntimeConfig = {
   links: {
     discordUrl: string;
     xUrl: string;
-    docsUrl: string;
-    termsOfServiceUrl: string;
+    docsUrl: string | null;
+    termsOfServiceUrl: string | null;
     contactUsUrl: string | null;
   };
   environmentConfig?: EnvironmentConfig;

--- a/packages/app/tests/components/TheFooter.spec.ts
+++ b/packages/app/tests/components/TheFooter.spec.ts
@@ -11,8 +11,8 @@ import enUS from "@/locales/en.json";
 const runtimeConfigMock = {
   version: "localhost",
   links: {
-    docsUrl: "https://docs.zksync.io/zksync-network/tooling/block-explorers",
-    termsOfServiceUrl: "https://zksync.io/terms",
+    docsUrl: "https://docs.zksync.io/zksync-network/tooling/block-explorers" as string | null,
+    termsOfServiceUrl: "https://zksync.io/terms" as string | null,
     contactUsUrl: "https://zksync.io/contact" as string | null,
   },
 };
@@ -32,6 +32,8 @@ describe("TheFooter:", () => {
   const mountFooter = () => mount(TheFooter, { global: { plugins: [i18n] } });
 
   beforeEach(() => {
+    runtimeConfigMock.links.docsUrl = "https://docs.zksync.io/zksync-network/tooling/block-explorers";
+    runtimeConfigMock.links.termsOfServiceUrl = "https://zksync.io/terms";
     runtimeConfigMock.links.contactUsUrl = "https://zksync.io/contact";
   });
 
@@ -45,5 +47,26 @@ describe("TheFooter:", () => {
   it("hides the contact link when no contact URL is resolved", () => {
     runtimeConfigMock.links.contactUsUrl = null;
     expect(mountFooter().findAll("a")).toHaveLength(2);
+  });
+
+  it("hides the docs link when no docs URL is resolved", () => {
+    runtimeConfigMock.links.docsUrl = null;
+    const links = mountFooter().findAll("a");
+    expect(links).toHaveLength(2);
+    expect(links[0].attributes("href")).toBe("https://zksync.io/terms");
+  });
+
+  it("hides the terms link when no terms URL is resolved", () => {
+    runtimeConfigMock.links.termsOfServiceUrl = null;
+    const links = mountFooter().findAll("a");
+    expect(links).toHaveLength(2);
+    expect(links[1].attributes("href")).toBe("https://zksync.io/contact");
+  });
+
+  it("renders no links when all URLs are hidden", () => {
+    runtimeConfigMock.links.docsUrl = null;
+    runtimeConfigMock.links.termsOfServiceUrl = null;
+    runtimeConfigMock.links.contactUsUrl = null;
+    expect(mountFooter().findAll("a")).toHaveLength(0);
   });
 });

--- a/packages/app/tests/components/TheHeader.spec.ts
+++ b/packages/app/tests/components/TheHeader.spec.ts
@@ -68,6 +68,17 @@ describe("TheHeader:", () => {
       "https://docs.zksync.io/zksync-network/tooling/block-explorers"
     );
   });
+  it("hides the documentation link when the docs URL is explicitly hidden", () => {
+    (window as any)["##runtimeConfig"] = { links: { docsUrl: "" } };
+    const wrapper = mount(TheHeader, {
+      global: {
+        stubs: { RouterLink: RouterLinkStub },
+        plugins: [i18n],
+      },
+    });
+    expect(wrapper.findAll(".navigation-container > .navigation-link")).toHaveLength(0);
+    delete (window as any)["##runtimeConfig"];
+  });
   it("renders social links", () => {
     const wrapper = mount(TheHeader, {
       global: {

--- a/packages/app/tests/composables/useRuntimeConfig.spec.ts
+++ b/packages/app/tests/composables/useRuntimeConfig.spec.ts
@@ -33,4 +33,46 @@ describe("useRuntimeConfig: contact us resolution", () => {
     const { links } = useRuntimeConfig();
     expect(links.contactUsUrl).toBe("https://bank-xyz.example/support");
   });
+
+  it("resolves contact to null when explicitly hidden", () => {
+    setRuntimeConfig({ links: { contactUsUrl: "" } });
+    const { links } = useRuntimeConfig();
+    expect(links.contactUsUrl).toBeNull();
+  });
+});
+
+describe("useRuntimeConfig: docs and terms resolution", () => {
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any)["##runtimeConfig"];
+  });
+
+  it("falls back to the ZKsync URLs when nothing is set", () => {
+    const { links } = useRuntimeConfig();
+    expect(links.docsUrl).toBe("https://docs.zksync.io/zksync-network/tooling/block-explorers");
+    expect(links.termsOfServiceUrl).toBe("https://zksync.io/terms");
+  });
+
+  it("uses the operator URLs when runtime config provides them", () => {
+    setRuntimeConfig({
+      links: { docsUrl: "https://bank-xyz.example/docs", termsOfServiceUrl: "https://bank-xyz.example/terms" },
+    });
+    const { links } = useRuntimeConfig();
+    expect(links.docsUrl).toBe("https://bank-xyz.example/docs");
+    expect(links.termsOfServiceUrl).toBe("https://bank-xyz.example/terms");
+  });
+
+  it("resolves to null when explicitly hidden with an empty string", () => {
+    setRuntimeConfig({ links: { docsUrl: "", termsOfServiceUrl: "" } });
+    const { links } = useRuntimeConfig();
+    expect(links.docsUrl).toBeNull();
+    expect(links.termsOfServiceUrl).toBeNull();
+  });
+
+  it("resolves to null when explicitly hidden with null", () => {
+    setRuntimeConfig({ links: { docsUrl: null, termsOfServiceUrl: null } });
+    const { links } = useRuntimeConfig();
+    expect(links.docsUrl).toBeNull();
+    expect(links.termsOfServiceUrl).toBeNull();
+  });
 });


### PR DESCRIPTION
# What ❔

Makes the header **Documentation** link and the footer **Docs** and **Terms** links hideable. `links.docsUrl` and `links.termsOfServiceUrl` are now nullable: an operator can explicitly set them to `null` or `""` in the runtime config to hide the corresponding links. When the keys are absent, behavior is unchanged and the existing ZKsync defaults apply.

The same explicit-hide semantics now also apply to `links.contactUsUrl`, so contact can be hidden outside prividium mode too. The footer contact entry already supported a custom URL, which covers pointing it at an operator page.

## Why ❔

Operators branding the explorer for their own chain asked to remove the ZKsync-specific Documentation, Docs, and Terms links and point Contact at their own site. Previously these links always rendered with ZKsync URLs unless overridden, with no way to remove them.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.