### PR TITLE
feat: allow overriding or hiding network stats subtitle via config

### DIFF
--- a/packages/app/src/components/NetworkStats.vue
+++ b/packages/app/src/components/NetworkStats.vue
@@ -2,7 +2,7 @@
   <div class="card">
     <div>
       <div class="title">{{ t("networkStats.title") }}</div>
-      <div class="subtitle">{{ subtitle }}</div>
+      <div v-if="subtitle" class="subtitle">{{ subtitle }}</div>
     </div>
     <dl class="description-list">
       <div class="stats-container">
@@ -77,11 +77,15 @@ defineProps({
   },
 });
 
-const subtitle = computed(() =>
-  currentNetwork.value.name.includes("mainnet")
+const subtitle = computed(() => {
+  const configSubtitle = currentNetwork.value.networkStatsSubtitle;
+  if (configSubtitle !== undefined) {
+    return configSubtitle || null;
+  }
+  return currentNetwork.value.name.includes("mainnet")
     ? t("networkStats.subtitleMainnet", { l2NetworkName: currentNetwork.value.l2NetworkName })
-    : t("networkStats.subtitleTestnet")
-);
+    : t("networkStats.subtitleTestnet");
+});
 </script>
 
 <style scoped lang="scss">

--- a/packages/app/src/components/NetworkStats.vue
+++ b/packages/app/src/components/NetworkStats.vue
@@ -52,6 +52,7 @@ import { useI18n } from "vue-i18n";
 import ContentLoader from "@/components/common/loaders/ContentLoader.vue";
 
 import useContext from "@/composables/useContext";
+import { resolveHideable } from "@/composables/useRuntimeConfig";
 
 import { formatMoney, formatWithSpaces } from "@/utils/formatters";
 
@@ -77,15 +78,14 @@ defineProps({
   },
 });
 
-const subtitle = computed(() => {
-  const configSubtitle = currentNetwork.value.networkStatsSubtitle;
-  if (configSubtitle !== undefined) {
-    return configSubtitle || null;
-  }
-  return currentNetwork.value.name.includes("mainnet")
-    ? t("networkStats.subtitleMainnet", { l2NetworkName: currentNetwork.value.l2NetworkName })
-    : t("networkStats.subtitleTestnet");
-});
+const subtitle = computed(() =>
+  resolveHideable(
+    currentNetwork.value.networkStatsSubtitle,
+    currentNetwork.value.name.includes("mainnet")
+      ? t("networkStats.subtitleMainnet", { l2NetworkName: currentNetwork.value.l2NetworkName })
+      : t("networkStats.subtitleTestnet")
+  )
+);
 </script>
 
 <style scoped lang="scss">

--- a/packages/app/src/components/header/TheHeader.vue
+++ b/packages/app/src/components/header/TheHeader.vue
@@ -96,8 +96,8 @@
                 <div class="mobile-navigation">
                   <LinksMobilePopover :items="toolsLinks" />
                 </div>
-                <div class="mobile-navigation-divider"></div>
-                <div class="mobile-navigation">
+                <div v-if="navigation.length" class="mobile-navigation-divider"></div>
+                <div v-if="navigation.length" class="mobile-navigation">
                   <a
                     v-for="item in navigation"
                     :key="item.label"

--- a/packages/app/src/composables/useRuntimeConfig.ts
+++ b/packages/app/src/composables/useRuntimeConfig.ts
@@ -19,10 +19,10 @@ export const DEFAULT_NETWORK: NetworkConfig = {
   baseTokenAddress: checksumAddress("0x000000000000000000000000000000000000800A"),
 };
 
