### PR TITLE
fix: reduce transaction status badge icon size and adjust margins

### DIFF
--- a/packages/app/src/components/transactions/TxStatusBadgeIcon.vue
+++ b/packages/app/src/components/transactions/TxStatusBadgeIcon.vue
@@ -12,6 +12,6 @@ const { currentNetwork } = useContext();
 
 <style lang="scss" scoped>
 .status-badge-icon {
-  @apply ml-1 h-5 w-5 object-contain;
+  @apply my-0.5 ml-2 mr-0 h-4 w-4 object-contain;
 }
 </style>


### PR DESCRIPTION
## What

Shrinks the configurable transaction status badge icon and adjusts its margins in `TxStatusBadgeIcon.vue`:

- height/width: `1.25rem` -> `1rem` (`h-5 w-5` -> `h-4 w-4`)
- margin-left: `.25rem` -> `.5rem` (`ml-1` -> `ml-2`)
- adds `.125rem` top/bottom margins (`my-0.5`) and explicit `mr-0`

## Why

Partner feedback that the custom status icon (introduced for configurable status badge icons) rendered too large next to the "Processed on" label.