### PR TITLE
feat: adaptive token price precision and market-cap display fix

### DIFF
--- a/packages/api/src/api/stats/stats.controller.ts
+++ b/packages/api/src/api/stats/stats.controller.ts
@@ -5,7 +5,7 @@ import { ResponseStatus, ResponseMessage } from "../dtos/common/responseBase.dto
 import { ApiExceptionFilter } from "../exceptionFilter";
 import { EthPriceResponseDto } from "../dtos/stats/ethPrice.dto";
 import { TokenService } from "../../token/token.service";
-import { dateToTimestamp } from "../../common/utils";
+import { dateToTimestamp, numberToDecimalString } from "../../common/utils";
 import { type BaseToken } from "../../config";
 
 const entityName = "stats";
@@ -32,7 +32,7 @@ export class StatsController {
       message: token ? ResponseMessage.OK : ResponseMessage.NO_DATA_FOUND,
       result: token
         ? {
-            ethusd: token.usdPrice?.toString() || "",
+            ethusd: token.usdPrice != null ? numberToDecimalString(token.usdPrice) : "",
             ethusd_timestamp: token.offChainDataUpdatedAt
               ? dateToTimestamp(token.offChainDataUpdatedAt).toString()
               : "",

--- a/packages/api/src/api/token/token.controller.spec.ts
+++ b/packages/api/src/api/token/token.controller.spec.ts
@@ -62,6 +62,18 @@ describe("TokenController", () => {
       });
     });
 
