### PR TITLE
fix: only fail liveness on pod-local errors, keep RPC check on readiness

### DIFF
--- a/packages/data-fetcher/src/health/health.controller.spec.ts
+++ b/packages/data-fetcher/src/health/health.controller.spec.ts
@@ -53,9 +53,17 @@ describe("HealthController", () => {
     healthController = app.get<HealthController>(HealthController);
   });
 
-  describe("check", () => {
-    it("checks health of the JSON RPC provider", async () => {
-      await healthController.check();
+  describe("checkLiveness", () => {
+    it("checks liveness of the JSON RPC provider", async () => {
+      await healthController.checkLiveness();
+      expect(jsonRpcHealthIndicatorMock.isAlive).toHaveBeenCalledTimes(1);
+      expect(jsonRpcHealthIndicatorMock.isAlive).toHaveBeenCalledWith("jsonRpcProvider");
+    });
+  });
+
+  describe("checkReadiness", () => {
+    it("checks reachability of the JSON RPC provider", async () => {
+      await healthController.checkReadiness();
       expect(jsonRpcHealthIndicatorMock.isHealthy).toHaveBeenCalledTimes(1);
       expect(jsonRpcHealthIndicatorMock.isHealthy).toHaveBeenCalledWith("jsonRpcProvider");
     });
@@ -63,7 +71,7 @@ describe("HealthController", () => {
     it("returns the overall check status", async () => {
       const healthCheckResult = mock<HealthCheckResult>({ status: "ok" });
       jest.spyOn(healthCheckServiceMock, "check").mockResolvedValueOnce(healthCheckResult);
-      const result = await healthController.check();
+      const result = await healthController.checkReadiness();
       expect(result).toBe(healthCheckResult);
     });
 
@@ -84,7 +92,7 @@ describe("HealthController", () => {
       it("throws generated error", async () => {
         expect.assertions(4);
         try {
-          await healthController.check();
+          await healthController.checkReadiness();
         } catch (e) {
           expect(e).toBeInstanceOf(ServiceUnavailableException);
           expect(e.message).toBe("Service Unavailable Exception");

--- a/packages/data-fetcher/src/health/health.controller.ts
+++ b/packages/data-fetcher/src/health/health.controller.ts
@@ -1,10 +1,10 @@
 import { Logger, Controller, Get, BeforeApplicationShutdown } from "@nestjs/common";
-import { HealthCheckService, HealthCheck, HealthCheckResult } from "@nestjs/terminus";
+import { HealthCheckService, HealthCheck, HealthCheckResult, HealthIndicatorFunction } from "@nestjs/terminus";
 import { ConfigService } from "@nestjs/config";
 import { setTimeout } from "node:timers/promises";
 import { JsonRpcHealthIndicator } from "./jsonRpcProvider.health";
 
-@Controller(["health", "ready"])
+@Controller()
 export class HealthController implements BeforeApplicationShutdown {
   private readonly logger: Logger;
   private readonly gracefulShutdownTimeoutMs: number;
@@ -18,11 +18,21 @@ export class HealthController implements BeforeApplicationShutdown {
     this.gracefulShutdownTimeoutMs = configService.get<number>("gracefulShutdownTimeoutMs");
   }
 
-  @Get()
+  @Get("health")
   @HealthCheck()
-  public async check(): Promise<HealthCheckResult> {
+  public async checkLiveness(): Promise<HealthCheckResult> {
+    return await this.check([() => this.jsonRpcHealthIndicator.isAlive("jsonRpcProvider")]);
+  }
+
+  @Get("ready")
+  @HealthCheck()
+  public async checkReadiness(): Promise<HealthCheckResult> {
+    return await this.check([() => this.jsonRpcHealthIndicator.isHealthy("jsonRpcProvider")]);
+  }
+
+  private async check(indicators: HealthIndicatorFunction[]): Promise<HealthCheckResult> {
     try {
-      return await this.healthCheckService.check([() => this.jsonRpcHealthIndicator.isHealthy("jsonRpcProvider")]);
+      return await this.healthCheckService.check(indicators);
     } catch (error) {
       this.logger.error({ message: error.message, response: error.getResponse() }, error.stack);
       throw error;

--- a/packages/data-fetcher/src/health/jsonRpcProvider.health.spec.ts
+++ b/packages/data-fetcher/src/health/jsonRpcProvider.health.spec.ts
@@ -108,4 +108,73 @@ describe("JsonRpcHealthIndicator", () => {
       expect(httpService.post).toHaveBeenCalledWith("http://localhost:3050", rpcRequest, { timeout: 10000 });
     });
   });
+
+  describe("isAlive", () => {
+    it("returns up when RPC responds successfully", async () => {
+      (httpService.post as jest.Mock).mockReturnValueOnce(of({ data: { result: "0x1" } }));
+      const result = await jsonRpcHealthIndicator.isAlive("jsonRpcProvider");
+      expect(result).toEqual({
+        jsonRpcProvider: {
+          status: "up",
+        },
+      });
+    });
+
+    it("returns up when RPC connection is refused (remote failure)", async () => {
+      const error = new AxiosError();
+      error.code = "ECONNREFUSED";
+
+      (httpService.post as jest.Mock).mockReturnValueOnce(throwError(() => error));
+      const result = await jsonRpcHealthIndicator.isAlive("jsonRpcProvider");
+      expect(result).toEqual({
+        jsonRpcProvider: {
+          status: "up",
+        },
+      });
+    });
+
+    it("returns up when RPC responds with an error status (remote failure)", async () => {
+      const error = new AxiosError();
+      error.response = {
+        status: 503,
+        data: "Service Unavailable",
+      } as any;
+
+      (httpService.post as jest.Mock).mockReturnValueOnce(throwError(() => error));
+      const result = await jsonRpcHealthIndicator.isAlive("jsonRpcProvider");
+      expect(result).toEqual({
+        jsonRpcProvider: {
+          status: "up",
+        },
+      });
+    });
+
+    it("throws HealthCheckError when DNS resolution is stuck (local failure)", async () => {
+      const error = new AxiosError();
+      error.code = "EAI_AGAIN";
+
+      (httpService.post as jest.Mock).mockReturnValueOnce(throwError(() => error));
+      await expect(jsonRpcHealthIndicator.isAlive("jsonRpcProvider")).rejects.toThrow();
+    });
+
+    it("throws HealthCheckError on getaddrinfo system error (local failure)", async () => {
+      const error = new AxiosError() as AxiosError & { syscall?: string };
+      error.code = "Unknown system error -116";
+      error.syscall = "getaddrinfo";
+
+      (httpService.post as jest.Mock).mockReturnValueOnce(throwError(() => error));
+      await expect(jsonRpcHealthIndicator.isAlive("jsonRpcProvider")).rejects.toThrow();
+    });
+
+    it("throws HealthCheckError when the getaddrinfo error is nested in cause (local failure)", async () => {
+      const error = new AxiosError();
+      error.cause = Object.assign(new Error("getaddrinfo EAI_AGAIN localhost"), {
+        code: "EAI_AGAIN",
+        syscall: "getaddrinfo",
+      });
+
+      (httpService.post as jest.Mock).mockReturnValueOnce(throwError(() => error));
+      await expect(jsonRpcHealthIndicator.isAlive("jsonRpcProvider")).rejects.toThrow();
+    });
+  });
 });

--- a/packages/data-fetcher/src/health/jsonRpcProvider.health.ts
+++ b/packages/data-fetcher/src/health/jsonRpcProvider.health.ts
@@ -6,6 +6,8 @@ import { HttpService } from "@nestjs/axios";
 import { catchError, firstValueFrom } from "rxjs";
 import { AxiosError } from "axios";
 
+const LOCAL_DNS_ERROR_CODES = ["EAI_AGAIN", "ENOTFOUND"];
+
 @Injectable()
 export class JsonRpcHealthIndicator extends HealthIndicator {
   private readonly rpcUrl: string;
@@ -20,7 +22,47 @@ export class JsonRpcHealthIndicator extends HealthIndicator {
   }
 
   async isHealthy(key: string): Promise<HealthIndicatorResult> {
-    let isHealthy = true;
+    const error = await this.pingRpc();
+    const isHealthy = !error;
+
+    const result = this.getStatus(key, isHealthy, { status: isHealthy ? "up" : "down" });
+
+    if (isHealthy) {
+      return result;
+    }
+
+    throw new HealthCheckError("JSON RPC provider is down or not reachable", result);
+  }
+
+  // Liveness-grade check: fails only on pod-local network problems (DNS resolution),
+  // where a restart can help. A remote RPC failure must not kill the pod — it is
+  // reported by isHealthy so readiness takes the pod out of the Service instead.
+  async isAlive(key: string): Promise<HealthIndicatorResult> {
+    const error = await this.pingRpc();
+    const isAlive = !error || !this.isLocalNetworkError(error);
+
+    const result = this.getStatus(key, isAlive, { status: isAlive ? "up" : "down" });
+
+    if (isAlive) {
+      return result;
+    }
+
+    throw new HealthCheckError("Local networking is broken", result);
+  }
+
+  private isLocalNetworkError(error: AxiosError): boolean {
+    if (error.response) {
+      return false;
+    }
+    const cause = (error.cause ?? error) as NodeJS.ErrnoException;
+    return (
+      cause.syscall === "getaddrinfo" ||
+      LOCAL_DNS_ERROR_CODES.includes(cause.code) ||
+      LOCAL_DNS_ERROR_CODES.includes(error.code)
+    );
+  }
+
+  private async pingRpc(): Promise<AxiosError | null> {
     try {
       // Check RPC health with a pure HTTP request to remove SDK out of the picture
       // and avoid any SDK-specific issues.
@@ -49,16 +91,9 @@ export class JsonRpcHealthIndicator extends HealthIndicator {
             })
           )
       );
-    } catch {
-      isHealthy = false;
+      return null;
+    } catch (error) {
+      return error as AxiosError;
     }
-
-    const result = this.getStatus(key, isHealthy, { status: isHealthy ? "up" : "down" });
-
-    if (isHealthy) {
-      return result;
-    }
-
-    throw new HealthCheckError("JSON RPC provider is down or not reachable", result);
   }
 }

--- a/packages/worker/src/health/health.controller.spec.ts
+++ b/packages/worker/src/health/health.controller.spec.ts
@@ -59,11 +59,16 @@ describe("HealthController", () => {
   });
 
   describe("checkLiveness", () => {
-    it("checks liveness of the JSON RPC provider and not the DB", async () => {
+    it("checks health of the DB", async () => {
+      await healthController.checkLiveness();
+      expect(dbHealthCheckerMock.pingCheck).toHaveBeenCalledTimes(1);
+      expect(dbHealthCheckerMock.pingCheck).toHaveBeenCalledWith("database", { timeout: 5000 });
+    });
+
+    it("checks liveness of the JSON RPC provider", async () => {
       await healthController.checkLiveness();
       expect(jsonRpcHealthIndicatorMock.isAlive).toHaveBeenCalledTimes(1);
       expect(jsonRpcHealthIndicatorMock.isAlive).toHaveBeenCalledWith("jsonRpcProvider");
-      expect(dbHealthCheckerMock.pingCheck).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/worker/src/health/health.controller.spec.ts
+++ b/packages/worker/src/health/health.controller.spec.ts
@@ -58,15 +58,24 @@ describe("HealthController", () => {
     healthController = app.get<HealthController>(HealthController);
   });
 
-  describe("check", () => {
+  describe("checkLiveness", () => {
+    it("checks liveness of the JSON RPC provider and not the DB", async () => {
+      await healthController.checkLiveness();
+      expect(jsonRpcHealthIndicatorMock.isAlive).toHaveBeenCalledTimes(1);
+      expect(jsonRpcHealthIndicatorMock.isAlive).toHaveBeenCalledWith("jsonRpcProvider");
+      expect(dbHealthCheckerMock.pingCheck).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("checkReadiness", () => {
     it("checks health of the DB", async () => {
-      await healthController.check();
+      await healthController.checkReadiness();
       expect(dbHealthCheckerMock.pingCheck).toHaveBeenCalledTimes(1);
       expect(dbHealthCheckerMock.pingCheck).toHaveBeenCalledWith("database", { timeout: 5000 });
     });
 
-    it("checks health of the JSON RPC provider", async () => {
-      await healthController.check();
+    it("checks reachability of the JSON RPC provider", async () => {
+      await healthController.checkReadiness();
       expect(jsonRpcHealthIndicatorMock.isHealthy).toHaveBeenCalledTimes(1);
       expect(jsonRpcHealthIndicatorMock.isHealthy).toHaveBeenCalledWith("jsonRpcProvider");
     });
@@ -74,7 +83,7 @@ describe("HealthController", () => {
     it("returns the overall check status", async () => {
       const healthCheckResult = mock<HealthCheckResult>({ status: "ok" });
       jest.spyOn(healthCheckServiceMock, "check").mockResolvedValueOnce(healthCheckResult);
-      const result = await healthController.check();
+      const result = await healthController.checkReadiness();
       expect(result).toBe(healthCheckResult);
     });
 
@@ -95,7 +104,7 @@ describe("HealthController", () => {
       it("throws generated error", async () => {
         expect.assertions(4);
         try {
-          await healthController.check();
+          await healthController.checkReadiness();
         } catch (e) {
           expect(e).toBeInstanceOf(ServiceUnavailableException);
           expect(e.message).toBe("Service Unavailable Exception");

--- a/packages/worker/src/health/health.controller.ts
+++ b/packages/worker/src/health/health.controller.ts
@@ -27,7 +27,10 @@ export class HealthController {
   @Get("health")
   @HealthCheck()
   public async checkLiveness(): Promise<HealthCheckResult> {
-    return await this.check([() => this.jsonRpcHealthIndicator.isAlive("jsonRpcProvider")]);
+    return await this.check([
+      () => this.dbHealthChecker.pingCheck("database", { timeout: this.dbHealthCheckTimeoutMs }),
+      () => this.jsonRpcHealthIndicator.isAlive("jsonRpcProvider"),
+    ]);
   }
 
   @Get("ready")

--- a/packages/worker/src/health/health.controller.ts
+++ b/packages/worker/src/health/health.controller.ts
@@ -1,9 +1,15 @@
 import { Logger, Controller, Get } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { HealthCheckService, TypeOrmHealthIndicator, HealthCheck, HealthCheckResult } from "@nestjs/terminus";
+import {
+  HealthCheckService,
+  TypeOrmHealthIndicator,
+  HealthCheck,
+  HealthCheckResult,
+  HealthIndicatorFunction,
+} from "@nestjs/terminus";
 import { JsonRpcHealthIndicator } from "./jsonRpcProvider.health";
 
-@Controller(["health", "ready"])
+@Controller()
 export class HealthController {
   private readonly logger: Logger;
   private readonly dbHealthCheckTimeoutMs: number;
@@ -18,14 +24,24 @@ export class HealthController {
     this.dbHealthCheckTimeoutMs = configService.get<number>("healthChecks.dbHealthCheckTimeoutMs");
   }
 
-  @Get()
+  @Get("health")
   @HealthCheck()
-  public async check(): Promise<HealthCheckResult> {
+  public async checkLiveness(): Promise<HealthCheckResult> {
+    return await this.check([() => this.jsonRpcHealthIndicator.isAlive("jsonRpcProvider")]);
+  }
+
+  @Get("ready")
+  @HealthCheck()
+  public async checkReadiness(): Promise<HealthCheckResult> {
+    return await this.check([
+      () => this.dbHealthChecker.pingCheck("database", { timeout: this.dbHealthCheckTimeoutMs }),
+      () => this.jsonRpcHealthIndicator.isHealthy("jsonRpcProvider"),
+    ]);
+  }
+
+  private async check(indicators: HealthIndicatorFunction[]): Promise<HealthCheckResult> {
     try {
-      return await this.healthCheckService.check([
-        () => this.dbHealthChecker.pingCheck("database", { timeout: this.dbHealthCheckTimeoutMs }),
-        () => this.jsonRpcHealthIndicator.isHealthy("jsonRpcProvider"),
-      ]);
+      return await this.healthCheckService.check(indicators);
     } catch (error) {
       this.logger.error({ message: error.message, response: error.getResponse() }, error.stack);
       throw error;

--- a/packages/worker/src/health/jsonRpcProvider.health.spec.ts
+++ b/packages/worker/src/health/jsonRpcProvider.health.spec.ts
@@ -108,4 +108,73 @@ describe("JsonRpcHealthIndicator", () => {
       expect(httpService.post).toHaveBeenCalledWith("http://localhost:3050", rpcRequest, { timeout: 10000 });
     });
   });
+
+  describe("isAlive", () => {
+    it("returns up when RPC responds successfully", async () => {
+      (httpService.post as jest.Mock).mockReturnValueOnce(of({ data: { result: "0x1" } }));
+      const result = await jsonRpcHealthIndicator.isAlive("jsonRpcProvider");
+      expect(result).toEqual({
+        jsonRpcProvider: {
+          status: "up",
+        },
+      });
+    });
+
+    it("returns up when RPC connection is refused (remote failure)", async () => {
+      const error = new AxiosError();
+      error.code = "ECONNREFUSED";
+
+      (httpService.post as jest.Mock).mockReturnValueOnce(throwError(() => error));
+      const result = await jsonRpcHealthIndicator.isAlive("jsonRpcProvider");
+      expect(result).toEqual({
+        jsonRpcProvider: {
+          status: "up",
+        },
+      });
+    });
+
+    it("returns up when RPC responds with an error status (remote failure)", async () => {
+      const error = new AxiosError();
+      error.response = {
+        status: 503,
+        data: "Service Unavailable",
+      } as any;
+
+      (httpService.post as jest.Mock).mockReturnValueOnce(throwError(() => error));
+      const result = await jsonRpcHealthIndicator.isAlive("jsonRpcProvider");
+      expect(result).toEqual({
+        jsonRpcProvider: {
+          status: "up",
+        },
+      });
+    });
+
+    it("throws HealthCheckError when DNS resolution is stuck (local failure)", async () => {
+      const error = new AxiosError();
+      error.code = "EAI_AGAIN";
+
+      (httpService.post as jest.Mock).mockReturnValueOnce(throwError(() => error));
+      await expect(jsonRpcHealthIndicator.isAlive("jsonRpcProvider")).rejects.toThrow();
+    });
+
+    it("throws HealthCheckError on getaddrinfo system error (local failure)", async () => {
+      const error = new AxiosError() as AxiosError & { syscall?: string };
+      error.code = "Unknown system error -116";
+      error.syscall = "getaddrinfo";
+
+      (httpService.post as jest.Mock).mockReturnValueOnce(throwError(() => error));
+      await expect(jsonRpcHealthIndicator.isAlive("jsonRpcProvider")).rejects.toThrow();
+    });
+
+    it("throws HealthCheckError when the getaddrinfo error is nested in cause (local failure)", async () => {
+      const error = new AxiosError();
+      error.cause = Object.assign(new Error("getaddrinfo EAI_AGAIN localhost"), {
+        code: "EAI_AGAIN",
+        syscall: "getaddrinfo",
+      });
+
+      (httpService.post as jest.Mock).mockReturnValueOnce(throwError(() => error));
+      await expect(jsonRpcHealthIndicator.isAlive("jsonRpcProvider")).rejects.toThrow();
+    });
+  });
 });

--- a/packages/worker/src/health/jsonRpcProvider.health.ts
+++ b/packages/worker/src/health/jsonRpcProvider.health.ts
@@ -6,6 +6,8 @@ import { HttpService } from "@nestjs/axios";
 import { catchError, firstValueFrom } from "rxjs";
 import { AxiosError } from "axios";
 
+const LOCAL_DNS_ERROR_CODES = ["EAI_AGAIN", "ENOTFOUND"];
+
 @Injectable()
 export class JsonRpcHealthIndicator extends HealthIndicator {
   private readonly rpcUrl: string;
@@ -20,7 +22,47 @@ export class JsonRpcHealthIndicator extends HealthIndicator {
   }
 
   async isHealthy(key: string): Promise<HealthIndicatorResult> {
-    let isHealthy = true;
+    const error = await this.pingRpc();
+    const isHealthy = !error;
+
+    const result = this.getStatus(key, isHealthy, { status: isHealthy ? "up" : "down" });
+
+    if (isHealthy) {
+      return result;
+    }
+
+    throw new HealthCheckError("JSON RPC provider is down or not reachable", result);
+  }
+
+  // Liveness-grade check: fails only on pod-local network problems (DNS resolution),
+  // where a restart can help. A remote RPC failure must not kill the pod — it is
+  // reported by isHealthy so readiness takes the pod out of the Service instead.
+  async isAlive(key: string): Promise<HealthIndicatorResult> {
+    const error = await this.pingRpc();
+    const isAlive = !error || !this.isLocalNetworkError(error);
+
+    const result = this.getStatus(key, isAlive, { status: isAlive ? "up" : "down" });
+
+    if (isAlive) {
+      return result;
+    }
+
+    throw new HealthCheckError("Local networking is broken", result);
+  }
+
+  private isLocalNetworkError(error: AxiosError): boolean {
+    if (error.response) {
+      return false;
+    }
+    const cause = (error.cause ?? error) as NodeJS.ErrnoException;
+    return (
+      cause.syscall === "getaddrinfo" ||
+      LOCAL_DNS_ERROR_CODES.includes(cause.code) ||
+      LOCAL_DNS_ERROR_CODES.includes(error.code)
+    );
+  }
+
+  private async pingRpc(): Promise<AxiosError | null> {
     try {
       // Check RPC health with a pure HTTP request to remove SDK out of the picture
       // and avoid any SDK-specific issues.
@@ -49,16 +91,9 @@ export class JsonRpcHealthIndicator extends HealthIndicator {
             })
           )
       );
-    } catch {
-      isHealthy = false;
+      return null;
+    } catch (error) {
+      return error as AxiosError;
     }
-
-    const result = this.getStatus(key, isHealthy, { status: isHealthy ? "up" : "down" });
-
-    if (isHealthy) {
-      return result;
-    }
-
-    throw new HealthCheckError("JSON RPC provider is down or not reachable", result);
   }
 }


### PR DESCRIPTION
## What

Splits the shared `/health`+`/ready` controller in `data-fetcher` and `worker`: `/ready` keeps the upstream RPC (and worker DB) check; `/health` no longer fails on remote upstream-RPC errors — only on pod-local DNS/`getaddrinfo` errors (the original intent of [#368](https://github.com/matter-labs/block-explorer/issues/368)). Per review, the worker's `/health` retains the DB status check.

## Why

Today both routes run the same upstream-RPC ping, so a brief upstream outage fails liveness on every replica and Kubernetes kills the whole fleet simultaneously (on one staging env: ~2,200 restarts per pod over 200 days). Details in [#654](https://github.com/matter-labs/block-explorer/issues/654). A restart can't help when the problem is upstream; readiness already takes the pod out of the Service.

Deployment-side probe rewiring: [gitops-kubernetes#14261](https://github.com/matter-labs/gitops-kubernetes/pull/14261).

Fixes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)
