### PR TITLE
fix: use the chain logo on the Prividium auth-check screen

### DIFF
--- a/packages/app/src/App.vue
+++ b/packages/app/src/App.vue
@@ -4,7 +4,12 @@
     v-if="isPrividiumAuthChecking"
     class="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-slate-50 via-white to-blue-50 px-4 py-12 sm:px-6 lg:px-8"
   >
-    <img :src="resolveAsset('/images/prividium_logo.svg')" alt="Prividium Logo" class="mb-6 h-16 w-auto" />
+    <!-- Inverse logo first: this screen is light, so a chain's light-background variant is the right one. -->
+    <img
+      :src="resolveAsset(currentNetwork.logoInverseUrl || currentNetwork.logoUrl || '/images/prividium_logo.svg')"
+      alt="Logo"
+      class="mb-6 h-16 w-auto"
+    />
     <div class="text-center">
       <h1 class="mb-4 text-2xl font-semibold text-gray-900">Checking permissions...</h1>
       <div class="mx-auto h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>


### PR DESCRIPTION
# What ❔

On the "Checking permissions..." screen shown while the Prividium auth check runs, `App.vue` hardcoded the bundled Prividium mark instead of the configured chain logo. It now falls back the way the other screens in this flow do, preferring `logoInverseUrl`:

```
currentNetwork.logoInverseUrl || currentNetwork.logoUrl || '/images/prividium_logo.svg'
```

`logoInverseUrl` comes first because this screen has a light background (`from-slate-50 via-white to-blue-50`), so a chain's light-background variant is the correct one. Default Prividium deployments are unaffected — `prividium.config.json` points both fields at `prividium_logo.svg`.

## Why ❔

Partner reported it as the last remaining Prividium logo in their branded flow: everything else (login, auth callback, not-authorized, header, favicon, banner, status icon) already resolves from their config, and this screen was the one spot that did not.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