+    it("returns tokenPriceUSD as a plain decimal string for very small prices", async () => {
+      jest.spyOn(tokenServiceMock, "findOne").mockResolvedValueOnce({
+        l2Address: "l2Address",
+        symbol: "TINY",
+        decimals: 18,
+        usdPrice: 1.25e-7,
+      } as Token);
+
+      const response = await controller.tokenInfo(contractAddress);
+      expect(response.result[0].tokenPriceUSD).toBe("0.000000125");
+    });
+
     it("returns ok response and token info with default values when token doesn't have all details", async () => {
       jest.spyOn(tokenServiceMock, "findOne").mockResolvedValueOnce({
         l2Address: "0x000000000000000000000000000000000000800A",

--- a/packages/api/src/api/token/token.controller.ts
+++ b/packages/api/src/api/token/token.controller.ts
@@ -5,6 +5,7 @@ import { ResponseStatus, ResponseMessage } from "../dtos/common/responseBase.dto
 import { ApiExceptionFilter } from "../exceptionFilter";
 import { TokenInfoResponseDto } from "../dtos/token/tokenInfo.dto";
 import { TokenService } from "../../token/token.service";
+import { numberToDecimalString } from "../../common/utils";
 const entityName = "token";
 
 @ApiExcludeController()
@@ -30,7 +31,7 @@ export class TokenController {
               tokenName: token.name || "",
               symbol: token.symbol,
               tokenDecimal: token.decimals.toString(),
-              tokenPriceUSD: token.usdPrice?.toString() || "",
+              tokenPriceUSD: token.usdPrice != null ? numberToDecimalString(token.usdPrice) : "",
               liquidity: token.liquidity?.toString() || "",
               l1Address: token.l1Address || "",
               iconURL: token.iconURL || "",

--- a/packages/api/src/common/utils.ts
+++ b/packages/api/src/common/utils.ts
@@ -150,6 +150,11 @@ export const dateToTimestamp = (date: Date) => Math.floor(date.getTime() / 1000)
 
 export const numberToHex = (num: number | bigint) => (num != null ? `0x${num.toString(16)}` : "0x");
 
+// Plain decimal string; use toLocaleString instead of toString which would emit exponential
+// notation for prices below 1e-6.
+export const numberToDecimalString = (num: number) =>
+  num.toLocaleString("en-US", { useGrouping: false, maximumFractionDigits: 20 });
+
 export const parseIntToHex = (numStr: string) => {
   if (numStr != null) {
     const parsedInt = parseInt(numStr, 10);

--- a/packages/app/src/components/token/MarketTokenInfoTable.vue
+++ b/packages/app/src/components/token/MarketTokenInfoTable.vue
@@ -7,7 +7,7 @@
         </table-body-column>
         <table-body-column class="token-info-field-value">
           <div v-if="tokenInfo.liquidity && tokenInfo.usdPrice">
-            {{ formatMoney(tokenInfo.liquidity, tokenInfo.decimals) }}
+            {{ formatMoney(tokenInfo.liquidity) }}
           </div>
         </table-body-column>
       </tr>

--- a/packages/app/src/utils/formatters.ts
+++ b/packages/app/src/utils/formatters.ts
@@ -85,15 +85,20 @@ export const numberToHexString = (num: number | bigint) => `0x${num.toString(16)
 
 export function formatPricePretty(amount: BigNumberish, decimals: number, usdPrice: string) {
   const price = +usdPrice * +formatBigNumberish(amount, decimals);
-  const leadingZeroes = price.toString().split(".")[1]?.match(/^0*/)?.[0].length || 0;
-  const priceDecimals = Math.max(2, Math.min(5, leadingZeroes + 1));
   if (price === 0) {
     return "$0";
   } else if (price < 0.00001) {
     return `<${formatMoney(0.00001, 5)}`;
-  } else {
-    return `${formatMoney(price, priceDecimals)}`;
+  } else if (price >= 1) {
+    return `${formatMoney(price, 2)}`;
   }
+  // Sub-dollar prices: show 4 significant figures so small-value tokens keep
+  // meaningful precision, adapting to magnitude and trimming trailing zeroes.
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumSignificantDigits: 4,
+  }).format(price);
 }
 
 export function formatShortAddress(address: string | null | undefined, prefixLength = 6, suffixLength = 4): string {

--- a/packages/app/src/utils/formatters.ts
+++ b/packages/app/src/utils/formatters.ts
@@ -4,7 +4,7 @@ import type { Token } from "@/composables/useToken";
 import type { HexDecimals } from "@/composables/useTrace";
 import type { Address, Hash } from "@/types";
 
-export function formatMoney(num: number, maximumFractionDigits = 1, minimumFractionDigits = 0) {
+export function formatMoney(num: number, maximumFractionDigits = 2, minimumFractionDigits = 0) {
   return new Intl.NumberFormat("en-US", {
     notation: num > 99_999_999 ? "compact" : "standard",
     style: "currency",
@@ -94,16 +94,12 @@ export function formatPricePretty(amount: BigNumberish, decimals: number, usdPri
     return formatMoney(price, 2, 2);
   }
   // Sub-dollar prices: show 4 significant figures so small-value tokens keep
-  // meaningful precision, adapting to magnitude and trimming trailing zeroes.
-  const formatted = new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumSignificantDigits: 4,
-  }).format(price);
-  // Rounding to 4 significant figures can leave fewer than 2 decimals
-  // ("$0.5", or "$1" when a price just below a dollar rounds up); use the
-  // same 2-decimal style as the >= $1 branch in that case.
-  return (formatted.split(".")[1]?.length ?? 0) >= 2 ? formatted : formatMoney(price, 2, 2);
+  // meaningful precision, adapting to magnitude and trimming trailing zeroes,
+  // but never fewer than 2 decimals ("$0.50", and "$1.00" when a price just
+  // below a dollar rounds up). The first significant digit sits at
+  // 10^exponent, so 4 significant figures end 3 places past it.
+  const exponent = Math.floor(Math.log10(price));
+  return formatMoney(price, Math.max(2, 3 - exponent), 2);
 }
 
 export function formatShortAddress(address: string | null | undefined, prefixLength = 6, suffixLength = 4): string {

--- a/packages/app/src/utils/formatters.ts
+++ b/packages/app/src/utils/formatters.ts
@@ -4,11 +4,12 @@ import type { Token } from "@/composables/useToken";
 import type { HexDecimals } from "@/composables/useTrace";
 import type { Address, Hash } from "@/types";
 
-export function formatMoney(num: number, maximumFractionDigits = 1) {
+export function formatMoney(num: number, maximumFractionDigits = 1, minimumFractionDigits = 0) {
   return new Intl.NumberFormat("en-US", {
     notation: num > 99_999_999 ? "compact" : "standard",
     style: "currency",
     currency: "USD",
+    minimumFractionDigits,
     maximumFractionDigits,
   }).format(num);
 }
@@ -90,15 +91,19 @@ export function formatPricePretty(amount: BigNumberish, decimals: number, usdPri
   } else if (price < 0.00001) {
     return `<${formatMoney(0.00001, 5)}`;
   } else if (price >= 1) {
-    return `${formatMoney(price, 2)}`;
+    return formatMoney(price, 2, 2);
   }
   // Sub-dollar prices: show 4 significant figures so small-value tokens keep
   // meaningful precision, adapting to magnitude and trimming trailing zeroes.
-  return new Intl.NumberFormat("en-US", {
+  const formatted = new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: "USD",
     maximumSignificantDigits: 4,
   }).format(price);
+  // Rounding to 4 significant figures can leave fewer than 2 decimals
+  // ("$0.5", or "$1" when a price just below a dollar rounds up); use the
+  // same 2-decimal style as the >= $1 branch in that case.
+  return (formatted.split(".")[1]?.length ?? 0) >= 2 ? formatted : formatMoney(price, 2, 2);
 }
 
 export function formatShortAddress(address: string | null | undefined, prefixLength = 6, suffixLength = 4): string {

--- a/packages/app/tests/components/NetworkStats.spec.ts
+++ b/packages/app/tests/components/NetworkStats.spec.ts
@@ -51,7 +51,7 @@ describe("NetworkStats:", () => {
     expect(wrapperArray[0].textContent).toContain("123");
     expect(wrapperArray[1].textContent).toContain("542");
     expect(wrapperArray[2].textContent).toContain("1 404");
-    expect(wrapperArray[3].textContent).toContain("$849,320.0");
+    expect(wrapperArray[3].textContent).toContain("$849,320");
   });
   it("renders component without total value locked property", () => {
     const { container } = render(NetworkStats, {

--- a/packages/app/tests/components/token/MarketTokenInfoTable.spec.ts
+++ b/packages/app/tests/components/token/MarketTokenInfoTable.spec.ts
@@ -47,7 +47,7 @@ describe("MarketTokenInfoTable", () => {
     const rowArray = wrapper.findAll("tr");
     const marketCap = rowArray[0].findAll("td");
     expect(marketCap[0].text()).toBe("Market Cap");
-    expect(marketCap[1].text()).toBe("$220.00B");
+    expect(marketCap[1].text()).toBe("$220.0B");
 
     const price = rowArray[1].findAll("td");
     expect(price[0].text()).toBe("Price");

--- a/packages/app/tests/components/token/MarketTokenInfoTable.spec.ts
+++ b/packages/app/tests/components/token/MarketTokenInfoTable.spec.ts
@@ -47,7 +47,7 @@ describe("MarketTokenInfoTable", () => {
     const rowArray = wrapper.findAll("tr");
     const marketCap = rowArray[0].findAll("td");
     expect(marketCap[0].text()).toBe("Market Cap");
-    expect(marketCap[1].text()).toBe("$220.0B");
+    expect(marketCap[1].text()).toBe("$220B");
 
     const price = rowArray[1].findAll("td");
     expect(price[0].text()).toBe("Price");

--- a/packages/app/tests/components/transactions/Table.spec.ts
+++ b/packages/app/tests/components/transactions/Table.spec.ts
@@ -281,12 +281,12 @@ describe("Transfers:", () => {
 
     it("renders value column", () => {
       expect(renderResult!.getAllByTestId(elements.tokenAmount)[0].textContent).toEqual("0.0000123213123");
-      expect(renderResult!.getAllByTestId(elements.tokenAmountPrice)[0].textContent).toEqual("$0.02");
+      expect(renderResult!.getAllByTestId(elements.tokenAmountPrice)[0].textContent).toEqual("$0.02218");
     });
 
     it("renders fee column", () => {
       expect(renderResult!.getAllByTestId(elements.tokenAmount)[2].textContent).toEqual("0.00006550325");
-      expect(renderResult!.getAllByTestId(elements.tokenAmountPrice)[1].textContent).toEqual("$0.12");
+      expect(renderResult!.getAllByTestId(elements.tokenAmountPrice)[1].textContent).toEqual("$0.1179");
     });
   });
 

--- a/packages/app/tests/utils/formatters.spec.ts
+++ b/packages/app/tests/utils/formatters.spec.ts
@@ -50,9 +50,14 @@ describe("formatters:", () => {
   });
   it("returns formatted token price", () => {
     expect(formatPricePretty("1", 1, "12.5315131")).toBe("$1.25");
-    expect(formatPricePretty("1", 4, "12.5315131")).toBe("$0.001");
+    expect(formatPricePretty("1", 4, "12.5315131")).toBe("$0.001253");
     expect(formatPricePretty("0", 4, "12.5315131")).toBe("$0");
     expect(formatPricePretty("1", 8, "12.5315131")).toBe("<$0.00001");
+  });
+  it("shows 2 decimals for prices >= $1 and significant digits below", () => {
+    expect(formatPricePretty("1", 0, "62791.86")).toBe("$62,791.86");
+    expect(formatPricePretty("1", 0, "0.5")).toBe("$0.5");
+    expect(formatPricePretty("1", 0, "0.0428")).toBe("$0.0428");
   });
   it("returns formatted Decimals data", () => {
     expect(formatHexDecimals("0x8002", "Dec")).toBe("32770");

--- a/packages/app/tests/utils/formatters.spec.ts
+++ b/packages/app/tests/utils/formatters.spec.ts
@@ -25,8 +25,11 @@ describe("formatters:", () => {
     expect(formatMoney(20300)).toBe("$20,300");
     expect(formatMoney(2000000)).toBe("$2,000,000");
     expect(formatMoney(45123456.8)).toBe("$45,123,456.8");
+    expect(formatMoney(12312.23131231312)).toBe("$12,312.23");
+    expect(formatMoney(0.03)).toBe("$0.03");
     expect(formatMoney(220000000000)).toBe("$220B");
     expect(formatMoney(7300503357)).toBe("$7.3B");
+    expect(formatMoney(7350000000)).toBe("$7.35B");
   });
   it("returns shorted value", () => {
     expect(shortValue("0xb989b65e02b")).toBe("0xb989...e02b");

--- a/packages/app/tests/utils/formatters.spec.ts
+++ b/packages/app/tests/utils/formatters.spec.ts
@@ -22,8 +22,11 @@ describe("formatters:", () => {
     expect(formatWithSpaces(20300)).toBe("20 300");
   });
   it("returns formatted number with symbols", () => {
-    expect(formatMoney(20300)).toBe("$20,300.0");
-    expect(formatMoney(2000000)).toBe("$2,000,000.0");
+    expect(formatMoney(20300)).toBe("$20,300");
+    expect(formatMoney(2000000)).toBe("$2,000,000");
+    expect(formatMoney(45123456.8)).toBe("$45,123,456.8");
+    expect(formatMoney(220000000000)).toBe("$220B");
+    expect(formatMoney(7300503357)).toBe("$7.3B");
   });
   it("returns shorted value", () => {
     expect(shortValue("0xb989b65e02b")).toBe("0xb989...e02b");
@@ -56,7 +59,9 @@ describe("formatters:", () => {
   });
   it("shows 2 decimals for prices >= $1 and significant digits below", () => {
     expect(formatPricePretty("1", 0, "62791.86")).toBe("$62,791.86");
-    expect(formatPricePretty("1", 0, "0.5")).toBe("$0.5");
+    expect(formatPricePretty("1", 0, "1")).toBe("$1.00");
+    expect(formatPricePretty("1", 0, "0.5")).toBe("$0.50");
+    expect(formatPricePretty("1", 0, "0.99999")).toBe("$1.00");
     expect(formatPricePretty("1", 0, "0.0428")).toBe("$0.0428");
   });
   it("returns formatted Decimals data", () => {

--- a/packages/worker/src/token/tokenOffChainData/providers/coingecko/coingeckoTokenOffChainDataProvider.spec.ts
+++ b/packages/worker/src/token/tokenOffChainData/providers/coingecko/coingeckoTokenOffChainDataProvider.spec.ts
@@ -304,7 +304,7 @@ describe("CoingeckoTokenOffChainDataProvider", () => {
         "https://pro-api.coingecko.com/api/v3/coins/list?include_platform=true&x_cg_pro_api_key=apiKey"
       );
       expect(httpServiceMock.get).toBeCalledWith(
-        "https://pro-api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=ethereum%2Ctoken1%2Ctoken2&per_page=3&page=1&locale=en&x_cg_pro_api_key=apiKey"
+        "https://pro-api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=ethereum%2Ctoken1%2Ctoken2&per_page=3&page=1&locale=en&precision=full&x_cg_pro_api_key=apiKey"
       );
       expect(tokens).toEqual([
         {

--- a/packages/worker/src/token/tokenOffChainData/providers/coingecko/coingeckoTokenOffChainDataProvider.ts
+++ b/packages/worker/src/token/tokenOffChainData/providers/coingecko/coingeckoTokenOffChainDataProvider.ts
@@ -92,6 +92,7 @@ export class CoingeckoTokenOffChainDataProvider implements TokenOffChainDataProv
         per_page: tokenIds.length.toString(),
         page: "1",
         locale: "en",
+        precision: "full",
       },
     });
   }


### PR DESCRIPTION
## Context

A Prividium partner's BD team reported that small-value tokens (e.g. DEXTF, ZK) lose meaningful precision on the explorer's token pages. They asked for magnitude-adaptive decimals: ">$1 use 2 decimals, <$1 use more precision, trim trailing zeros."

While investigating, two root causes and one adjacent latent bug surfaced.

## Changes

**Worker — request full price precision**
`getTokensMarketData` sent no `precision` param to CoinGecko's `/coins/markets`, so sub-dollar prices could be rounded at the source before reaching the DB. Added `precision: "full"` (not `4`, which would round tiny tokens to `0.0000`). Harmless for large tokens; the stored column is `double precision` so no schema change.

**App — adaptive price formatting**
`formatPricePretty` used a `leadingZeros + 1` heuristic that showed effectively one significant figure for sub-dollar tokens (`$0.0428` → `$0.04`). Rewrote it:
- `>= $1` → exactly 2 decimals (`$1.00`, `$62,791.86`)
- `< $1` → 4 significant figures (adapts to magnitude, trims trailing zeroes), with a 2-decimal floor so results never show fewer than 2 decimals (`$0.50`, not `$0.5`; `$0.99999` rounds to `$1.00`, not `$1`)
- `$0` and `<$0.00001` floors unchanged

This deletes the fragile string-parsing and benefits all consumers (`TokenPrice`, `TokenAmountPrice`, `BalanceValue`).

| Price | Before | After |
|---|---|---|
| $62,791.86 | $62,791.86 | $62,791.86 |
| $1 | $1.00 | $1.00 |
| $0.99999 | $1.00 | $1.00 |
| $0.5 | $0.50 | $0.50 |
| $0.0428 | $0.04 | $0.0428 |
| $0.001253 | $0.001 | $0.001253 |
| < $0.00001 | <$0.00001 | <$0.00001 |

**App — market-cap display fix (latent bug)**
`MarketTokenInfoTable` passed the token's on-chain `decimals` as `formatMoney`'s `maximumFractionDigits`, producing noisy output for large caps (`$7.30503357B`). Dropped the arg so it uses the sensible default → `$7.3B`. Kept compact notation (spelling out billions would require plumbing a `notation` option through the shared `formatMoney`, used by `NetworkStats` too, and implies false precision).

**App — no forced trailing zero in `formatMoney`**
`formatMoney` implicitly forced a minimum of 1 fraction digit (currency default of 2 clamped to the `maximumFractionDigits` arg), so whole-number amounts always rendered a meaningless dangling digit: `$20,300.0`, `$849,320.0` (NetworkStats TVL), `$220.0B`. Added an explicit `minimumFractionDigits` param defaulting to `0` → `$20,300`, `$849,320`, `$220B`. Values with real decimals are unaffected (`$7.3B`, `$45,123,456.8`). The price path passes `minimumFractionDigits: 2` explicitly, preserving `$1.50`-style output everywhere prices render.

## Tests

Updated unit and component expectations to match the improved output (`formatters.spec.ts`, `MarketTokenInfoTable.spec.ts`, `Table.spec.ts`, `NetworkStats.spec.ts`, and the worker provider URL assertion), and added cases for the `$1` boundary (`$0.99999` → `$1.00`), the 2-decimal floor (`$0.50`), and compact vs standard `formatMoney` shapes. Worker provider suite passes; all price-related app tests pass.

## Notes

Price refresh cadence (the partner's separate "update every 4h" request) is a deploy-config change (`UPDATE_TOKEN_OFFCHAIN_DATA_INTERVAL`) and is handled outside this PR.