-// An operator can hide a link by explicitly setting it to null or "" in the
-// runtime config. Only when the key is absent does the fallback URL apply.
-const resolveHideableLink = (configUrl: string | null | undefined, fallbackUrl: string | null): string | null =>
-  configUrl === undefined ? fallbackUrl : configUrl || null;
+// An operator can hide a value by explicitly setting it to null or "" in the
+// config. Only when the key is absent does the fallback apply.
+export const resolveHideable = (configValue: string | null | undefined, fallback: string | null): string | null =>
+  configValue === undefined ? fallback : configValue || null;
 
 export default (): RuntimeConfig => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -39,15 +39,15 @@ export default (): RuntimeConfig => {
     links: {
       discordUrl: runtimeConfig?.links?.discordUrl || import.meta.env?.VITE_DISCORD_URL || "https://join.zksync.dev",
       xUrl: runtimeConfig?.links?.xUrl || import.meta.env?.VITE_X_URL || "https://x.com/zksync",
-      docsUrl: resolveHideableLink(
+      docsUrl: resolveHideable(
         runtimeConfig?.links?.docsUrl,
         import.meta.env?.VITE_DOCS_URL || "https://docs.zksync.io/zksync-network/tooling/block-explorers"
       ),
-      termsOfServiceUrl: resolveHideableLink(
+      termsOfServiceUrl: resolveHideable(
         runtimeConfig?.links?.termsOfServiceUrl,
         import.meta.env?.VITE_TERMS_OF_SERVICE_URL || "https://zksync.io/terms"
       ),
-      contactUsUrl: resolveHideableLink(
+      contactUsUrl: resolveHideable(
         runtimeConfig?.links?.contactUsUrl,
         import.meta.env?.VITE_CONTACT_US_URL || (appEnvironment === "prividium" ? null : "https://zksync.io/contact")
       ),

--- a/packages/app/src/configs/index.ts
+++ b/packages/app/src/configs/index.ts
@@ -7,6 +7,7 @@ export type NetworkConfig = {
   heroBannerImageUrl?: string;
   heroBannerCover?: boolean;
   txStatusBadgeIconUrl?: string;
+  networkStatsSubtitle?: string | null;
   verificationApiUrl?: string;
   apiUrl: string;
   rpcUrl: string;

--- a/packages/app/tests/components/NetworkStats.spec.ts
+++ b/packages/app/tests/components/NetworkStats.spec.ts
@@ -11,11 +11,16 @@ import NetworkStats from "@/components/NetworkStats.vue";
 import enUS from "@/locales/en.json";
 
 const currentNetworkMock = vi.fn(() => "testnet");
+const networkStatsSubtitleMock = vi.fn((): string | null | undefined => undefined);
 
 vi.mock("@/composables/useContext", () => {
   return {
     default: () => ({
-      currentNetwork: computed(() => ({ name: currentNetworkMock(), l2NetworkName: "Network" })),
+      currentNetwork: computed(() => ({
+        name: currentNetworkMock(),
+        l2NetworkName: "Network",
+        networkStatsSubtitle: networkStatsSubtitleMock(),
+      })),
     }),
   };
 });
@@ -163,5 +168,41 @@ describe("NetworkStats:", () => {
 
     expect(wrapper.find(".subtitle").text()).toBe("Network is open to everyone.");
     mockNetwork.mockRestore();
+  });
+  it("renders custom subtitle when networkStatsSubtitle is set", () => {
+    const mockSubtitle = networkStatsSubtitleMock.mockReturnValue("Custom subtitle text");
+    const wrapper = mount(NetworkStats, {
+      props: {
+        loading: false,
+      },
+      global,
+    });
+
+    expect(wrapper.find(".subtitle").text()).toBe("Custom subtitle text");
+    mockSubtitle.mockRestore();
+  });
+  it("hides subtitle when networkStatsSubtitle is an empty string", () => {
+    const mockSubtitle = networkStatsSubtitleMock.mockReturnValue("");
+    const wrapper = mount(NetworkStats, {
+      props: {
+        loading: false,
+      },
+      global,
+    });
+
+    expect(wrapper.find(".subtitle").exists()).toBe(false);
+    mockSubtitle.mockRestore();
+  });
+  it("hides subtitle when networkStatsSubtitle is null", () => {
+    const mockSubtitle = networkStatsSubtitleMock.mockReturnValue(null);
+    const wrapper = mount(NetworkStats, {
+      props: {
+        loading: false,
+      },
+      global,
+    });
+
+    expect(wrapper.find(".subtitle").exists()).toBe(false);
+    mockSubtitle.mockRestore();
   });
 });


### PR DESCRIPTION
## What

Adds an optional per-network config field `networkStatsSubtitle` that controls the subtitle under the Network Stats card on the home page:

- Key absent: current behavior ("Stats are occasionally reset on testnet." or "{l2NetworkName} is open to everyone." based on the network name)
- Non-empty string: shown as the subtitle
- `""` or `null`: subtitle is hidden entirely

## Why

Operators cannot change or remove the hardcoded testnet subtitle without renaming the network, which has side effects (network switcher, `?network=` URLs). This follows the same per-network pattern as `txStatusBadgeIconUrl` (#640) and the absent/empty/null semantics of the hideable links (#642).

## Usage

```json
{
  "networks": [
    {
      "name": "my-chain",
      "networkStatsSubtitle": "Custom subtitle text"
    }
  ]
}
```

Set `"networkStatsSubtitle": null` (or `""`) to hide the subtitle.

## Testing

- Unit tests added for custom text, hidden on empty string, hidden on null, defaults unchanged when key absent
- Verified manually in the running app for all three states plus the mainnet default path